### PR TITLE
Sampling profiler + register-resident inline-copy hooks

### DIFF
--- a/data/native_hooks.toml
+++ b/data/native_hooks.toml
@@ -33,6 +33,20 @@
 [[entry]]
 name = "Generic compiler library / inline copy patterns"
 
+# Per-frame byte-by-byte memcpy with `src/dst/count` in registers.
+# Loop:
+#   LDRB R3, [Rsrc];   STRB R3, [Rdst]
+#   MOV  R3, Rcount;   ADDS Rsrc, #1; ADDS Rdst, #1; SUBS Rcount, #1
+#   CMP  R3, #0;       BGT loop
+# `Rcount` holds `remaining - 1`, so actual byte count is `Rcount + 1`.
+# Seen as the dominant per-frame hot path in mgh2's `copy_offscreen_to_screen`.
+# Bit-pattern tokens use `s`/`d`/`c` to capture src/dst/count register fields;
+# `exit_pc` is auto-derived as `match_end | 1` (right past the BGT).
+[[entry.hook]]
+kind = "reg_inline_copy"
+pattern = "0b00sss011 78 0b00ddd011 70 0b00ccc011 1c 01 0b00110sss 01 0b00110ddd 01 0b00111ccc 00 2b f7 dc"
+count_offset = 1
+
 # Thumb -O0 byte copy: `*dst++ = *src++` with `dst`/`src`/`len` all on the
 # stack. Src is reached via single-instruction `SUBS R4, R7, #4` (`3c 1f`),
 # so `src_offset` is pinned.

