### PR TITLE
Add platform filesystem with overlay-based routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,10 +2826,13 @@ name = "test_utils"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "hashbrown 0.17.0",
  "java_class_proto",
  "java_runtime",
  "jvm",
  "jvm_rust",
+ "spin",
+ "tracing",
  "wie_backend",
  "wie_jvm_support",
  "wie_util",

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+spin = { workspace = true }
+tracing = { workspace = true }
+
+hashbrown = { version = "^0.17", features = ["default-hasher"], default-features = false }
 
 java_class_proto = { workspace = true }
 java_runtime = { workspace = true }

--- a/test_utils/src/filesystem.rs
+++ b/test_utils/src/filesystem.rs
@@ -1,0 +1,62 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::cmp::min;
+
+use hashbrown::HashMap;
+use spin::Mutex;
+
+use wie_backend::Filesystem;
+
+/// In-memory `Filesystem` implementation for tests.
+#[derive(Default)]
+pub struct MemoryFilesystem {
+    files: Mutex<HashMap<(String, String), Vec<u8>>>,
+}
+
+impl MemoryFilesystem {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Filesystem for MemoryFilesystem {
+    fn exists(&self, aid: &str, path: &str) -> bool {
+        self.files.lock().contains_key(&(aid.to_string(), path.to_string()))
+    }
+
+    fn size(&self, aid: &str, path: &str) -> Option<usize> {
+        self.files.lock().get(&(aid.to_string(), path.to_string())).map(|v| v.len())
+    }
+
+    fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+        let files = self.files.lock();
+        let data = files.get(&(aid.to_string(), path.to_string()))?;
+
+        if offset >= data.len() {
+            return Some(0);
+        }
+
+        let size_to_read = min(count, data.len() - offset);
+        buf[..size_to_read].copy_from_slice(&data[offset..offset + size_to_read]);
+        Some(size_to_read)
+    }
+
+    fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+        let mut files = self.files.lock();
+        let file = files.entry((aid.to_string(), path.to_string())).or_default();
+        if file.len() < offset + data.len() {
+            file.resize(offset + data.len(), 0);
+        }
+        file[offset..offset + data.len()].copy_from_slice(data);
+
+        data.len()
+    }
+
+    fn truncate(&self, aid: &str, path: &str, len: usize) {
+        let mut files = self.files.lock();
+        let file = files.entry((aid.to_string(), path.to_string())).or_default();
+        file.resize(len, 0);
+    }
+}

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,10 +1,12 @@
 #![no_std]
 extern crate alloc;
 
+mod filesystem;
 mod jvm;
 mod platform;
 
 pub use self::{
+    filesystem::MemoryFilesystem,
     jvm::run_jvm_test,
     platform::{TestPlatform, TestPlatformEvent},
 };

--- a/test_utils/src/platform.rs
+++ b/test_utils/src/platform.rs
@@ -1,8 +1,10 @@
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use wie_backend::{AudioSink, DatabaseRepository, Instant, Platform, Screen, canvas::Image};
+use wie_backend::{AudioSink, DatabaseRepository, Filesystem, Instant, Platform, Screen, canvas::Image};
 use wie_util::Result;
+
+use crate::filesystem::MemoryFilesystem;
 
 static TEST_EPOCH: AtomicU64 = AtomicU64::new(0);
 
@@ -11,10 +13,16 @@ pub enum TestPlatformEvent {
     Exit,
 }
 
