### PR TITLE
fix(allocator): 4바이트 미만 할당 시 발생하는 underflow panic 수정

### DIFF
--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -76,6 +76,7 @@ impl BucketAllocator {
 
     #[inline]
     fn find_bucket_index(size: u32) -> usize {
+        let size = size.max(BUCKETS[0] as u32);
         (size.ilog2() + if size.is_power_of_two() { 0 } else { 1 } - 2) as _
     }
 }
@@ -120,6 +121,31 @@ mod tests {
 
         let address8 = BucketAllocator::alloc(&mut core, 0x40000000, 8)?;
         assert_eq!(address8, 0x40104018);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_allocator_small_sizes() -> Result<()> {
+        let mut core = ArmCore::new(false).unwrap();
+        core.map(0x40000000, 0x1000000)?;
+
+        BucketAllocator::init(&mut core, 0x40000000, 0x1000000)?;
+
+        // sizes 0..=3 must all land in the smallest (4-byte) bucket
+        let a0 = BucketAllocator::alloc(&mut core, 0x40000000, 0)?;
+        assert_eq!(a0, 0x40008000);
+        let a1 = BucketAllocator::alloc(&mut core, 0x40000000, 1)?;
+        assert_eq!(a1, 0x40008004);
+        let a2 = BucketAllocator::alloc(&mut core, 0x40000000, 2)?;
+        assert_eq!(a2, 0x40008008);
+        let a3 = BucketAllocator::alloc(&mut core, 0x40000000, 3)?;
+        assert_eq!(a3, 0x4000800c);
+
+        // free with the same (small) size must round-trip without panicking
+        BucketAllocator::free(&mut core, 0x40000000, a1, 1)?;
+        let a1b = BucketAllocator::alloc(&mut core, 0x40000000, 1)?;
+        assert_eq!(a1b, 0x40008004);
 
         Ok(())
     }


### PR DESCRIPTION
[Report](https://github.com/mirusu400/wie-test/blob/main/report.md)를 살펴보면 현재 많은 패닉이 `bucket.rs` 에서 이뤄지고 있습니다.

확인 결과 `BucketAllocator::find_bucket_index`가 4바이트 미만 크기로 호출될 때 `attempt to subtract with overflow` panic이 발생합니다.

BUCKET의 최소 버킷 사이즈가 4 이상이라고 고려하여, 버킷 사이즈가 0, 1, 2 일때 `find_bucket_index` 함수에서 패닉이 납니다.
* 0 -> is_power_of_two() 에서 패닉
* 1 -> 0 + 0 - 2 => -2 로 패닉
* 2 -> 1 + 0 - 2 => -1 로 패닉
* 3 이상부터는 정상 동작

`size`를 최소 버킷 크기로 가져오게 하여 문제를 해결하였고, 관련하여 간단한 테스트 코드도 작성하였습니다.

+ 생존일기.zip, 보글보글.zip에서 문제 확인하였습니다 (현재는 bucket쪽 커널패닉이 아닌 jvm쪽 커널 패닉으로 오류가 나옴)