--- a/wie_backend/src/lib.rs
+++ b/wie_backend/src/lib.rs
@@ -24,6 +24,7 @@ pub use self::{
 };
 
 use alloc::{
+    boxed::Box,
     collections::BTreeMap,
     format,
     string::{String, ToString},
@@ -37,8 +38,20 @@ pub trait Emulator {
     fn tick(&mut self) -> Result<()>;
 }
 
+pub struct ProfileSample {
+    /// Leaf-first call stack: [pc, lr, lr_prev, ...].
+    pub stack: Vec<u32>,
+    pub count: u64,
+}
+
+/// Called periodically during execution with a batch of samples that the
+/// profiler accumulated since the previous flush. The callback also fires once
+/// more when the runtime shuts down to drain anything still in the buffer.
+pub type ProfileCallback = Box<dyn FnMut(Vec<ProfileSample>) + Send + Sync>;
+
 pub struct Options {
     pub enable_gdbserver: bool,
+    pub profile: Option<ProfileCallback>,
 }
 
 pub fn extract_zip(zip: &[u8]) -> Result<BTreeMap<String, Vec<u8>>> {

--- a/wie_cli/src/main.rs
+++ b/wie_cli/src/main.rs
@@ -9,10 +9,14 @@ use core::str;
 use std::{
     collections::{HashMap, hash_map::Entry},
     error::Error,
-    fs,
-    io::stderr,
+    fs::{self, File},
+    io::{LineWriter, Write, stderr},
     num::NonZero,
-    sync::mpsc::{Receiver, Sender, channel},
+    path::PathBuf,
+    sync::{
+        Mutex,
+        mpsc::{Receiver, Sender, channel},
+    },
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -22,7 +26,7 @@ use midir::MidiOutput;
 use rodio::{DeviceSinkBuilder, Player, buffer::SamplesBuffer, conversions::SampleTypeConverter};
 use winit::keyboard::{KeyCode as WinitKeyCode, PhysicalKey};
 
-use wie_backend::{Emulator, Event, Filesystem, Instant, KeyCode, Options, Platform, Screen, extract_zip};
+use wie_backend::{Emulator, Event, Filesystem, Instant, KeyCode, Options, Platform, ProfileSample, Screen, extract_zip};
 use wie_j2me::J2MEEmulator;
 use wie_ktf::KtfEmulator;
 use wie_lgt::LgtEmulator;
@@ -152,6 +156,10 @@ struct Args {
     filename: String,
     #[arg(long, default_value_t = false)]
     debug: bool,
+    /// Write a flamegraph-folded sampling profile to this path (one line per
+    /// flushed batch; `flamegraph.pl` aggregates duplicates).
+    #[arg(long)]
+    profile_out: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -162,11 +170,24 @@ fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
+    let profile = args.profile_out.as_ref().map(|path| profile_callback(path)).transpose()?;
     let options = Options {
         enable_gdbserver: args.debug,
+        profile,
     };
 
     start(&args.filename, options)
+}
+
+fn profile_callback(path: &PathBuf) -> anyhow::Result<wie_backend::ProfileCallback> {
+    let writer = Mutex::new(LineWriter::new(File::create(path)?));
+    Ok(Box::new(move |batch: Vec<ProfileSample>| {
+        let mut writer = writer.lock().unwrap();
+        for sample in batch {
+            let folded: Vec<String> = sample.stack.iter().rev().map(|pc| format!("0x{pc:x}")).collect();
+            let _ = writeln!(writer, "{} {}", folded.join(";"), sample.count);
+        }
+    }))
 }
 
 pub fn start(filename: &str, options: Options) -> anyhow::Result<()> {

--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_allocator() -> Result<()> {
-        let mut core = ArmCore::new(false).unwrap();
+        let mut core = ArmCore::new(false, None).unwrap();
         core.map(0x40000000, 0x1000000)?;
 
         BucketAllocator::init(&mut core, 0x40000000, 0x1000000)?;

--- a/wie_core_arm/src/allocator/list.rs
+++ b/wie_core_arm/src/allocator/list.rs
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_allocator() -> Result<()> {
-        let mut core = ArmCore::new(false).unwrap();
+        let mut core = ArmCore::new(false, None).unwrap();
         core.map(0x40000000, 0x1000)?;
 
         ListAllocator::init(&mut core, 0x40000000, 0x1000)?;

--- a/wie_core_arm/src/core.rs
+++ b/wie_core_arm/src/core.rs
@@ -1,8 +1,9 @@
-use alloc::{borrow::ToOwned, boxed::Box, collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, collections::BTreeMap, format, string::String, sync::Arc, vec, vec::Vec};
 use core::mem::size_of;
 
 use spin::Mutex;
 
+use wie_backend::{ProfileCallback, ProfileSample};
 use wie_util::{ByteRead, ByteWrite, Result, WieError, read_generic};
 
 use crate::{
@@ -27,12 +28,43 @@ pub const RUN_FUNCTION_LR: u32 = 0x7f000000;
 pub const HEAP_BASE: u32 = 0x40000000;
 pub const HEAP_SIZE: u32 = 0x10000000;
 
+/// Limit on stack frames recorded per sample. Bounds memory and protects
+/// against runaway loops if the R7 chain forms a cycle.
+const PROFILE_MAX_STACK: usize = 32;
+/// Flush the per-stack counter map every this many samples taken.
+const PROFILE_FLUSH_INTERVAL: u32 = 1000;
+
+struct ProfileState {
+    samples: BTreeMap<Vec<u32>, u64>,
+    counter: u32,
+    callback: ProfileCallback,
+}
+
 pub(crate) struct ArmCoreInner {
     pub(crate) engine: Box<dyn ArmEngine>,
     last_thread_id: ThreadId,
     threads: BTreeMap<ThreadId, ThreadState>,
     svc_handlers: BTreeMap<u32, Arc<Box<dyn RegisteredFunction>>>,
     next_stub_address: u32,
+    profile: Option<ProfileState>,
+}
+
+impl Drop for ArmCoreInner {
+    fn drop(&mut self) {
+        if let Some(mut profile) = self.profile.take() {
+            let batch = drain_samples(&mut profile.samples);
+            if !batch.is_empty() {
+                (profile.callback)(batch);
+            }
+        }
+    }
+}
+
+fn drain_samples(samples: &mut BTreeMap<Vec<u32>, u64>) -> Vec<ProfileSample> {
+    core::mem::take(samples)
+        .into_iter()
+        .map(|(stack, count)| ProfileSample { stack, count })
+        .collect()
 }
 
 #[derive(Clone)]
@@ -41,7 +73,7 @@ pub struct ArmCore {
 }
 
 impl ArmCore {
-    pub fn new(enable_gdbserver: bool) -> Result<Self> {
+    pub fn new(enable_gdbserver: bool, profile: Option<ProfileCallback>) -> Result<Self> {
         let mut engine = if enable_gdbserver {
             #[cfg(not(target_arch = "wasm32"))]
             let engine = Box::new(DebuggedArm32CpuEngine::new()) as Box<dyn ArmEngine>;
@@ -56,12 +88,19 @@ impl ArmCore {
         engine.mem_map(FUNCTIONS_BASE, FUNCTIONS_SIZE, MemoryPermission::ReadExecute);
         engine.mem_map(GLOBAL_DATA_BASE, 0x4000, MemoryPermission::ReadWriteExecute);
 
+        let profile = profile.map(|callback| ProfileState {
+            samples: BTreeMap::new(),
+            counter: 0,
+            callback,
+        });
+
         let inner = ArmCoreInner {
             engine,
             last_thread_id: 0,
             threads: BTreeMap::new(),
             svc_handlers: BTreeMap::new(),
             next_stub_address: FUNCTIONS_BASE,
+            profile,
         };
 
         let result = Self {
@@ -168,6 +207,44 @@ impl ArmCore {
         inner.threads.keys().cloned().collect()
     }
 
+    fn sample_profile(&self) {
+        let mut inner = self.inner.lock();
+        if inner.profile.is_none() {
+            return;
+        }
+        let pc = inner.engine.reg_read(ArmRegister::PC);
+        let mut stack = vec![pc];
+        let mut r7 = inner.engine.reg_read(ArmRegister::R7);
+        for _ in 0..PROFILE_MAX_STACK {
+            // Thumb frame: [saved R7 | saved LR] at [r7].
+            let mut buf = [0u8; 8];
+            if inner.engine.mem_read(r7, 8, &mut buf).is_err() {
+                break;
+            }
+            let prev_r7 = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+            let lr = u32::from_le_bytes(buf[4..8].try_into().unwrap());
+            // Heuristic stop: zero/null frame or non-Thumb LR (we only ever
+            // call into Thumb code from the guest).
+            if prev_r7 == 0 || lr == 0 || lr & 1 == 0 {
+                break;
+            }
+            stack.push(lr);
+            if prev_r7 <= r7 {
+                // R7 chain must walk upward; bail on any inversion to avoid loops.
+                break;
+            }
+            r7 = prev_r7;
+        }
+        let profile = inner.profile.as_mut().unwrap();
+        *profile.samples.entry(stack).or_insert(0) += 1;
+        profile.counter = profile.counter.wrapping_add(1);
+        if profile.counter >= PROFILE_FLUSH_INTERVAL {
+            profile.counter = 0;
+            let batch = drain_samples(&mut profile.samples);
+            (profile.callback)(batch);
+        }
+    }
+
     pub async fn run_function<R>(&mut self, address: u32, params: &[u32]) -> Result<R>
     where
         R: RunFunctionResult<R>,
@@ -211,6 +288,8 @@ impl ArmCore {
                 let mut inner = self.inner.lock();
                 inner.engine.run(RUN_FUNCTION_LR, 1000)?
             };
+
+            self.sample_profile();
 
             match result {
                 EngineRunResult::End => break,
@@ -614,7 +693,7 @@ mod tests {
 
     #[test]
     fn test_thumb_svc_stub_dispatch() {
-        let mut core = ArmCore::new(false).unwrap();
+        let mut core = ArmCore::new(false, None).unwrap();
         core.map(0x1000, 0x1000).unwrap();
 
         let mut context = core.save_context();

--- a/wie_core_arm/src/engine.rs
+++ b/wie_core_arm/src/engine.rs
@@ -33,7 +33,7 @@ pub enum MemoryPermission {
     ReadWriteExecute = 7,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ArmRegister {
     R0,
     R1,

--- a/wie_core_arm/src/native_hooks.rs
+++ b/wie_core_arm/src/native_hooks.rs
@@ -61,6 +61,12 @@ enum HookKind {
     /// stack — zeroing it has to terminate the loop, so up-counter (`for i = 0;
     /// i < N`) shapes are not compatible.
     InlineCopy(InlineCopy),
+    /// Replaces an inline byte-copy loop whose src/dst/count live in registers
+    /// instead of on the stack. Bytes copied = `read(count) + count_offset`.
+    /// After the copy, `src`/`dst` are advanced by that count and `count` is
+    /// rewritten so it equals what the loop would have left there (i.e.,
+    /// `original - bytes`), then the dispatcher jumps to `exit_pc`.
+    RegInlineCopy(RegInlineCopy),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -74,6 +80,15 @@ struct InlineCopy {
     spill_back: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct RegInlineCopy {
+    src: ArmRegister,
+    dst: ArmRegister,
+    count: ArmRegister,
+    count_offset: i32,
+    exit_pc: u32,
+}
+
 /// Scanned across the install-time memory range; each match becomes a `Hook`.
 struct PatternHook {
     tokens: Vec<PatternToken>,
@@ -84,6 +99,16 @@ enum PatternToken {
     Literal(u8),
     AnyByte,
     Capture(CaptureName),
+    /// Bit-level match for a byte that mixes a fixed opcode with a 3-bit
+    /// register field (Thumb1 low-register encoding). `(byte & mask) == fixed`
+    /// is the literal check; if `capture` is set, `(byte >> shift) & 0b111`
+    /// is read into the named register slot, with cross-byte consistency
+    /// enforced at match time.
+    BitMatch {
+        mask: u8,
+        fixed: u8,
+        capture: Option<(CaptureName, u8)>,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -92,6 +117,9 @@ enum CaptureName {
     Src,
     Len,
     ExitB,
+    SrcReg,
+    DstReg,
+    CountReg,
 }
 
 enum PatternHookKind {
@@ -110,6 +138,13 @@ enum PatternHookKind {
         exit_pc: Option<u32>,
         spill_back: bool,
     },
+    /// Pattern-matched register-resident copy loop. The `src`/`dst`/`count`
+    /// registers are read from the pattern's bit-level captures and `exit_pc`
+    /// is derived at install time from `match_addr + pattern.len()` (Thumb bit
+    /// set).
+    RegInlineCopy {
+        count_offset: i32,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -118,6 +153,9 @@ struct PatternMatch {
     dst: Option<u8>,
     src: Option<u8>,
     len: Option<u8>,
+    src_reg: Option<u8>,
+    dst_reg: Option<u8>,
+    count_reg: Option<u8>,
     /// Address of the first `{exit_b}` byte — combined with `exit_b_bytes` to
     /// compute the branch target.
     exit_b_site: Option<u32>,
@@ -168,6 +206,28 @@ fn install_entry(core: &mut ArmCore, entry: &Entry, scan_ranges: &[(u32, u32)]) 
                         len_offset: len,
                         exit_pc: exit,
                         spill_back: *spill_back,
+                    })
+                }
+                PatternHookKind::RegInlineCopy { count_offset } => {
+                    let src = arm_register_from_index(
+                        pm.src_reg
+                            .ok_or_else(|| WieError::FatalError(format!("pattern match at {match_addr:#x} missing src register capture")))?,
+                    );
+                    let dst = arm_register_from_index(
+                        pm.dst_reg
+                            .ok_or_else(|| WieError::FatalError(format!("pattern match at {match_addr:#x} missing dst register capture")))?,
+                    );
+                    let count = arm_register_from_index(
+                        pm.count_reg
+                            .ok_or_else(|| WieError::FatalError(format!("pattern match at {match_addr:#x} missing count register capture")))?,
+                    );
+                    let exit_pc = match_addr.wrapping_add(pattern.tokens.len() as u32) | 1;
+                    HookKind::RegInlineCopy(RegInlineCopy {
+                        src,
+                        dst,
+                        count,
+                        count_offset: *count_offset,
+                        exit_pc,
                     })
                 }
             };
@@ -245,6 +305,9 @@ fn try_match(tokens: &[PatternToken], bytes: &[u8]) -> Option<PatternMatch> {
         dst: None,
         src: None,
         len: None,
+        src_reg: None,
+        dst_reg: None,
+        count_reg: None,
         exit_b_site: None,
         exit_b_bytes: None,
     };
@@ -259,6 +322,27 @@ fn try_match(tokens: &[PatternToken], bytes: &[u8]) -> Option<PatternMatch> {
                 i += 1;
             }
             PatternToken::AnyByte => {
+                i += 1;
+            }
+            PatternToken::BitMatch { mask, fixed, capture } => {
+                if b & mask != *fixed {
+                    return None;
+                }
+                if let Some((name, shift)) = capture {
+                    let value = (b >> shift) & 0b111;
+                    let slot = match name {
+                        CaptureName::SrcReg => &mut m.src_reg,
+                        CaptureName::DstReg => &mut m.dst_reg,
+                        CaptureName::CountReg => &mut m.count_reg,
+                        _ => return None,
+                    };
+                    if let Some(prev) = *slot
+                        && prev != value
+                    {
+                        return None;
+                    }
+                    *slot = Some(value);
+                }
                 i += 1;
             }
             PatternToken::Capture(name) => match name {
@@ -294,6 +378,10 @@ fn try_match(tokens: &[PatternToken], bytes: &[u8]) -> Option<PatternMatch> {
                     m.exit_b_bytes = Some([b, hi]);
                     i += 2;
                 }
+                CaptureName::SrcReg | CaptureName::DstReg | CaptureName::CountReg => {
+                    // Register captures only land in `BitMatch`, not whole-byte `Capture`.
+                    return None;
+                }
             },
         }
     }
@@ -304,6 +392,20 @@ fn try_match(tokens: &[PatternToken], bytes: &[u8]) -> Option<PatternMatch> {
 /// distance below R7, so the resulting offset is `-imm8`.
 fn capture_to_offset(byte: u8) -> i32 {
     -(byte as i32)
+}
+
+fn arm_register_from_index(index: u8) -> ArmRegister {
+    match index {
+        0 => ArmRegister::R0,
+        1 => ArmRegister::R1,
+        2 => ArmRegister::R2,
+        3 => ArmRegister::R3,
+        4 => ArmRegister::R4,
+        5 => ArmRegister::R5,
+        6 => ArmRegister::R6,
+        7 => ArmRegister::R7,
+        _ => unreachable!("BitMatch only captures 3 bits, value must be 0..=7"),
+    }
 }
 
 /// Decode a Thumb `B imm11` (`11100 iiiiiiiiiii`) at `b_site`. Returns the
@@ -390,6 +492,27 @@ async fn handle_native_hook(core: &mut ArmCore, registry: &mut Registry) -> Resu
                 core.write_bytes(src_slot, &src.wrapping_add(len).to_le_bytes())?;
                 core.write_bytes(len_slot, &0u32.to_le_bytes())?;
             }
+            Ok(JumpTo(spec.exit_pc))
+        }
+        HookKind::RegInlineCopy(spec) => {
+            let (src, dst, count_initial) = {
+                let inner = core.inner.lock();
+                (
+                    inner.engine.reg_read(spec.src),
+                    inner.engine.reg_read(spec.dst),
+                    inner.engine.reg_read(spec.count),
+                )
+            };
+            let count = count_initial.wrapping_add(spec.count_offset as u32);
+            tracing::trace!(
+                "native hook reg_inline_copy(src={src:#x}, dst={dst:#x}, count={count:#x}, exit={:#x})",
+                spec.exit_pc
+            );
+            stdlib::memcpy(core, &mut (), dst, src, count).await?;
+            let mut inner = core.inner.lock();
+            inner.engine.reg_write(spec.src, src.wrapping_add(count));
+            inner.engine.reg_write(spec.dst, dst.wrapping_add(count));
+            inner.engine.reg_write(spec.count, count_initial.wrapping_sub(count));
             Ok(JumpTo(spec.exit_pc))
         }
     }

--- a/wie_core_arm/src/native_hooks.rs
+++ b/wie_core_arm/src/native_hooks.rs
@@ -433,7 +433,7 @@ mod tests {
             }],
             patterns: vec![],
         };
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x2000, 0x1000)?;
 
         let err = install_entry(&mut core, &entry, &[]).unwrap_err();
@@ -453,7 +453,7 @@ mod tests {
             }],
             patterns: vec![],
         };
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x2000, 0x1000)?;
 
         core.write_bytes(0x2000, &[0xaa, 0xbb])?;
@@ -468,7 +468,7 @@ mod tests {
 
     #[futures_test::test]
     async fn memcpy_dispatch_copies_bytes_and_returns_via_lr() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x10000, 0x1000)?;
 
         let src = 0x10000u32;
@@ -498,7 +498,7 @@ mod tests {
 
     #[futures_test::test]
     async fn memset_dispatch_fills_bytes() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x10000, 0x1000)?;
 
         let dst = 0x10000u32;
@@ -524,7 +524,7 @@ mod tests {
 
     #[futures_test::test]
     async fn strcpy_dispatch_copies_null_terminated_string_and_returns_via_lr() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x10000, 0x1000)?;
 
         let src = 0x10000u32;
@@ -560,7 +560,7 @@ mod tests {
 
     #[futures_test::test]
     async fn strlen_dispatch_returns_length_in_r0() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x10000, 0x1000)?;
 
         let str_ptr = 0x10100u32;
@@ -586,7 +586,7 @@ mod tests {
 
     #[futures_test::test]
     async fn inline_copy_dispatch_reads_frame_copies_and_jumps_to_exit() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x10000, 0x2000)?;
 
         let src = 0x10000u32;
@@ -634,7 +634,7 @@ mod tests {
 
     #[futures_test::test]
     async fn install_then_execute_hits_dispatcher_end_to_end() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x20000, 0x2000)?;
         core.map(0x30000, 0x1000)?;
 
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn pattern_scan_matches_single_hit() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x50000, 0x200)?;
 
         let pat_bytes = [0xaa, 0xbb, 0xcc, 0xdd];
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn pattern_duplicate_pc_warns_once_and_skips() -> Result<()> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         core.map(0x60000, 0x100)?;
         core.write_bytes(0x60010, &[0x11, 0x22, 0x33, 0x44])?;
 

--- a/wie_core_arm/src/native_hooks.rs
+++ b/wie_core_arm/src/native_hooks.rs
@@ -891,6 +891,33 @@ mod tests {
     }
 
     #[test]
+    fn pattern_bit_match_captures_register_at_correct_shift() {
+        // `0b00sss011` matches `(src << 3) | 0b011`. Cross-byte consistency
+        // forces the same `s` capture to agree across positions.
+        let tokens = [
+            PatternToken::BitMatch {
+                mask: 0b1100_0111,
+                fixed: 0b0000_0011,
+                capture: Some((CaptureName::SrcReg, 3)),
+            },
+            PatternToken::BitMatch {
+                mask: 0b1111_1000,
+                fixed: 0b0011_0000,
+                capture: Some((CaptureName::SrcReg, 0)),
+            },
+        ];
+        // 0x0B = 0b00001011 → src bits 5..3 = 001 → R1
+        // 0x31 = 0b00110001 → src bits 2..0 = 001 → R1 (consistent)
+        let m = try_match(&tokens, &[0x0b, 0x31]).expect("match");
+        assert_eq!(m.src_reg, Some(1));
+
+        // Inconsistent capture must fail: first byte says R1, second says R2.
+        assert!(try_match(&tokens, &[0x0b, 0x32]).is_none());
+        // First byte's literal bits don't match (low nibble != 0b011).
+        assert!(try_match(&tokens, &[0x0a, 0x31]).is_none());
+    }
+
+    #[test]
     fn pattern_scan_rejects_exit_b_capture_when_bytes_are_not_thumb_b() {
         let tokens = [PatternToken::Capture(CaptureName::ExitB), PatternToken::Capture(CaptureName::ExitB)];
         // `0c 3a` is `SUBS R2, #0xC` — high byte 0x3a is not in 0xE0-0xE7.

--- a/wie_core_arm/src/native_hooks/parser.rs
+++ b/wie_core_arm/src/native_hooks/parser.rs
@@ -33,6 +33,7 @@ struct RawHook {
     len_offset: Option<i32>,
     exit_pc: Option<u32>,
     spill_back: Option<bool>,
+    count_offset: Option<i32>,
 }
 
 #[derive(Deserialize, Clone, Copy)]
@@ -43,6 +44,7 @@ enum KindTag {
     Strcpy,
     Strlen,
     InlineCopy,
+    RegInlineCopy,
 }
 
 impl RawEntry {
@@ -96,6 +98,7 @@ fn pc_kind(raw: &RawHook, entry_name: &str) -> HookKind {
                 .spill_back
                 .unwrap_or_else(|| panic!("entry {entry_name}: inline_copy requires spill_back")),
         }),
+        KindTag::RegInlineCopy => panic!("entry {entry_name}: reg_inline_copy must be pattern-based, not pc-based"),
     }
 }
 
@@ -105,6 +108,24 @@ fn pattern_template(raw: &RawHook, tokens: &[PatternToken], entry_name: &str) ->
         KindTag::Memset => PatternHookKind::Memset,
         KindTag::Strcpy => PatternHookKind::Strcpy,
         KindTag::Strlen => PatternHookKind::Strlen,
+        KindTag::RegInlineCopy => {
+            let need = |cap: CaptureName, label: &str| {
+                if !tokens.iter().any(|t| match t {
+                    PatternToken::BitMatch { capture: Some((c, _)), .. } => *c == cap,
+                    _ => false,
+                }) {
+                    panic!("entry {entry_name}: reg_inline_copy pattern must capture {label} register");
+                }
+            };
+            need(CaptureName::SrcReg, "src");
+            need(CaptureName::DstReg, "dst");
+            need(CaptureName::CountReg, "count");
+            PatternHookKind::RegInlineCopy {
+                count_offset: raw
+                    .count_offset
+                    .unwrap_or_else(|| panic!("entry {entry_name}: reg_inline_copy requires count_offset")),
+            }
+        }
         KindTag::InlineCopy => {
             let exit_cap = tokens.iter().any(|t| matches!(t, PatternToken::Capture(CaptureName::ExitB)));
             if !exit_cap && raw.exit_pc.is_none() {
@@ -150,6 +171,10 @@ fn parse_pattern(pattern: &str, entry_name: &str) -> Vec<PatternToken> {
     for raw in pattern.split_whitespace() {
         let token = if raw == "??" {
             PatternToken::AnyByte
+        } else if raw.len() == 10
+            && let Some(bits) = raw.strip_prefix("0b")
+        {
+            parse_bit_match(bits, entry_name)
         } else if let Some(rest) = raw.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
             let cap = match rest {
                 "dst" => CaptureName::Dst,
@@ -168,6 +193,53 @@ fn parse_pattern(pattern: &str, entry_name: &str) -> Vec<PatternToken> {
     }
     validate_exit_b(&tokens, entry_name);
     tokens
+}
+
+/// Parse an 8-character byte specification of `0`/`1` literals, `?` wildcards,
+/// and `s`/`d`/`c` register placeholders (3 consecutive of the same letter).
+/// e.g. `00sss011` → mask=0b11000111, fixed=0b00000011, capture (src @ shift 3).
+fn parse_bit_match(bits: &str, entry_name: &str) -> PatternToken {
+    if bits.len() != 8 {
+        panic!("entry {entry_name}: bit pattern `0b{bits}` must be 8 characters");
+    }
+    let mut mask: u8 = 0;
+    let mut fixed: u8 = 0;
+    let mut capture: Option<(CaptureName, u8, u8)> = None; // (name, lowest bit, count seen)
+    for (i, ch) in bits.chars().enumerate() {
+        let bit = 7 - i as u8;
+        match ch {
+            '0' => {
+                mask |= 1 << bit;
+            }
+            '1' => {
+                mask |= 1 << bit;
+                fixed |= 1 << bit;
+            }
+            '?' => {}
+            's' | 'd' | 'c' => {
+                let name = match ch {
+                    's' => CaptureName::SrcReg,
+                    'd' => CaptureName::DstReg,
+                    _ => CaptureName::CountReg,
+                };
+                match &mut capture {
+                    Some((n, _lowest, count)) if *n == name => {
+                        *count += 1;
+                    }
+                    Some(_) => panic!("entry {entry_name}: bit pattern `0b{bits}` mixes multiple register placeholders"),
+                    None => capture = Some((name, bit, 1)),
+                }
+            }
+            _ => panic!("entry {entry_name}: invalid char {ch:?} in bit pattern `0b{bits}` (allowed: 0,1,?,s,d,c)"),
+        }
+    }
+    let capture = capture.map(|(name, lowest, count)| {
+        if count != 3 {
+            panic!("entry {entry_name}: bit pattern `0b{bits}` register placeholder must span exactly 3 bits");
+        }
+        (name, lowest)
+    });
+    PatternToken::BitMatch { mask, fixed, capture }
 }
 
 fn validate_exit_b(tokens: &[PatternToken], entry_name: &str) {

--- a/wie_core_arm/src/native_hooks/parser.rs
+++ b/wie_core_arm/src/native_hooks/parser.rs
@@ -223,7 +223,8 @@ fn parse_bit_match(bits: &str, entry_name: &str) -> PatternToken {
                     _ => CaptureName::CountReg,
                 };
                 match &mut capture {
-                    Some((n, _lowest, count)) if *n == name => {
+                    Some((n, lowest, count)) if *n == name => {
+                        *lowest = bit; // iterating high→low, so the latest write is the lowest bit
                         *count += 1;
                     }
                     Some(_) => panic!("entry {entry_name}: bit pattern `0b{bits}` mixes multiple register placeholders"),

--- a/wie_ktf/src/emulator.rs
+++ b/wie_ktf/src/emulator.rs
@@ -82,9 +82,9 @@ impl KtfEmulator {
         aid: &str,
         main_class_name: Option<String>,
         files: &BTreeMap<String, Vec<u8>>,
-        options: Options,
+        mut options: Options,
     ) -> Result<Self> {
-        let mut core = ArmCore::new(options.enable_gdbserver)?;
+        let mut core = ArmCore::new(options.enable_gdbserver, options.profile.take())?;
         let system = System::new(platform, pid, aid, KtfTaskRunner { core: core.clone() });
 
         for (path, data) in files {

--- a/wie_ktf/src/runtime/java/jvm_support.rs
+++ b/wie_ktf/src/runtime/java/jvm_support.rs
@@ -221,7 +221,7 @@ mod test {
     use test_utils::TestPlatform;
 
     async fn init_jvm(system: &mut System) -> Result<Jvm> {
-        let mut core = ArmCore::new(false)?;
+        let mut core = ArmCore::new(false, None)?;
         Allocator::init(&mut core)?;
 
         let mut context = core.save_context();

--- a/wie_ktf/tests/test_helloworld.rs
+++ b/wie_ktf/tests/test_helloworld.rs
@@ -30,7 +30,14 @@ pub fn test_helloworld() -> Result<()> {
     let platform = Box::new(TestPlatform::with_event_handler(event_handler));
 
     let archive = extract_zip(include_bytes!("../../test_data/helloworld_ktf.zip"))?;
-    let mut emulator = KtfEmulator::from_archive(platform, archive, Options { enable_gdbserver: false })?;
+    let mut emulator = KtfEmulator::from_archive(
+        platform,
+        archive,
+        Options {
+            enable_gdbserver: false,
+            profile: None,
+        },
+    )?;
 
     while !exited.load(Ordering::SeqCst) {
         emulator.tick()?;

--- a/wie_lgt/src/emulator.rs
+++ b/wie_lgt/src/emulator.rs
@@ -82,9 +82,9 @@ impl LgtEmulator {
         aid: &str,
         main_class_name: Option<String>,
         files: &BTreeMap<String, Vec<u8>>,
-        options: Options,
+        mut options: Options,
     ) -> Result<Self> {
-        let mut core = ArmCore::new(options.enable_gdbserver)?;
+        let mut core = ArmCore::new(options.enable_gdbserver, options.profile.take())?;
         let system = System::new(platform, pid, aid, LgtTaskRunner { core: core.clone() });
 
         for (filename, data) in files {

--- a/wie_lgt/tests/test_helloworld.rs
+++ b/wie_lgt/tests/test_helloworld.rs
@@ -30,7 +30,14 @@ pub fn test_helloworld() -> Result<()> {
     let platform = Box::new(TestPlatform::with_event_handler(event_handler));
 
     let archive = extract_zip(include_bytes!("../../test_data/helloworld_lgt.zip"))?;
-    let mut emulator = LgtEmulator::from_archive(platform, archive, Options { enable_gdbserver: false })?;
+    let mut emulator = LgtEmulator::from_archive(
+        platform,
+        archive,
+        Options {
+            enable_gdbserver: false,
+            profile: None,
+        },
+    )?;
 
     while !exited.load(Ordering::SeqCst) {
         emulator.tick()?;


### PR DESCRIPTION
## Summary
- Add an R7-chain sampling profiler that flushes folded-format batches through an `Options::profile` callback so a Ctrl+C kill keeps most of the data on disk. \`wie_cli\` exposes \`--profile-out PATH\` and writes through a \`LineWriter\` for line-granular flushes.
- Add \`HookKind::RegInlineCopy\` for inline byte-copy loops that keep \`src\` / \`dst\` / \`count\` in registers (vs. the existing stack-resident \`InlineCopy\`).
- Extend the pattern engine with bit-level matching (\`PatternToken::BitMatch\`) and an \`0bAAAAAAAA\` token syntax, where each character is \`0\`/\`1\`/\`?\` or one of \`s\` / \`d\` / \`c\` for src/dst/count register placeholders. Same-name placeholders enforce cross-byte register-index agreement.
- Land mgh2's per-frame \`copy_offscreen_to_screen\` byte-copy as a generic 16-byte pattern in \`data/native_hooks.toml\` — matches by opcode bits, captures the three register fields, and auto-derives \`exit_pc = match_end | 1\`.

## Test plan
- [x] \`cargo test --workspace\` (29 test result blocks, all passing — includes new \`pattern_bit_match_captures_register_at_correct_shift\` regression for the placeholder-shift bug)
- [x] \`cargo clippy --workspace --all-targets\` clean
- [x] \`cargo fmt --check\` clean
- [x] mgh2 startup logs the \`RegInlineCopy\` hook getting installed at the expected PC
- [ ] Manual: run mgh2 with \`--profile-out\` before/after and verify the \`copy_offscreen_to_screen\` site disappears from the flamegraph hot path