### PR TITLE
Add window scaling & HiDPI support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +800,18 @@ checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fast_image_resize"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02abb58c39fa9b20678cedabab49e6c4f6ecb7480d7cb5711496b9289184a875"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -1010,6 +1031,14 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hqx"
+version = "0.1.0"
+source = "git+https://github.com/CryZe/wasmboy-rs?tag=v0.1.3#d7cbae67906796928c8e451b186f3c653924beb8"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "idna"
@@ -1234,6 +1263,12 @@ name = "linux-raw-sys"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -2624,6 +2659,8 @@ dependencies = [
  "anyhow",
  "clap",
  "directories",
+ "fast_image_resize",
+ "hqx",
  "midir",
  "rodio",
  "softbuffer",
@@ -3132,6 +3169,7 @@ dependencies = [
  "atomic-waker",
  "bitflags 2.6.0",
  "block2",
+ "bytemuck",
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
@@ -3148,6 +3186,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-ui-kit",
  "orbclient",
+ "percent-encoding",
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
@@ -3165,6 +3204,8 @@ dependencies = [
  "web-sys",
  "web-time",
  "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
  "xkbcommon-dl",
 ]
 
@@ -3175,6 +3216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]

--- a/wie_cli/Cargo.toml
+++ b/wie_cli/Cargo.toml
@@ -14,10 +14,12 @@ rodio = { version = "^0.18", default-features = false }
 midir = { version = "^0.10", default-features = false }
 softbuffer = { version = "^0.4" }
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
-winit = { version = "^0.30", features = ["wayland", "rwh_06"], default-features = false }
+winit = { version = "^0.30", features = ["x11", "wayland", "rwh_06"], default-features = false }
+hqx = {git = "https://github.com/CryZe/wasmboy-rs", tag="v0.1.3"}
 
 wie_backend = { workspace = true }
 wie_j2me = { path = "../wie_j2me" }
 wie_ktf = { path = "../wie_ktf" }
 wie_lgt = { path = "../wie_lgt" }
 wie_skt = { path = "../wie_skt" }
+fast_image_resize = "4.0.0"

--- a/wie_cli/src/window.rs
+++ b/wie_cli/src/window.rs
@@ -1,14 +1,17 @@
 use alloc::sync::Arc;
-use core::{fmt::Debug, num::NonZeroU32};
+use core::{fmt::Debug, fmt::Formatter, num::NonZeroU32};
+use std::fmt;
 
+use fast_image_resize::{FilterType, PixelType, ResizeOptions, SrcCropping};
+use fast_image_resize::ResizeAlg::Convolution;
 use softbuffer::{Context, Surface};
 use winit::{
     application::ApplicationHandler,
-    dpi::PhysicalSize,
+    dpi::{LogicalSize, PhysicalSize},
     event::{ElementState, KeyEvent, StartCause, WindowEvent},
     event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy},
     keyboard::PhysicalKey,
-    window::{Window as WinitWindow, WindowAttributes, WindowId},
+    window::{Window as WinitWindow, WindowId},
 };
 
 use wie_backend::{canvas::Image, Screen};
@@ -45,14 +48,6 @@ impl Screen for WindowHandle {
         self.send_event(WindowInternalEvent::RequestRedraw)
     }
 
-    fn width(&self) -> u32 {
-        self.width
-    }
-
-    fn height(&self) -> u32 {
-        self.height
-    }
-
     fn paint(&mut self, image: &dyn Image) {
         let data = image
             .colors()
@@ -61,6 +56,14 @@ impl Screen for WindowHandle {
             .collect::<Vec<_>>();
 
         self.send_event(WindowInternalEvent::Paint(data)).unwrap()
+    }
+
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    fn height(&self) -> u32 {
+        self.height
     }
 }
 
