### PR TITLE
Reset sustain and lingering voices on SMAF stop

### DIFF
--- a/wie_backend/src/system/audio.rs
+++ b/wie_backend/src/system/audio.rs
@@ -1,4 +1,9 @@
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use smaf_player::{SmafEvent, parse_smaf};
@@ -95,6 +100,7 @@ impl SmafPlayer {
 
     pub async fn play(&self, system: &mut System, sink: &dyn AudioSink, stop_flag: &AtomicBool) {
         let mut active_notes: Vec<(u8, u8)> = Vec::new();
+        let mut used_channels: BTreeSet<u8> = BTreeSet::new();
 
         let start_time = system.platform().now();
         for (time, event) in &self.events {
@@ -122,6 +128,7 @@ impl SmafPlayer {
                 SmafEvent::MidiNoteOn { channel, note, velocity } => {
                     sink.midi_note_on(*channel, *note, *velocity);
                     active_notes.push((*channel, *note));
+                    used_channels.insert(*channel);
                 }
                 SmafEvent::MidiNoteOff { channel, note, velocity } => {
                     sink.midi_note_off(*channel, *note, *velocity);
@@ -129,9 +136,11 @@ impl SmafPlayer {
                 }
                 SmafEvent::MidiProgramChange { channel, program } => {
                     sink.midi_program_change(*channel, *program);
+                    used_channels.insert(*channel);
                 }
                 SmafEvent::MidiControlChange { channel, control, value } => {
                     sink.midi_control_change(*channel, *control, *value);
+                    used_channels.insert(*channel);
                 }
                 SmafEvent::End => {}
             }
@@ -139,6 +148,16 @@ impl SmafPlayer {
 
         for (channel, note) in &active_notes {
             sink.midi_note_off(*channel, *note, 0);
+        }
+
+        // Release sustain and force any lingering voices off on every channel
+        // this track touched. Tracks that set sustain pedal (CC 64) or use
+        // long release envelopes (e.g. drum voices) otherwise keep ringing
+        // after note_off.
+        for channel in &used_channels {
+            sink.midi_control_change(*channel, 64, 0); // sustain off
+            sink.midi_control_change(*channel, 120, 0); // all sound off
+            sink.midi_control_change(*channel, 123, 0); // all notes off
         }
     }
 }


### PR DESCRIPTION
## Summary
오디오 stop 후 특정 MIDI 악기가 계속 울리는 증상 수정.

기존 cleanup은 `active_notes`에 추적된 노트에 대해서만 note_off를 보냈음. 다음 경우 소리가 남음:
- 채널이 sustain pedal(CC 64)을 켜둔 상태 — note_off가 와도 음이 release되지 않음
- 드럼 등 release envelope이 긴 악기

SMAF 트랙이 건드린 모든 채널에 대해 정리 메시지 3종 발송하도록 변경:
- Sustain off (CC 64 = 0)
- All Sound Off (CC 120 = 0)
- All Notes Off (CC 123 = 0)

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] \`cargo fmt --check\`
- [ ] 실제 SMAF BGM 재생 중 stop → 이전에 안 꺼지던 악기가 끊기는지 수동 확인