-#[derive(Default)]
 pub struct TestPlatform {
     screen: TestScreen,
     event_handler: Option<Box<dyn Fn(TestPlatformEvent) + Sync + Send>>,
+    fs: Arc<MemoryFilesystem>,
+}
+
+impl Default for TestPlatform {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TestPlatform {
@@ -22,6 +30,7 @@ impl TestPlatform {
         Self {
             screen: TestScreen,
             event_handler: None,
+            fs: Arc::new(MemoryFilesystem::default()),
         }
     }
 
@@ -32,6 +41,7 @@ impl TestPlatform {
         Self {
             screen: TestScreen,
             event_handler: Some(Box::new(event_handler)),
+            fs: Arc::new(MemoryFilesystem::default()),
         }
     }
 }
@@ -48,6 +58,10 @@ impl Platform for TestPlatform {
 
     fn database_repository(&self) -> &dyn DatabaseRepository {
         todo!()
+    }
+
+    fn filesystem(&self) -> &dyn Filesystem {
+        self.fs.as_ref()
     }
 
     fn audio_sink(&self) -> Box<dyn AudioSink> {

--- a/wie_backend/src/lib.rs
+++ b/wie_backend/src/lib.rs
@@ -16,9 +16,9 @@ pub use self::{
     audio_sink::AudioSink,
     database::{Database, DatabaseRepository, RecordId},
     executor::{AsyncCallable, AsyncCallableResult},
-    platform::Platform,
+    platform::{Filesystem, Platform},
     screen::Screen,
-    system::{Event, KeyCode, System},
+    system::{Event, FilesystemOverlay, KeyCode, System},
     task_runner::{DefaultTaskRunner, TaskRunner},
     time::Instant,
 };

--- a/wie_backend/src/platform.rs
+++ b/wie_backend/src/platform.rs
@@ -6,9 +6,48 @@ pub trait Platform: Send + Sync {
     fn screen(&self) -> &dyn Screen;
     fn now(&self) -> Instant;
     fn database_repository(&self) -> &dyn DatabaseRepository;
+    fn filesystem(&self) -> &dyn Filesystem;
     fn audio_sink(&self) -> Box<dyn AudioSink>;
     fn write_stdout(&self, buf: &[u8]);
     fn write_stderr(&self, buf: &[u8]);
     fn exit(&self);
     fn vibrate(&self, duration_ms: u64, intensity: u8);
+}
+
+/// Platform filesystem abstraction. Every method is scoped by `aid`;
+/// implementations MUST NOT cross aid boundaries.
+pub trait Filesystem: Send + Sync {
+    fn exists(&self, aid: &str, path: &str) -> bool;
+
+    fn size(&self, aid: &str, path: &str) -> Option<usize>;
+
+    /// Read up to `count` bytes starting at `offset` into `buf[..count]`.
+    ///
+    /// - File missing → `None`.
+    /// - `offset >= size` (read past EOF) → `Some(0)`.
+    /// - Otherwise → `Some(n)` where `0 < n <= count`. Short reads allowed
+    ///   at end of file.
+    /// - Caller guarantees `buf.len() >= count`. Implementations only write
+    ///   to `buf[..n]`.
+    fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize>;
+
+    /// Write `data` starting at `offset`.
+    ///
+    /// - Creates the file (and any missing intermediate directories) if it
+    ///   does not yet exist. A zero-length `data` is a valid way to
+    ///   materialize an empty file.
+    /// - If `offset + data.len() > current_size` the implementation MUST
+    ///   automatically extend the file, zero-filling the gap.
+    /// - Returns the number of bytes actually written. On success this
+    ///   equals `data.len()`.
+    /// - On failure (path rejected, disk full, permission denied, etc.)
+    ///   MUST return `0` and log via `tracing::warn!` or `tracing::error!`.
+    ///   Silent `0` returns are forbidden.
+    fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize;
+
+    /// Truncate the file to exactly `len` bytes. Creates the file if
+    /// missing.
+    /// - `len > current_size` → zero-fill extend.
+    /// - `len < current_size` → tail bytes dropped.
+    fn truncate(&self, aid: &str, path: &str, len: usize);
 }

--- a/wie_backend/src/system.rs
+++ b/wie_backend/src/system.rs
@@ -4,7 +4,7 @@ mod file_system;
 
 use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc};
 
-use spin::{Mutex, MutexGuard, RwLock, RwLockWriteGuard};
+use spin::{RwLock, RwLockWriteGuard};
 
 use wie_util::Result;
 
@@ -16,9 +16,12 @@ use crate::{
     task_runner::TaskRunner,
 };
 
-use self::{audio::Audio, event_queue::EventQueue, file_system::Filesystem};
+use self::{audio::Audio, event_queue::EventQueue};
 
-pub use self::event_queue::{Event, KeyCode};
+pub use self::{
+    event_queue::{Event, KeyCode},
+    file_system::FilesystemOverlay,
+};
 
 #[derive(Clone)]
 pub struct System {
@@ -26,7 +29,7 @@ pub struct System {
     aid: String,
     executor: Executor,
     platform: Arc<Box<dyn Platform>>,
-    filesystem: Arc<Mutex<Filesystem>>,
+    filesystem: FilesystemOverlay,
     event_queue: Arc<RwLock<EventQueue>>,
     audio: Arc<RwLock<Audio>>,
     task_runner: Arc<dyn TaskRunner>,
@@ -38,13 +41,14 @@ impl System {
         T: TaskRunner + 'static,
     {
         let audio_sink = platform.audio_sink();
+        let platform = Arc::new(platform);
 
         Self {
             pid: pid.to_owned(),
             aid: aid.to_owned(), // TODO create metadata dictionary or something
             executor: Executor::new(),
-            platform: Arc::new(platform),
-            filesystem: Arc::new(Mutex::new(Filesystem::new())),
+            filesystem: FilesystemOverlay::new(platform.clone(), aid),
+            platform,
             event_queue: Arc::new(RwLock::new(EventQueue::new())),
             audio: Arc::new(RwLock::new(Audio::new(audio_sink))),
             task_runner: Arc::new(task_runner),
@@ -76,8 +80,11 @@ impl System {
         YieldFuture::new()
     }
 
-    pub fn filesystem(&self) -> MutexGuard<'_, Filesystem> {
-        self.filesystem.lock()
+    /// Unified filesystem view. Reads consult the persistent platform
+    /// backend first and fall back to the in-memory virtual layer loaded
+    /// from archives; writes always hit the platform backend.
+    pub fn filesystem(&self) -> &FilesystemOverlay {
+        &self.filesystem
     }
 
     pub fn pid(&self) -> &str {

--- a/wie_backend/src/system/file_system.rs
+++ b/wie_backend/src/system/file_system.rs
@@ -1,86 +1,281 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::cmp::min;
 
 use hashbrown::HashMap;
+use spin::Mutex;
 
-#[derive(Default)]
-pub struct Filesystem {
-    virtual_files: HashMap<String, Vec<u8>>,
-}
+use crate::platform::Platform;
 
-impl Filesystem {
-    pub fn new() -> Self {
-        Self {
-            virtual_files: HashMap::new(),
+/// Normalize a guest-supplied path so both overlay layers see the same key.
+///
+/// - Leading `/` are stripped (archive paths often carry them).
+/// - `.` segments are dropped.
+/// - `..` segments, trailing `/`, backslashes, and empty results all
+///   return `None`.
+fn normalize_guest_path(path: &str) -> Option<String> {
+    if path.contains('\\') {
+        return None;
+    }
+
+    let trimmed = path.trim_start_matches('/');
+    if trimmed.is_empty() || trimmed.ends_with('/') {
+        return None;
+    }
+
+    let mut out = String::new();
+    for seg in trimmed.split('/') {
+        match seg {
+            "" => continue,
+            "." => continue,
+            ".." => return None,
+            normal => {
+                if !out.is_empty() {
+                    out.push('/');
+                }
+                out.push_str(normal);
+            }
         }
     }
 
-    pub fn add(&mut self, path: &str, data: Vec<u8>) {
-        let normalized_path = Self::normalize_path(path);
+    if out.is_empty() { None } else { Some(out) }
+}
 
-        self.virtual_files.insert(normalized_path.into(), data);
+/// Unified filesystem view exposed by `System::filesystem()`.
+///
+/// Wraps the persistent `Platform::filesystem()` backend and an in-memory
+/// virtual layer holding archive resources. Writes always hit the platform
+/// backend; reads prefer the platform backend and fall back to the virtual
+/// layer. Paths are normalized internally so callers pass raw guest paths.
+#[derive(Clone)]
+pub struct FilesystemOverlay {
+    platform: Arc<Box<dyn Platform>>,
+    virtual_files: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    aid: Arc<str>,
+}
+
+impl FilesystemOverlay {
+    pub fn new(platform: Arc<Box<dyn Platform>>, aid: &str) -> Self {
+        Self {
+            platform,
+            virtual_files: Arc::new(Mutex::new(HashMap::new())),
+            aid: Arc::from(aid),
+        }
+    }
+
+    pub fn add_virtual(&self, path: &str, data: Vec<u8>) {
+        let key = normalize_guest_path(path).unwrap_or_else(|| path.trim_start_matches('/').to_owned());
+        self.virtual_files.lock().insert(key, data);
     }
 
     pub fn exists(&self, path: &str) -> bool {
-        let normalized_path = Self::normalize_path(path);
+        let Some(normalized) = normalize_guest_path(path) else {
+            return false;
+        };
 
-        self.virtual_files.contains_key(normalized_path)
+        if self.platform.filesystem().exists(&self.aid, &normalized) {
+            return true;
+        }
+        self.virtual_files.lock().contains_key(&normalized)
     }
 
     pub fn size(&self, path: &str) -> Option<usize> {
-        let normalized_path = Self::normalize_path(path);
+        let normalized = normalize_guest_path(path)?;
 
-        if let Some(data) = self.virtual_files.get(normalized_path) {
-            return Some(data.len());
+        if let Some(size) = self.platform.filesystem().size(&self.aid, &normalized) {
+            return Some(size);
         }
-
-        None
+        self.virtual_files.lock().get(&normalized).map(|d| d.len())
     }
 
     pub fn read(&self, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
-        let normalized_path = Self::normalize_path(path);
+        let normalized = normalize_guest_path(path)?;
 
-        if let Some(data) = self.virtual_files.get(normalized_path) {
+        let plat_fs = self.platform.filesystem();
+        if plat_fs.exists(&self.aid, &normalized) {
+            return plat_fs.read(&self.aid, &normalized, offset, count, buf);
+        }
+
+        let files = self.virtual_files.lock();
+        let data = files.get(&normalized)?;
+        if offset >= data.len() {
+            return Some(0);
+        }
+        let n = min(count, data.len() - offset);
+        buf[..n].copy_from_slice(&data[offset..offset + n]);
+        Some(n)
+    }
+
+    pub fn write(&self, path: &str, offset: usize, data: &[u8]) -> usize {
+        let Some(normalized) = normalize_guest_path(path) else {
+            return 0;
+        };
+        self.platform.filesystem().write(&self.aid, &normalized, offset, data)
+    }
+
+    pub fn truncate(&self, path: &str, len: usize) {
+        let Some(normalized) = normalize_guest_path(path) else {
+            return;
+        };
+        self.platform.filesystem().truncate(&self.aid, &normalized, len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        sync::Arc,
+        vec,
+        vec::Vec,
+    };
+
+    use hashbrown::HashMap;
+    use spin::Mutex;
+
+    use crate::{
+        audio_sink::AudioSink,
+        database::DatabaseRepository,
+        platform::{Filesystem, Platform},
+        screen::Screen,
+        time::Instant,
+    };
+
+    use super::FilesystemOverlay;
+
+    #[derive(Default)]
+    struct StubFilesystem {
+        files: Mutex<HashMap<(String, String), Vec<u8>>>,
+    }
+    impl Filesystem for StubFilesystem {
+        fn exists(&self, aid: &str, path: &str) -> bool {
+            self.files.lock().contains_key(&(aid.to_string(), path.to_string()))
+        }
+        fn size(&self, aid: &str, path: &str) -> Option<usize> {
+            self.files.lock().get(&(aid.to_string(), path.to_string())).map(|v| v.len())
+        }
+        fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+            let files = self.files.lock();
+            let data = files.get(&(aid.to_string(), path.to_string()))?;
             if offset >= data.len() {
                 return Some(0);
             }
-
-            let data_size = data.len();
-            let size_to_read = min(count, data_size - offset);
-
-            buf[..size_to_read].copy_from_slice(&data[offset..offset + size_to_read]);
-
-            return Some(size_to_read);
+            let n = core::cmp::min(count, data.len() - offset);
+            buf[..n].copy_from_slice(&data[offset..offset + n]);
+            Some(n)
         }
-
-        None
-    }
-
-    pub fn write(&mut self, path: &str, offset: usize, data: &[u8]) -> usize {
-        let normalized_path = Self::normalize_path(path);
-
-        let file = self.virtual_files.get_mut(normalized_path).unwrap();
-        if file.len() < offset + data.len() {
-            file.resize(offset + data.len(), 0);
+        fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+            let mut files = self.files.lock();
+            let file = files.entry((aid.to_string(), path.to_string())).or_default();
+            if file.len() < offset + data.len() {
+                file.resize(offset + data.len(), 0);
+            }
+            file[offset..offset + data.len()].copy_from_slice(data);
+            data.len()
         }
-        file[offset..offset + data.len()].copy_from_slice(data);
-
-        data.len()
-    }
-
-    pub fn truncate(&mut self, path: &str, len: usize) {
-        let normalized_path = Self::normalize_path(path);
-
-        if let Some(data) = self.virtual_files.get_mut(normalized_path) {
-            data.resize(len, 0);
+        fn truncate(&self, aid: &str, path: &str, len: usize) {
+            let mut files = self.files.lock();
+            let file = files.entry((aid.to_string(), path.to_string())).or_default();
+            file.resize(len, 0);
         }
     }
 
-    pub fn files(&self) -> impl Iterator<Item = (&str, &[u8])> {
-        self.virtual_files.iter().map(|(k, v)| (k.as_str(), v.as_slice()))
+    struct StubPlatform {
+        fs: StubFilesystem,
+    }
+    impl Platform for StubPlatform {
+        fn screen(&self) -> &dyn Screen {
+            unimplemented!()
+        }
+        fn now(&self) -> Instant {
+            Instant::from_epoch_millis(0)
+        }
+        fn database_repository(&self) -> &dyn DatabaseRepository {
+            unimplemented!()
+        }
+        fn filesystem(&self) -> &dyn Filesystem {
+            &self.fs
+        }
+        fn audio_sink(&self) -> Box<dyn AudioSink> {
+            unimplemented!()
+        }
+        fn write_stdout(&self, _buf: &[u8]) {}
+        fn write_stderr(&self, _buf: &[u8]) {}
+        fn exit(&self) {}
+        fn vibrate(&self, _duration_ms: u64, _intensity: u8) {}
     }
 
-    fn normalize_path(path: &str) -> &str {
-        path.trim_start_matches('/')
+    fn setup() -> FilesystemOverlay {
+        let platform: Arc<Box<dyn Platform>> = Arc::new(Box::new(StubPlatform {
+            fs: StubFilesystem::default(),
+        }));
+        FilesystemOverlay::new(platform, "test-aid")
+    }
+
+    #[test]
+    fn add_then_read_virtual() {
+        let fs = setup();
+        fs.add_virtual("a.bin", vec![1, 2, 3, 4]);
+
+        let mut buf = [0u8; 4];
+        assert_eq!(fs.read("a.bin", 0, 4, &mut buf), Some(4));
+        assert_eq!(buf, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn size_falls_through_to_virtual() {
+        let fs = setup();
+        fs.add_virtual("x", vec![0; 17]);
+
+        assert_eq!(fs.size("x"), Some(17));
+        assert_eq!(fs.size("nope"), None);
+    }
+
+    #[test]
+    fn exists_checks_both_layers() {
+        let fs = setup();
+        fs.add_virtual("x", vec![1]);
+
+        assert!(fs.exists("x"));
+        assert!(!fs.exists("y"));
+
+        fs.write("written", 0, &[9]);
+        assert!(fs.exists("written"));
+    }
+
+    #[test]
+    fn leading_slash_normalized() {
+        let fs = setup();
+        fs.add_virtual("/a/b", vec![9]);
+
+        assert!(fs.exists("a/b"));
+        assert!(fs.exists("/a/b"));
+    }
+
+    #[test]
+    fn read_past_eof_virtual_returns_some_zero() {
+        let fs = setup();
+        fs.add_virtual("a", vec![1, 2, 3]);
+
+        let mut buf = [0u8; 4];
+        assert_eq!(fs.read("a", 10, 4, &mut buf), Some(0));
+    }
+
+    #[test]
+    fn read_missing_returns_none() {
+        let fs = setup();
+        let mut buf = [0u8; 4];
+        assert_eq!(fs.read("nope", 0, 4, &mut buf), None);
+    }
+
+    #[test]
+    fn platform_write_shadows_virtual() {
+        let fs = setup();
+        fs.add_virtual("cfg.dat", vec![0xAA, 0xBB, 0xCC]);
+        fs.write("cfg.dat", 0, &[1, 2, 3, 4]);
+
+        let mut buf = [0u8; 4];
+        assert_eq!(fs.read("cfg.dat", 0, 4, &mut buf), Some(4));
+        assert_eq!(buf, [1, 2, 3, 4]);
     }
 }

--- a/wie_cli/src/database.rs
+++ b/wie_cli/src/database.rs
@@ -18,7 +18,7 @@ impl DatabaseRepository {
     }
 
     fn get_path_for_database(&self, name: &str, app_id: &str) -> PathBuf {
-        self.base_path.join(app_id).join(name)
+        self.base_path.join(app_id).join("db").join(name)
     }
 }
 
@@ -115,5 +115,21 @@ impl wie_backend::Database for Database {
             .filter(|x| x.as_ref().unwrap().path().is_file())
             .map(|x| x.unwrap().file_name().to_str().unwrap().parse().unwrap())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::DatabaseRepository;
+
+    #[test]
+    fn database_path_includes_db_segment() {
+        let repo = DatabaseRepository {
+            base_path: PathBuf::from("/tmp/wie_test"),
+        };
+        let path = repo.get_path_for_database("records", "game123");
+        assert_eq!(path, PathBuf::from("/tmp/wie_test/game123/db/records"));
     }
 }

--- a/wie_cli/src/filesystem.rs
+++ b/wie_cli/src/filesystem.rs
@@ -1,0 +1,187 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Component, Path, PathBuf},
+};
+
+use directories::ProjectDirs;
+
+use wie_backend::Filesystem;
+
+/// Persistent filesystem backed by `std::fs` under `<base>/<aid>/fs/<path>`.
+/// Any I/O error or rejected path returns the trait's failure value.
+pub struct CliFilesystem {
+    base_path: PathBuf,
+}
+
+impl CliFilesystem {
+    pub fn new() -> Self {
+        let base_dir = ProjectDirs::from("net", "dlunch", "wie").unwrap();
+        Self {
+            base_path: base_dir.data_dir().to_owned(),
+        }
+    }
+
+    fn path_for(&self, aid: &str, path: &str) -> Option<PathBuf> {
+        let sanitized_aid: String = aid.chars().filter(|c| !matches!(c, '/' | '\\' | '\0')).collect();
+        if sanitized_aid.is_empty() || sanitized_aid == "." || sanitized_aid == ".." {
+            tracing::error!(aid, path, "rejected: invalid aid");
+            return None;
+        }
+
+        let mut normalized = PathBuf::new();
+        for component in Path::new(path).components() {
+            match component {
+                Component::Normal(c) => normalized.push(c),
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    tracing::error!(aid, path, "path traversal attempt rejected");
+                    return None;
+                }
+            }
+        }
+
+        if normalized.as_os_str().is_empty() {
+            tracing::error!(aid, path, "rejected: empty normalized path");
+            return None;
+        }
+
+        Some(self.base_path.join(&sanitized_aid).join("fs").join(normalized))
+    }
+}
+
+impl Default for CliFilesystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Filesystem for CliFilesystem {
+    fn exists(&self, aid: &str, path: &str) -> bool {
+        let Some(disk_path) = self.path_for(aid, path) else {
+            return false;
+        };
+
+        match disk_path.metadata() {
+            Ok(md) => md.is_file(),
+            Err(_) => false,
+        }
+    }
+
+    fn size(&self, aid: &str, path: &str) -> Option<usize> {
+        let disk_path = self.path_for(aid, path)?;
+        let md = disk_path.metadata().ok()?;
+        if !md.is_file() {
+            return None;
+        }
+        Some(md.len() as usize)
+    }
+
+    fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+        let disk_path = self.path_for(aid, path)?;
+
+        let mut file = match OpenOptions::new().read(true).open(&disk_path) {
+            Ok(f) => f,
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return None;
+                }
+                tracing::warn!(aid, path, error = %err, "read: open failed");
+                return None;
+            }
+        };
+
+        let size = file.metadata().map(|m| m.len() as usize).unwrap_or(0);
+        if offset >= size {
+            return Some(0);
+        }
+
+        if let Err(err) = file.seek(SeekFrom::Start(offset as u64)) {
+            tracing::warn!(aid, path, error = %err, "read: seek failed");
+            return Some(0);
+        }
+
+        let to_read = core::cmp::min(count, size - offset);
+        let slice = &mut buf[..to_read];
+        // read_exact so short reads surface to the caller only at EOF, not
+        // on signal interruption.
+        match file.read_exact(slice) {
+            Ok(()) => Some(to_read),
+            Err(err) => {
+                tracing::warn!(aid, path, error = %err, "read: IO error");
+                Some(0)
+            }
+        }
+    }
+
+    fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+        let Some(disk_path) = self.path_for(aid, path) else {
+            return 0;
+        };
+
+        if let Some(parent) = disk_path.parent()
+            && let Err(err) = fs::create_dir_all(parent)
+        {
+            tracing::warn!(aid, path, error = %err, "write: create parent dir failed");
+            return 0;
+        }
+
+        let mut file = match OpenOptions::new().read(true).write(true).create(true).truncate(false).open(&disk_path) {
+            Ok(f) => f,
+            Err(err) => {
+                tracing::warn!(aid, path, error = %err, "write: open failed");
+                return 0;
+            }
+        };
+
+        let current_size = file.metadata().map(|m| m.len() as usize).unwrap_or(0);
+
+        if offset > current_size {
+            // OS sparse extend avoids host allocation for the gap; POSIX
+            // ftruncate and Windows SetEndOfFile both zero-fill the
+            // newly-created region.
+            if let Err(err) = file.set_len(offset as u64) {
+                tracing::warn!(aid, path, error = %err, "write: set_len extend failed");
+                return 0;
+            }
+        }
+
+        if let Err(err) = file.seek(SeekFrom::Start(offset as u64)) {
+            tracing::warn!(aid, path, error = %err, "write: seek failed");
+            return 0;
+        }
+
+        match file.write_all(data) {
+            Ok(()) => data.len(),
+            Err(err) => {
+                tracing::warn!(aid, path, error = %err, "write: write_all failed");
+                0
+            }
+        }
+    }
+
+    fn truncate(&self, aid: &str, path: &str, len: usize) {
+        let Some(disk_path) = self.path_for(aid, path) else {
+            return;
+        };
+
+        if let Some(parent) = disk_path.parent()
+            && let Err(err) = fs::create_dir_all(parent)
+        {
+            tracing::warn!(aid, path, error = %err, "truncate: create parent dir failed");
+            return;
+        }
+
+        let file = match OpenOptions::new().read(true).write(true).create(true).truncate(false).open(&disk_path) {
+            Ok(f) => f,
+            Err(err) => {
+                tracing::warn!(aid, path, error = %err, "truncate: open failed");
+                return;
+            }
+        };
+
+        if let Err(err) = file.set_len(len as u64) {
+            tracing::warn!(aid, path, error = %err, "truncate: set_len failed");
+        }
+    }
+}

--- a/wie_cli/src/main.rs
+++ b/wie_cli/src/main.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 mod audio_sink;
 mod database;
+mod filesystem;
 mod window;
 
 use core::str;
@@ -21,7 +22,7 @@ use midir::MidiOutput;
 use rodio::{DeviceSinkBuilder, Player, buffer::SamplesBuffer, conversions::SampleTypeConverter};
 use winit::keyboard::{KeyCode as WinitKeyCode, PhysicalKey};
 
-use wie_backend::{Emulator, Event, Instant, KeyCode, Options, Platform, Screen, extract_zip};
+use wie_backend::{Emulator, Event, Filesystem, Instant, KeyCode, Options, Platform, Screen, extract_zip};
 use wie_j2me::J2MEEmulator;
 use wie_ktf::KtfEmulator;
 use wie_lgt::LgtEmulator;
@@ -30,12 +31,14 @@ use wie_skt::SktEmulator;
 use self::{
     audio_sink::AudioSink,
     database::DatabaseRepository,
+    filesystem::CliFilesystem,
     window::{WindowCallbackEvent, WindowHandle, WindowImpl},
 };
 
 struct WieCliPlatform {
     audio_thread_tx: Sender<(u8, u32, Vec<i16>)>,
     database_repository: DatabaseRepository,
+    filesystem: CliFilesystem,
     window: WindowHandle,
 }
 
@@ -47,6 +50,7 @@ impl WieCliPlatform {
         Self {
             audio_thread_tx: tx,
             database_repository: DatabaseRepository::new(),
+            filesystem: CliFilesystem::new(),
             window,
         }
     }
@@ -103,6 +107,10 @@ impl Platform for WieCliPlatform {
 
     fn database_repository(&self) -> &dyn wie_backend::DatabaseRepository {
         &self.database_repository
+    }
+
+    fn filesystem(&self) -> &dyn Filesystem {
+        &self.filesystem
     }
 
     fn audio_sink(&self) -> Box<dyn wie_backend::AudioSink> {

--- a/wie_j2me/src/emulator.rs
+++ b/wie_j2me/src/emulator.rs
@@ -52,7 +52,7 @@ impl J2MEEmulator {
         let system = System::new(platform, id, id, DefaultTaskRunner);
 
         for (path, data) in files {
-            system.filesystem().add(path, data.clone());
+            system.filesystem().add_virtual(path, data.clone());
         }
 
         let mut system_clone = system.clone();

--- a/wie_jvm_support/src/runtime.rs
+++ b/wie_jvm_support/src/runtime.rs
@@ -211,8 +211,6 @@ where
     }
 
     async fn metadata(&self, path: &str) -> IOResult<FileStat> {
-        let filesystem = self.system.filesystem();
-
         if path.is_empty() || path.ends_with("/") {
             return Ok(FileStat {
                 size: 0,
@@ -220,15 +218,12 @@ where
             });
         }
 
-        let size = filesystem.size(path);
-        if let Some(size) = size {
-            Ok(FileStat {
-                size: size as _,
-                r#type: FileType::File,
-            })
-        } else {
-            Err(IOError::NotFound)
-        }
+        let size = self.system.filesystem().size(path).ok_or(IOError::NotFound)?;
+
+        Ok(FileStat {
+            size: size as _,
+            r#type: FileType::File,
+        })
     }
 
     async fn find_rustjar_class(&self, jvm: &Jvm, classpath: &str, class: &str) -> JvmResult<Option<Box<dyn ClassDefinition>>> {

--- a/wie_jvm_support/src/runtime/file.rs
+++ b/wie_jvm_support/src/runtime/file.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use wie_backend::System;
@@ -15,16 +15,8 @@ pub struct FileImpl {
 
 impl FileImpl {
     pub fn new(system: System, path: &str, write: bool) -> Result<Self, IOError> {
-        {
-            let mut filesystem = system.filesystem();
-
-            if write {
-                if !filesystem.exists(path) {
-                    filesystem.add(path, Vec::new());
-                }
-            } else if !filesystem.exists(path) {
-                return Err(IOError::NotFound);
-            }
+        if !write && !system.filesystem().exists(path) {
+            return Err(IOError::NotFound);
         }
 
         Ok(Self {
@@ -40,9 +32,9 @@ impl FileImpl {
 impl File for FileImpl {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, IOError> {
         let cursor = self.cursor.load(Ordering::SeqCst) as usize;
+        let fs = self.system.filesystem();
 
-        let filesystem = self.system.filesystem();
-        let read = filesystem.read(&self.path, cursor, buf.len(), buf).ok_or(IOError::NotFound)?;
+        let read = fs.read(&self.path, cursor, buf.len(), buf).ok_or(IOError::NotFound)?;
 
         self.cursor.fetch_add(read as u64, Ordering::SeqCst);
 
@@ -55,13 +47,11 @@ impl File for FileImpl {
         }
 
         let cursor = self.cursor.load(Ordering::SeqCst) as usize;
+        let written = self.system.filesystem().write(&self.path, cursor, buf);
 
-        let mut filesystem = self.system.filesystem();
-        let write = filesystem.write(&self.path, cursor, buf);
+        self.cursor.fetch_add(written as u64, Ordering::SeqCst);
 
-        self.cursor.fetch_add(write as u64, Ordering::SeqCst);
-
-        Ok(write)
+        Ok(written)
     }
 
     async fn seek(&mut self, pos: FileSize) -> IOResult<()> {
@@ -98,26 +88,53 @@ impl File for FileImpl {
 mod tests {
     use alloc::{boxed::Box, vec};
 
-    use java_runtime::{File, IOError};
+    use java_runtime::{File, FileType, IOError};
     use test_utils::TestPlatform;
     use wie_backend::{DefaultTaskRunner, System};
 
     use super::FileImpl;
 
     fn new_system() -> System {
-        System::new(Box::new(TestPlatform::new()), "test", "test", DefaultTaskRunner)
+        System::new(Box::new(TestPlatform::new()), "test", "test-aid", DefaultTaskRunner)
     }
 
     #[futures_test::test]
-    async fn read_only_files_reject_mutation() {
+    async fn virtual_archive_file_is_readable() {
         let system = new_system();
-        system.filesystem().add("readonly.bin", vec![1, 2, 3]);
+        system.filesystem().add_virtual("res.png", vec![1, 2, 3]);
 
-        let mut file = FileImpl::new(system.clone(), "readonly.bin", false).unwrap();
+        let mut file = FileImpl::new(system.clone(), "res.png", false).unwrap();
+        let mut buf = [0u8; 3];
+        assert_eq!(file.read(&mut buf).await.unwrap(), 3);
+        assert_eq!(buf, [1, 2, 3]);
 
         assert!(matches!(file.write(&[9]).await, Err(IOError::Unsupported)));
         assert!(matches!(file.set_len(1).await, Err(IOError::Unsupported)));
-        assert_eq!(system.filesystem().size("readonly.bin"), Some(3));
+    }
+
+    #[futures_test::test]
+    async fn virtual_archive_file_can_be_shadowed() {
+        let system = new_system();
+        system.filesystem().add_virtual("cfg.dat", vec![0xAA, 0xBB, 0xCC]);
+
+        let mut file = FileImpl::new(system.clone(), "cfg.dat", true).unwrap();
+        assert_eq!(file.write(&[1, 2, 3, 4]).await.unwrap(), 4);
+
+        let mut reopened = FileImpl::new(system.clone(), "cfg.dat", false).unwrap();
+        let mut buf = [0u8; 4];
+        assert_eq!(reopened.read(&mut buf).await.unwrap(), 4);
+        assert_eq!(buf, [1, 2, 3, 4]);
+    }
+
+    #[futures_test::test]
+    async fn write_handle_sees_virtual_until_first_write() {
+        let system = new_system();
+        system.filesystem().add_virtual("big.bin", vec![7u8; 10]);
+
+        let mut file = FileImpl::new(system.clone(), "big.bin", true).unwrap();
+        let mut buf = [0u8; 10];
+        assert_eq!(file.read(&mut buf).await.unwrap(), 10);
+        assert_eq!(buf, [7u8; 10]);
     }
 
     #[futures_test::test]
@@ -134,5 +151,61 @@ mod tests {
         let mut buf = [0; 3];
         assert_eq!(reopened.read(&mut buf).await.unwrap(), 3);
         assert_eq!(buf, [1, 2, 9]);
+    }
+
+    #[futures_test::test]
+    async fn read_missing_file_returns_not_found() {
+        let system = new_system();
+        let result = FileImpl::new(system, "nope.dat", false);
+        assert!(matches!(result, Err(IOError::NotFound)));
+    }
+
+    #[futures_test::test]
+    async fn metadata_overlay_size() {
+        let system = new_system();
+        system.filesystem().add_virtual("f.bin", vec![0u8; 5]);
+
+        {
+            let mut writer = FileImpl::new(system.clone(), "f.bin", true).unwrap();
+            writer.write(&[1u8; 10]).await.unwrap();
+        }
+
+        let file = FileImpl::new(system.clone(), "f.bin", false).unwrap();
+        let meta = file.metadata().await.unwrap();
+        assert_eq!(meta.size, 10);
+        assert!(matches!(meta.r#type, FileType::File));
+    }
+
+    #[futures_test::test]
+    async fn metadata_falls_back_to_virtual() {
+        let system = new_system();
+        system.filesystem().add_virtual("only_virtual.bin", vec![0u8; 7]);
+
+        let file = FileImpl::new(system, "only_virtual.bin", false).unwrap();
+        let meta = file.metadata().await.unwrap();
+        assert_eq!(meta.size, 7);
+    }
+
+    #[futures_test::test]
+    async fn path_aliases_resolve_to_same_file() {
+        let system = new_system();
+        system.filesystem().add_virtual("/leading.bin", vec![1, 2, 3, 4]);
+
+        let mut f = FileImpl::new(system.clone(), "./leading.bin", false).unwrap();
+        let mut buf = [0u8; 4];
+        assert_eq!(f.read(&mut buf).await.unwrap(), 4);
+        assert_eq!(buf, [1, 2, 3, 4]);
+
+        let mut f2 = FileImpl::new(system, "/leading.bin", false).unwrap();
+        let mut buf2 = [0u8; 4];
+        assert_eq!(f2.read(&mut buf2).await.unwrap(), 4);
+        assert_eq!(buf2, [1, 2, 3, 4]);
+    }
+
+    #[futures_test::test]
+    async fn traversal_path_rejected_when_reading() {
+        let system = new_system();
+        assert!(matches!(FileImpl::new(system.clone(), "../escape.dat", false), Err(IOError::NotFound)));
+        assert!(matches!(FileImpl::new(system, "", false), Err(IOError::NotFound)));
     }
 }

--- a/wie_ktf/src/emulator.rs
+++ b/wie_ktf/src/emulator.rs
@@ -89,7 +89,7 @@ impl KtfEmulator {
 
         for (path, data) in files {
             let path = path.trim_start_matches("P/");
-            system.filesystem().add(path, data.clone());
+            system.filesystem().add_virtual(path, data.clone());
         }
 
         Allocator::init(&mut core)?;

--- a/wie_lgt/src/emulator.rs
+++ b/wie_lgt/src/emulator.rs
@@ -88,7 +88,7 @@ impl LgtEmulator {
         let system = System::new(platform, pid, aid, LgtTaskRunner { core: core.clone() });
 
         for (filename, data) in files {
-            system.filesystem().add(filename, data.clone())
+            system.filesystem().add_virtual(filename, data.clone())
         }
 
         Allocator::init(&mut core)?;

--- a/wie_skt/src/emulator.rs
+++ b/wie_skt/src/emulator.rs
@@ -55,7 +55,7 @@ impl SktEmulator {
         let system = System::new(platform, id, id, DefaultTaskRunner);
 
         for (filename, data) in files {
-            system.filesystem().add(filename, data.clone())
+            system.filesystem().add_virtual(filename, data.clone())
         }
 
         let mut system_clone = system.clone();


### PR DESCRIPTION
## Summary
- 게스트 파일 write가 실제 디스크에 영속화되도록 `PlatformFilesystem` trait 도입 (기존 `DatabaseRepository` 패턴 대칭)
- Overlay 라우팅: write는 항상 primary fs, read는 primary → virtual(archive) fallback → NotFound. Archive 경로에 write하면 primary에 shadow 생성
- Database 경로를 `<data_dir>/<aid>/<name>` → `<data_dir>/<aid>/db/<name>`로 이동, filesystem은 `<data_dir>/<aid>/fs/<path>`로 분리
- 기존 in-memory `Filesystem`을 `VirtualFilesystem`으로 rename하고 `write/truncate` public API 제거 (archive 전용 read-only)
- 3개 구현체(`VirtualFilesystem`/`MemoryFilesystem`/`CliFilesystem`) 간 path 의미 통일 위해 `wie_backend::normalize_guest_path` 공용 유틸 추가
- `CliFilesystem`의 zero-fill extension을 `file.set_len()` (sparse)으로 구현해 메모리 DoS 방어

## Breaking
- 기존 사용자의 `<data_dir>/<aid>/<record_id>` DB 데이터는 자동 마이그레이션 없이 버려집니다 (새 경로로 재생성). 릴리즈 노트 반영 필요.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets` (경고 0)
- [x] `cargo test --workspace` (97개 통과)
- [x] `cargo fmt --check`
- [ ] 샘플 KTF zip / MIDP jar로 save → exit → rerun → load 왕복 수동 회귀

## Follow-up
- `metadata_directory_passthrough` 회귀 테스트
- 경계값 테스트: null-byte aid, zero-byte write, u32::MAX offset
- Windows `OpenOptions::share_mode` 설정
- 선택적 `fsync` 옵션
- `CliFilesystem` LRU open 캐시 (hot-path 최적화)

상세 산출물은 `docs/forge/20260418-platform-filesystem/`(PRD, 아키텍처, 리뷰, QA, 최종 리포트) 참조.