@@ -92,17 +95,109 @@ impl WindowImpl {
     {
         self.event_loop.set_control_flow(ControlFlow::Poll);
 
-        let size = PhysicalSize::new(self.width, self.height);
-        let window_attributes = WinitWindow::default_attributes().with_inner_size(size).with_title("WIE");
-
+        const DEFAULT_USER_SCALE_FACTOR: f64 = 1.0;
+        let orig_size = LogicalSize::new(self.width, self.height);
         let mut handler = ApplicationHandlerImpl {
-            window_attributes,
+            native_scale_factor: 1.0,
+            user_scale_factor: DEFAULT_USER_SCALE_FACTOR,
+            wipi_size: orig_size,
+            scaled_size: orig_size.to_physical(1.0),
+            window_size: Default::default(),
+            scaler: Scaler::Native,
+            scaled_image_buf: Default::default(),
             window: None,
+            context: None,
             surface: None,
             callback: Box::new(callback),
+            last_frame: None,
         };
 
         Ok(self.event_loop.run_app(&mut handler)?)
+    }
+}
+
+enum Scaler {
+    /// 1:1 native scaling.
+    Native,
+    /// hq2x, hq3x, hq4x scaling.
+    Hqx { scale: i8 },
+    /// Lanczos3 scaling
+    Lanczos3 { scale: f64, resizer: fast_image_resize::Resizer },
+}
+
+impl fmt::Display for Scaler {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Scaler::Native => f.write_str("Native")?,
+            Scaler::Hqx { scale } => f.write_fmt(format_args!("Hq{}x", scale))?,
+            Scaler::Lanczos3 { scale, resizer: _ } => f.write_fmt(format_args!("Lanczos3({})", scale))?,
+        }
+        Ok(())
+    }
+}
+
+impl Scaler {
+    fn new(scale: f64) -> Scaler {
+        match scale {
+            _ if (scale - 1.0).abs() < 1e-3 => Scaler::Native,
+            _ => Scaler::Lanczos3 { scale, resizer: fast_image_resize::Resizer::new() },
+        }
+    }
+
+    #[allow(dead_code)]
+    fn new_hqx(scale: f64) -> Scaler {
+        match scale {
+            _ if scale < 1.5 => Scaler::Native,
+            _ if scale < 2.5 => Scaler::Hqx { scale: 2 },
+            _ if scale < 3.5 => Scaler::Hqx { scale: 3 },
+            _ => Scaler::Hqx { scale: 4 },
+        }
+    }
+
+    fn scale(&self) -> f64 {
+        match self {
+            Scaler::Native => 1.0,
+            Scaler::Hqx { scale } => *scale as f64,
+            Scaler::Lanczos3 { scale, resizer: _ } => *scale,
+        }
+    }
+
+    fn to_physical(&self, logical_size: LogicalSize<u32>) -> PhysicalSize<u32> {
+        match self {
+            Scaler::Native => PhysicalSize::new(
+                logical_size.width,
+                logical_size.height,
+            ),
+            Scaler::Hqx { scale } => PhysicalSize::new(
+                logical_size.width * *scale as u32,
+                logical_size.height * *scale as u32,
+            ),
+            Scaler::Lanczos3 { scale, resizer: _ } => PhysicalSize::new(
+                (logical_size.width as f64 * *scale).floor() as u32,
+                (logical_size.height as f64 * *scale).floor() as u32,
+            ),
+        }
+    }
+
+    fn scale_image(&mut self, dst: &mut Vec<u32>, src: &Vec<u32>, dst_size: PhysicalSize<u32>, src_size: LogicalSize<u32>) {
+        match self {
+            Scaler::Native => dst.copy_from_slice(src),
+            Scaler::Hqx { scale } if *scale == 2 => hqx::hq2x(src.as_slice(), dst.as_mut_slice(), src_size.width as usize, src_size.height as usize),
+            Scaler::Hqx { scale } if *scale == 3 => hqx::hq3x(src.as_slice(), dst.as_mut_slice(), src_size.width as usize, src_size.height as usize),
+            Scaler::Hqx { scale } if *scale == 4 => hqx::hq4x(src.as_slice(), dst.as_mut_slice(), src_size.width as usize, src_size.height as usize),
+            Scaler::Hqx { scale } => panic!("invalid hqx scale factor {}", scale),
+            Scaler::Lanczos3 { scale: _, ref mut resizer } => {
+                let (_, srcarr, _) = unsafe { src.align_to::<u8>() };
+                let srcimg = fast_image_resize::images::ImageRef::new(src_size.width, src_size.height, srcarr, PixelType::U8x4).unwrap();
+                let (_, dstarr, _) = unsafe { dst.as_mut_slice().align_to_mut::<u8>() };
+                let mut dstimg = fast_image_resize::images::Image::from_slice_u8(dst_size.width, dst_size.height, dstarr, PixelType::U8x4).unwrap();
+                resizer.resize(&srcimg, &mut dstimg, Some(&ResizeOptions {
+                    algorithm: Convolution(FilterType::Lanczos3),
+                    cropping: SrcCropping::None,
+                    mul_div_alpha: false,
+                })).unwrap();
+            }
+        }
     }
 }
 
