### PR TITLE
Add kft vibrator

### DIFF
--- a/wie_ktf/src/runtime/wipi_c/method_table.rs
+++ b/wie_ktf/src/runtime/wipi_c/method_table.rs
@@ -281,7 +281,7 @@ pub fn get_media_method_table() -> Vec<WIPICMethodBody> {
         gen_stub(13, "MC_mdaUnk13"),
         media::get_volume.into_body(),
         gen_stub(15, "MC_mdaUnk15"),
-        gen_stub(16, "MC_mdaUnk16"),
+        media::vibrator.into_body(),
         gen_stub(17, "MC_mdaUnk17"),
         gen_stub(18, "MC_mdaUnk18"),
         gen_stub(19, "MC_mdaUnk19"),


### PR DESCRIPTION
일단 이런 접근 방법이 맞는지 모르겠네요.

미니게임천국1으로 테스트를 진행했습니다.
환경설정에서 진동 OFF->ON으로 변경될 때와
게임 오버 상황에서 Fatal error: Unimplemented: MC_mdaUnk16 오류가 발생하는 상태였고
해당 부분을 MC_mdaVibrator으로 매핑시켜 확인하니 level 50, timeout 1000이 찍히고 오류도 사라졌습니다.