### PR TITLE
Convert Filesystem trait to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,6 +3358,7 @@ dependencies = [
  "ab_glyph",
  "async-trait",
  "bytemuck",
+ "futures-test",
  "hashbrown 0.17.0",
  "image",
  "lazy_static",

--- a/test_utils/src/filesystem.rs
+++ b/test_utils/src/filesystem.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     vec::Vec,
 };
@@ -21,16 +22,17 @@ impl MemoryFilesystem {
     }
 }
 
+#[async_trait::async_trait]
 impl Filesystem for MemoryFilesystem {
-    fn exists(&self, aid: &str, path: &str) -> bool {
+    async fn exists(&self, aid: &str, path: &str) -> bool {
         self.files.lock().contains_key(&(aid.to_string(), path.to_string()))
     }
 
-    fn size(&self, aid: &str, path: &str) -> Option<usize> {
+    async fn size(&self, aid: &str, path: &str) -> Option<usize> {
         self.files.lock().get(&(aid.to_string(), path.to_string())).map(|v| v.len())
     }
 
-    fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+    async fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
         let files = self.files.lock();
         let data = files.get(&(aid.to_string(), path.to_string()))?;
 
@@ -43,7 +45,7 @@ impl Filesystem for MemoryFilesystem {
         Some(size_to_read)
     }
 
-    fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+    async fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
         let mut files = self.files.lock();
         let file = files.entry((aid.to_string(), path.to_string())).or_default();
         if file.len() < offset + data.len() {
@@ -54,7 +56,7 @@ impl Filesystem for MemoryFilesystem {
         data.len()
     }
 
-    fn truncate(&self, aid: &str, path: &str, len: usize) {
+    async fn truncate(&self, aid: &str, path: &str, len: usize) {
         let mut files = self.files.lock();
         let file = files.entry((aid.to_string(), path.to_string())).or_default();
         file.resize(len, 0);

--- a/wie_backend/Cargo.toml
+++ b/wie_backend/Cargo.toml
@@ -21,3 +21,6 @@ wie_util = { workspace = true }
 
 smaf = { git = "https://github.com/dlunch/smaf.git" }
 smaf_player = { git = "https://github.com/dlunch/smaf.git" }
+
+[dev-dependencies]
+futures-test = { workspace = true }

--- a/wie_backend/src/platform.rs
+++ b/wie_backend/src/platform.rs
@@ -16,10 +16,11 @@ pub trait Platform: Send + Sync {
 
 /// Platform filesystem abstraction. Every method is scoped by `aid`;
 /// implementations MUST NOT cross aid boundaries.
+#[async_trait::async_trait]
 pub trait Filesystem: Send + Sync {
-    fn exists(&self, aid: &str, path: &str) -> bool;
+    async fn exists(&self, aid: &str, path: &str) -> bool;
 
-    fn size(&self, aid: &str, path: &str) -> Option<usize>;
+    async fn size(&self, aid: &str, path: &str) -> Option<usize>;
 
     /// Read up to `count` bytes starting at `offset` into `buf[..count]`.
     ///
@@ -29,7 +30,7 @@ pub trait Filesystem: Send + Sync {
     ///   at end of file.
     /// - Caller guarantees `buf.len() >= count`. Implementations only write
     ///   to `buf[..n]`.
-    fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize>;
+    async fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize>;
 
     /// Write `data` starting at `offset`.
     ///
@@ -43,11 +44,11 @@ pub trait Filesystem: Send + Sync {
     /// - On failure (path rejected, disk full, permission denied, etc.)
     ///   MUST return `0` and log via `tracing::warn!` or `tracing::error!`.
     ///   Silent `0` returns are forbidden.
-    fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize;
+    async fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize;
 
     /// Truncate the file to exactly `len` bytes. Creates the file if
     /// missing.
     /// - `len > current_size` → zero-fill extend.
     /// - `len < current_size` → tail bytes dropped.
-    fn truncate(&self, aid: &str, path: &str, len: usize);
+    async fn truncate(&self, aid: &str, path: &str, len: usize);
 }

--- a/wie_backend/src/system/file_system.rs
+++ b/wie_backend/src/system/file_system.rs
@@ -67,32 +67,32 @@ impl FilesystemOverlay {
         self.virtual_files.lock().insert(key, data);
     }
 
-    pub fn exists(&self, path: &str) -> bool {
+    pub async fn exists(&self, path: &str) -> bool {
         let Some(normalized) = normalize_guest_path(path) else {
             return false;
         };
 
-        if self.platform.filesystem().exists(&self.aid, &normalized) {
+        if self.platform.filesystem().exists(&self.aid, &normalized).await {
             return true;
         }
         self.virtual_files.lock().contains_key(&normalized)
     }
 
-    pub fn size(&self, path: &str) -> Option<usize> {
+    pub async fn size(&self, path: &str) -> Option<usize> {
         let normalized = normalize_guest_path(path)?;
 
-        if let Some(size) = self.platform.filesystem().size(&self.aid, &normalized) {
+        if let Some(size) = self.platform.filesystem().size(&self.aid, &normalized).await {
             return Some(size);
         }
         self.virtual_files.lock().get(&normalized).map(|d| d.len())
     }
 
-    pub fn read(&self, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+    pub async fn read(&self, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
         let normalized = normalize_guest_path(path)?;
 
         let plat_fs = self.platform.filesystem();
-        if plat_fs.exists(&self.aid, &normalized) {
-            return plat_fs.read(&self.aid, &normalized, offset, count, buf);
+        if plat_fs.exists(&self.aid, &normalized).await {
+            return plat_fs.read(&self.aid, &normalized, offset, count, buf).await;
         }
 
         let files = self.virtual_files.lock();
@@ -105,18 +105,18 @@ impl FilesystemOverlay {
         Some(n)
     }
 
-    pub fn write(&self, path: &str, offset: usize, data: &[u8]) -> usize {
+    pub async fn write(&self, path: &str, offset: usize, data: &[u8]) -> usize {
         let Some(normalized) = normalize_guest_path(path) else {
             return 0;
         };
-        self.platform.filesystem().write(&self.aid, &normalized, offset, data)
+        self.platform.filesystem().write(&self.aid, &normalized, offset, data).await
     }
 
-    pub fn truncate(&self, path: &str, len: usize) {
+    pub async fn truncate(&self, path: &str, len: usize) {
         let Some(normalized) = normalize_guest_path(path) else {
             return;
         };
-        self.platform.filesystem().truncate(&self.aid, &normalized, len);
+        self.platform.filesystem().truncate(&self.aid, &normalized, len).await;
     }
 }
 
@@ -147,14 +147,15 @@ mod tests {
     struct StubFilesystem {
         files: Mutex<HashMap<(String, String), Vec<u8>>>,
     }
+    #[async_trait::async_trait]
     impl Filesystem for StubFilesystem {
-        fn exists(&self, aid: &str, path: &str) -> bool {
+        async fn exists(&self, aid: &str, path: &str) -> bool {
             self.files.lock().contains_key(&(aid.to_string(), path.to_string()))
         }
-        fn size(&self, aid: &str, path: &str) -> Option<usize> {
+        async fn size(&self, aid: &str, path: &str) -> Option<usize> {
             self.files.lock().get(&(aid.to_string(), path.to_string())).map(|v| v.len())
         }
-        fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+        async fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
             let files = self.files.lock();
             let data = files.get(&(aid.to_string(), path.to_string()))?;
             if offset >= data.len() {
@@ -164,7 +165,7 @@ mod tests {
             buf[..n].copy_from_slice(&data[offset..offset + n]);
             Some(n)
         }
-        fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+        async fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
             let mut files = self.files.lock();
             let file = files.entry((aid.to_string(), path.to_string())).or_default();
             if file.len() < offset + data.len() {
@@ -173,7 +174,7 @@ mod tests {
             file[offset..offset + data.len()].copy_from_slice(data);
             data.len()
         }
-        fn truncate(&self, aid: &str, path: &str, len: usize) {
+        async fn truncate(&self, aid: &str, path: &str, len: usize) {
             let mut files = self.files.lock();
             let file = files.entry((aid.to_string(), path.to_string())).or_default();
             file.resize(len, 0);
@@ -212,70 +213,70 @@ mod tests {
         FilesystemOverlay::new(platform, "test-aid")
     }
 
-    #[test]
-    fn add_then_read_virtual() {
+    #[futures_test::test]
+    async fn add_then_read_virtual() {
         let fs = setup();
         fs.add_virtual("a.bin", vec![1, 2, 3, 4]);
 
         let mut buf = [0u8; 4];
-        assert_eq!(fs.read("a.bin", 0, 4, &mut buf), Some(4));
+        assert_eq!(fs.read("a.bin", 0, 4, &mut buf).await, Some(4));
         assert_eq!(buf, [1, 2, 3, 4]);
     }
 
-    #[test]
-    fn size_falls_through_to_virtual() {
+    #[futures_test::test]
+    async fn size_falls_through_to_virtual() {
         let fs = setup();
         fs.add_virtual("x", vec![0; 17]);
 
-        assert_eq!(fs.size("x"), Some(17));
-        assert_eq!(fs.size("nope"), None);
+        assert_eq!(fs.size("x").await, Some(17));
+        assert_eq!(fs.size("nope").await, None);
     }
 
-    #[test]
-    fn exists_checks_both_layers() {
+    #[futures_test::test]
+    async fn exists_checks_both_layers() {
         let fs = setup();
         fs.add_virtual("x", vec![1]);
 
-        assert!(fs.exists("x"));
-        assert!(!fs.exists("y"));
+        assert!(fs.exists("x").await);
+        assert!(!fs.exists("y").await);
 
-        fs.write("written", 0, &[9]);
-        assert!(fs.exists("written"));
+        fs.write("written", 0, &[9]).await;
+        assert!(fs.exists("written").await);
     }
 
-    #[test]
-    fn leading_slash_normalized() {
+    #[futures_test::test]
+    async fn leading_slash_normalized() {
         let fs = setup();
         fs.add_virtual("/a/b", vec![9]);
 
-        assert!(fs.exists("a/b"));
-        assert!(fs.exists("/a/b"));
+        assert!(fs.exists("a/b").await);
+        assert!(fs.exists("/a/b").await);
     }
 
-    #[test]
-    fn read_past_eof_virtual_returns_some_zero() {
+    #[futures_test::test]
+    async fn read_past_eof_virtual_returns_some_zero() {
         let fs = setup();
         fs.add_virtual("a", vec![1, 2, 3]);
 
         let mut buf = [0u8; 4];
-        assert_eq!(fs.read("a", 10, 4, &mut buf), Some(0));
+        assert_eq!(fs.read("a", 10, 4, &mut buf).await, Some(0));
     }
 
-    #[test]
-    fn read_missing_returns_none() {
+    #[futures_test::test]
+    async fn read_missing_returns_none() {
         let fs = setup();
         let mut buf = [0u8; 4];
-        assert_eq!(fs.read("nope", 0, 4, &mut buf), None);
+        assert_eq!(fs.read("nope", 0, 4, &mut buf).await, None);
     }
 
-    #[test]
-    fn platform_write_shadows_virtual() {
+    #[futures_test::test]
+    async fn platform_write_shadows_virtual() {
         let fs = setup();
         fs.add_virtual("cfg.dat", vec![0xAA, 0xBB, 0xCC]);
-        fs.write("cfg.dat", 0, &[1, 2, 3, 4]);
+        fs.write("cfg.dat", 0, &[1, 2, 3, 4]).await;
 
         let mut buf = [0u8; 4];
-        assert_eq!(fs.read("cfg.dat", 0, 4, &mut buf), Some(4));
+        assert_eq!(fs.read("cfg.dat", 0, 4, &mut buf).await, Some(4));
         assert_eq!(buf, [1, 2, 3, 4]);
     }
 }

--- a/wie_cli/src/filesystem.rs
+++ b/wie_cli/src/filesystem.rs
@@ -56,8 +56,9 @@ impl Default for CliFilesystem {
     }
 }
 
+#[async_trait::async_trait]
 impl Filesystem for CliFilesystem {
-    fn exists(&self, aid: &str, path: &str) -> bool {
+    async fn exists(&self, aid: &str, path: &str) -> bool {
         let Some(disk_path) = self.path_for(aid, path) else {
             return false;
         };
@@ -68,7 +69,7 @@ impl Filesystem for CliFilesystem {
         }
     }
 
-    fn size(&self, aid: &str, path: &str) -> Option<usize> {
+    async fn size(&self, aid: &str, path: &str) -> Option<usize> {
         let disk_path = self.path_for(aid, path)?;
         let md = disk_path.metadata().ok()?;
         if !md.is_file() {
@@ -77,7 +78,7 @@ impl Filesystem for CliFilesystem {
         Some(md.len() as usize)
     }
 
-    fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
+    async fn read(&self, aid: &str, path: &str, offset: usize, count: usize, buf: &mut [u8]) -> Option<usize> {
         let disk_path = self.path_for(aid, path)?;
 
         let mut file = match OpenOptions::new().read(true).open(&disk_path) {
@@ -114,7 +115,7 @@ impl Filesystem for CliFilesystem {
         }
     }
 
-    fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+    async fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
         let Some(disk_path) = self.path_for(aid, path) else {
             return 0;
         };
@@ -160,7 +161,7 @@ impl Filesystem for CliFilesystem {
         }
     }
 
-    fn truncate(&self, aid: &str, path: &str, len: usize) {
+    async fn truncate(&self, aid: &str, path: &str, len: usize) {
         let Some(disk_path) = self.path_for(aid, path) else {
             return;
         };

--- a/wie_jvm_support/src/runtime.rs
+++ b/wie_jvm_support/src/runtime.rs
@@ -194,7 +194,7 @@ where
     async fn open(&self, path: &str, write: bool) -> IOResult<FileDescriptorId> {
         tracing::debug!("open({path:?}, {write:?})");
 
-        let file = FileImpl::new(self.system.clone(), path, write)?;
+        let file = FileImpl::new(self.system.clone(), path, write).await?;
         Ok(self.file_table.lock().add(Box::new(file)))
     }
 
@@ -218,7 +218,7 @@ where
             });
         }
 
-        let size = self.system.filesystem().size(path).ok_or(IOError::NotFound)?;
+        let size = self.system.filesystem().size(path).await.ok_or(IOError::NotFound)?;
 
         Ok(FileStat {
             size: size as _,

--- a/wie_jvm_support/src/runtime/file.rs
+++ b/wie_jvm_support/src/runtime/file.rs
@@ -14,8 +14,8 @@ pub struct FileImpl {
 }
 
 impl FileImpl {
-    pub fn new(system: System, path: &str, write: bool) -> Result<Self, IOError> {
-        if !write && !system.filesystem().exists(path) {
+    pub async fn new(system: System, path: &str, write: bool) -> Result<Self, IOError> {
+        if !write && !system.filesystem().exists(path).await {
             return Err(IOError::NotFound);
         }
 
@@ -34,7 +34,7 @@ impl File for FileImpl {
         let cursor = self.cursor.load(Ordering::SeqCst) as usize;
         let fs = self.system.filesystem();
 
-        let read = fs.read(&self.path, cursor, buf.len(), buf).ok_or(IOError::NotFound)?;
+        let read = fs.read(&self.path, cursor, buf.len(), buf).await.ok_or(IOError::NotFound)?;
 
         self.cursor.fetch_add(read as u64, Ordering::SeqCst);
 
@@ -47,7 +47,7 @@ impl File for FileImpl {
         }
 
         let cursor = self.cursor.load(Ordering::SeqCst) as usize;
-        let written = self.system.filesystem().write(&self.path, cursor, buf);
+        let written = self.system.filesystem().write(&self.path, cursor, buf).await;
 
         self.cursor.fetch_add(written as u64, Ordering::SeqCst);
 
@@ -69,13 +69,13 @@ impl File for FileImpl {
             return Err(IOError::Unsupported);
         }
 
-        self.system.filesystem().truncate(&self.path, len as usize);
+        self.system.filesystem().truncate(&self.path, len as usize).await;
 
         Ok(())
     }
 
     async fn metadata(&self) -> IOResult<FileStat> {
-        let size = self.system.filesystem().size(&self.path).ok_or(IOError::NotFound)?;
+        let size = self.system.filesystem().size(&self.path).await.ok_or(IOError::NotFound)?;
 
         Ok(FileStat {
             size: size as _,
@@ -103,7 +103,7 @@ mod tests {
         let system = new_system();
         system.filesystem().add_virtual("res.png", vec![1, 2, 3]);
 
-        let mut file = FileImpl::new(system.clone(), "res.png", false).unwrap();
+        let mut file = FileImpl::new(system.clone(), "res.png", false).await.unwrap();
         let mut buf = [0u8; 3];
         assert_eq!(file.read(&mut buf).await.unwrap(), 3);
         assert_eq!(buf, [1, 2, 3]);
@@ -117,10 +117,10 @@ mod tests {
         let system = new_system();
         system.filesystem().add_virtual("cfg.dat", vec![0xAA, 0xBB, 0xCC]);
 
-        let mut file = FileImpl::new(system.clone(), "cfg.dat", true).unwrap();
+        let mut file = FileImpl::new(system.clone(), "cfg.dat", true).await.unwrap();
         assert_eq!(file.write(&[1, 2, 3, 4]).await.unwrap(), 4);
 
-        let mut reopened = FileImpl::new(system.clone(), "cfg.dat", false).unwrap();
+        let mut reopened = FileImpl::new(system.clone(), "cfg.dat", false).await.unwrap();
         let mut buf = [0u8; 4];
         assert_eq!(reopened.read(&mut buf).await.unwrap(), 4);
         assert_eq!(buf, [1, 2, 3, 4]);
@@ -131,7 +131,7 @@ mod tests {
         let system = new_system();
         system.filesystem().add_virtual("big.bin", vec![7u8; 10]);
 
-        let mut file = FileImpl::new(system.clone(), "big.bin", true).unwrap();
+        let mut file = FileImpl::new(system.clone(), "big.bin", true).await.unwrap();
         let mut buf = [0u8; 10];
         assert_eq!(file.read(&mut buf).await.unwrap(), 10);
         assert_eq!(buf, [7u8; 10]);
@@ -140,14 +140,14 @@ mod tests {
     #[futures_test::test]
     async fn writable_files_can_create_and_truncate() {
         let system = new_system();
-        let mut file = FileImpl::new(system.clone(), "writeable.bin", true).unwrap();
+        let mut file = FileImpl::new(system.clone(), "writeable.bin", true).await.unwrap();
 
         assert_eq!(file.write(&[1, 2, 3, 4]).await.unwrap(), 4);
         file.seek(2).await.unwrap();
         assert_eq!(file.write(&[9]).await.unwrap(), 1);
         file.set_len(3).await.unwrap();
 
-        let mut reopened = FileImpl::new(system.clone(), "writeable.bin", false).unwrap();
+        let mut reopened = FileImpl::new(system.clone(), "writeable.bin", false).await.unwrap();
         let mut buf = [0; 3];
         assert_eq!(reopened.read(&mut buf).await.unwrap(), 3);
         assert_eq!(buf, [1, 2, 9]);
@@ -156,7 +156,7 @@ mod tests {
     #[futures_test::test]
     async fn read_missing_file_returns_not_found() {
         let system = new_system();
-        let result = FileImpl::new(system, "nope.dat", false);
+        let result = FileImpl::new(system, "nope.dat", false).await;
         assert!(matches!(result, Err(IOError::NotFound)));
     }
 
@@ -166,11 +166,11 @@ mod tests {
         system.filesystem().add_virtual("f.bin", vec![0u8; 5]);
 
         {
-            let mut writer = FileImpl::new(system.clone(), "f.bin", true).unwrap();
+            let mut writer = FileImpl::new(system.clone(), "f.bin", true).await.unwrap();
             writer.write(&[1u8; 10]).await.unwrap();
         }
 
-        let file = FileImpl::new(system.clone(), "f.bin", false).unwrap();
+        let file = FileImpl::new(system.clone(), "f.bin", false).await.unwrap();
         let meta = file.metadata().await.unwrap();
         assert_eq!(meta.size, 10);
         assert!(matches!(meta.r#type, FileType::File));
@@ -181,7 +181,7 @@ mod tests {
         let system = new_system();
         system.filesystem().add_virtual("only_virtual.bin", vec![0u8; 7]);
 
-        let file = FileImpl::new(system, "only_virtual.bin", false).unwrap();
+        let file = FileImpl::new(system, "only_virtual.bin", false).await.unwrap();
         let meta = file.metadata().await.unwrap();
         assert_eq!(meta.size, 7);
     }
@@ -191,12 +191,12 @@ mod tests {
         let system = new_system();
         system.filesystem().add_virtual("/leading.bin", vec![1, 2, 3, 4]);
 
-        let mut f = FileImpl::new(system.clone(), "./leading.bin", false).unwrap();
+        let mut f = FileImpl::new(system.clone(), "./leading.bin", false).await.unwrap();
         let mut buf = [0u8; 4];
         assert_eq!(f.read(&mut buf).await.unwrap(), 4);
         assert_eq!(buf, [1, 2, 3, 4]);
 
-        let mut f2 = FileImpl::new(system, "/leading.bin", false).unwrap();
+        let mut f2 = FileImpl::new(system, "/leading.bin", false).await.unwrap();
         let mut buf2 = [0u8; 4];
         assert_eq!(f2.read(&mut buf2).await.unwrap(), 4);
         assert_eq!(buf2, [1, 2, 3, 4]);
@@ -205,7 +205,10 @@ mod tests {
     #[futures_test::test]
     async fn traversal_path_rejected_when_reading() {
         let system = new_system();
-        assert!(matches!(FileImpl::new(system.clone(), "../escape.dat", false), Err(IOError::NotFound)));
-        assert!(matches!(FileImpl::new(system, "", false), Err(IOError::NotFound)));
+        assert!(matches!(
+            FileImpl::new(system.clone(), "../escape.dat", false).await,
+            Err(IOError::NotFound)
+        ));
+        assert!(matches!(FileImpl::new(system, "", false).await, Err(IOError::NotFound)));
     }
 }


### PR DESCRIPTION
## Summary
- `Filesystem` trait의 5개 메서드(exists/size/read/write/truncate)를 async로 전환 (`#[async_trait]`)
- `FilesystemOverlay`의 동일 5개 메서드도 async. `add_virtual`은 in-memory 조작이라 sync 유지
- 3개 구현체(CliFilesystem / MemoryFilesystem / test StubFilesystem) + 호출자(FileImpl, JvmRuntime::metadata) 갱신
- 내부 I/O 자체는 여전히 std::fs/HashMap이지만, 미래의 wasm/IndexedDB/tokio::fs 백엔드가 await 지점을 자연스럽게 쓸 수 있음

## Depends on
- platform-filesystem 브랜치 위의 후속 커밋입니다 (`a83c66c4` 다음 `da981560`)

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo fmt --check`