@@ -111,8 +206,28 @@ where
     C: FnMut(WindowCallbackEvent) -> Result<(), E> + 'static,
     E: Debug,
 {
-    window_attributes: WindowAttributes,
+    /// Native scale factor of the emulator window.
+    native_scale_factor: f64,
+    /// User specified scale factor.
+    user_scale_factor: f64,
+    /// Scaler config.
+    /// Actual scaling factor = native_scale_factor + user_scale_factor
+    scaler: Scaler,
+    /// Temporary buffer for scaler.
+    scaled_image_buf: Vec<u32>,
+
+    /// WIPI screen size.
+    wipi_size: LogicalSize<u32>,
+    /// Scaled screen size.
+    /// Equals to orig_size * scale_factor.
+    scaled_size: PhysicalSize<u32>,
+    /// Size of the OS window.
+    window_size: PhysicalSize<u32>,
+    /// Last WIPI screen image data.
+    last_frame: Option<Vec<u32>>,
+
     window: Option<Arc<WinitWindow>>,
+    context: Option<Context<Arc<WinitWindow>>>,
     surface: Option<Surface<Arc<WinitWindow>, Arc<WinitWindow>>>,
     callback: Box<C>,
 }
@@ -130,6 +245,76 @@ where
             event_loop.exit();
         }
     }
+
+    /// Sets the native/user scale factor.
+    /// After calling this you'll need to call [`Self::on_resize`] to update the surface accordingly.
+    fn update_scale_factor(&mut self, native: Option<f64>, user: Option<f64>) {
+        if let Some(f) = native {
+            self.native_scale_factor = f
+        }
+        if let Some(f) = user {
+            self.user_scale_factor = f
+        }
+        if self.native_scale_factor + self.user_scale_factor < 0.1 {
+            tracing::info!("scale factor too small(native {} + user {}), resetting user_scale_factor",
+                self.native_scale_factor, self.user_scale_factor);
+            self.user_scale_factor = 0.0;
+        }
+
+        self.scaler = Scaler::new(self.native_scale_factor + self.user_scale_factor);
+        self.scaled_size = self.scaler.to_physical(self.wipi_size);
+        self.scaled_image_buf = vec![0u32; self.scaled_size.width as usize * self.scaled_size.height as usize];
+    }
+
+    /// Updates the scaled WIPI image surface's size.
+    fn on_resize(&mut self) {
+        tracing::info!("on_resize scale=(native {}, actual {}), wipi={:?}, scaled={:?}, window={:?}",
+            self.native_scale_factor, self.scaler.scale(), self.wipi_size, self.scaled_size, self.window_size);
+        let surface = match self.surface.as_mut() {
+            None => {
+                self.surface = Some(Surface::new(self.context.as_ref().unwrap(), self.window.as_ref().unwrap().clone()).unwrap());
+                self.surface.as_mut().unwrap()
+            }
+            Some(surface) => {
+                let desired_len = self.scaled_size.width * self.scaled_size.height;
+                if surface.buffer_mut().unwrap().len() == desired_len as usize {
+                    // nothing to do
+                    return
+                };
+                surface
+            }
+        };
+
+        surface
+            .resize(NonZeroU32::new(self.scaled_size.width).unwrap(), NonZeroU32::new(self.scaled_size.height).unwrap())
+            .unwrap();
+        self.paint_last_frame();
+    }
+
+    /// Displays the last WIPI frame to the window.
+    fn paint_last_frame(&mut self) -> Option<()> {
+        let data = self.last_frame.as_ref()?;
+        if data.len() != self.wipi_size.width as usize * self.wipi_size.height as usize {
+            return None
+        }
+        let data_to_blit = if self.scaled_image_buf.len() == data.len() {
+            data
+        } else {
+            self.scaler.scale_image(&mut self.scaled_image_buf, data, self.scaled_size, self.wipi_size);
+            &self.scaled_image_buf
+        };
+
+        let mut win_buf = self.surface.as_mut().unwrap().buffer_mut().unwrap();
+        if win_buf.len() == data_to_blit.len() {
+            win_buf.copy_from_slice(data_to_blit);
+        } else {
+            tracing::warn!("buffer size mismatch, skipping paint: {}, {} (wipi {:?}, scaled {:?}, win {:?})",
+                win_buf.len(), data_to_blit.len(), self.wipi_size, self.scaled_size, self.window_size);
+            return None
+        }
+        win_buf.present().unwrap();
+        Some(())
+    }
 }
 
 impl<C, E> ApplicationHandler<WindowInternalEvent> for ApplicationHandlerImpl<C, E>
@@ -142,19 +327,22 @@ where
     }
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        let window = Arc::new(event_loop.create_window(self.window_attributes.clone()).unwrap());
-
+        // Initialize the window.
+        let window_attributes = WinitWindow::default_attributes()
+            .with_inner_size(self.wipi_size.to_physical::<u32>(1.0))
+            .with_title("WIE");
+        let window = Arc::new(event_loop.create_window(window_attributes).unwrap());
         let context = Context::new(window.clone()).unwrap();
-        let mut surface = Surface::new(&context, window.clone()).unwrap();
+        self.window = Some(window.clone());
+        self.context = Some(context);
+        self.window_size = window.inner_size();
 
-        let size = window.inner_size();
-
-        surface
-            .resize(NonZeroU32::new(size.width).unwrap(), NonZeroU32::new(size.height).unwrap())
-            .unwrap();
-
-        self.window = Some(window);
-        self.surface = Some(surface);
+        // After the window is initialized we resize the window again with the correct scale factor.
+        self.update_scale_factor(Some(window.scale_factor()), Some(1.0));
+        if let Some(new_size) = window.request_inner_size(self.scaled_size) {
+            self.window_size = new_size;
+        }
+        self.on_resize();
     }
 
     fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: WindowInternalEvent) {
@@ -163,10 +351,8 @@ where
                 self.window.as_ref().unwrap().request_redraw();
             }
             WindowInternalEvent::Paint(data) => {
-                let mut buffer = self.surface.as_mut().unwrap().buffer_mut().unwrap();
-                buffer.copy_from_slice(&data);
-
-                buffer.present().unwrap();
+                self.last_frame = Some(data);
+                self.paint_last_frame();
             }
         }
     }
@@ -198,6 +384,25 @@ where
             }
             WindowEvent::RedrawRequested => {
                 self.callback(WindowCallbackEvent::Redraw, event_loop);
+            }
+            WindowEvent::Resized(new_size) => {
+                tracing::debug!("WindowResized {:?}", new_size);
+                self.window_size = new_size;
+                if self.window_size != self.scaled_size {
+                    // Determine the new scale factor.
+                    let wscale = self.window_size.width as f64 / self.wipi_size.width as f64;
+                    let hscale = self.window_size.height as f64 / self.wipi_size.height as f64;
+                    let new_scale = wscale.min(hscale);
+                    let new_user_scale = new_scale - self.native_scale_factor;
+                    self.update_scale_factor(None, Some(new_user_scale));
+                }
+                self.on_resize();
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, mut inner_size_writer } => {
+                tracing::info!("ScaleFactorChanged {}", scale_factor);
+                self.update_scale_factor(Some(scale_factor), None);
+                let _ = inner_size_writer.request_inner_size(self.scaled_size);
+                // Will receive WindowEvent::Resized soon, so no need to call self.on_resize().
             }
             _ => {}
         }


### PR DESCRIPTION
This adds two modes of scaling (lanczos & hq[234]x) and HiDPI support.

For lanzcos scaling it uses fast_image_resize and for Hq*x scaling it uses code from wasmboy-rs, both of which are WebAssembly compatible.
