### PR TITLE
fix(allocator): Rust JVM JavaMethod::run 단의 exception handler 구현

### DIFF
--- a/wie_ktf/src/runtime/java/jvm_support/method.rs
+++ b/wie_ktf/src/runtime/java/jvm_support/method.rs
@@ -150,6 +150,27 @@ impl JavaMethod {
 
         let access_flags = MethodAccessFlags::from_bits_truncate(raw.access_flags);
 
+        // Re-enters `run_function` if a Java catch handler matches the current ARM frame —
+        // mirrors the trampoline path in `interface.rs::map_jump_result`, but for the
+        // outermost frame whose caller is the Rust JVM rather than another ARM trampoline.
+        async fn run_with_unwind(core: &mut ArmCore, mut pc: u32, mut args: Vec<u32>) -> Result<JavaMethodRunResult> {
+            loop {
+                match core.run_function::<JavaMethodRunResult>(pc, &args).await {
+                    Ok(r) => return Ok(r),
+                    Err(WieError::JavaExceptionUnwind {
+                        context_base,
+                        target,
+                        next_pc,
+                    }) => {
+                        tracing::debug!("Resuming via exception restore: pc={next_pc:#x}, context_base={context_base:#x}, target={target:#x}");
+                        pc = next_pc;
+                        args = vec![context_base, target];
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
         let result: JavaMethodRunResult = if access_flags.contains(MethodAccessFlags::NATIVE) {
             let arg_container = Allocator::alloc(&mut core, (raw_args.len() as u32) * 4)?;
             for (i, arg) in raw_args.iter().enumerate() {
@@ -157,7 +178,7 @@ impl JavaMethod {
             }
 
             tracing::trace!("Calling native method: {:#x}", raw.fn_body_native_or_exception_table);
-            let result = core.run_function(raw.fn_body_native_or_exception_table, &[0, arg_container]).await;
+            let result = run_with_unwind(&mut core, raw.fn_body_native_or_exception_table, vec![0, arg_container]).await;
 
             Allocator::free(&mut core, arg_container, (raw_args.len() as u32) * 4)?;
 
@@ -167,7 +188,7 @@ impl JavaMethod {
             params.extend(raw_args);
 
             tracing::trace!("Calling method: {:#x}", raw.fn_body);
-            core.run_function(raw.fn_body, &params).await?
+            run_with_unwind(&mut core, raw.fn_body, params).await?
         };
 
         if matches!(return_type, JavaType::Double | JavaType::Long) {


### PR DESCRIPTION
KTF 에서 `try..catch` 문은 [`setjmp`/`longjmp`](https://developer.arm.com/documentation/109445/6-22-2LTS/The-C-and-C---Library-Functions-Reference/setjmp--) 와 유사하게 처리됩니다.

KTF 구조는 아래처럼 동작합니다

1. try 진입 -> AOT 코드가 `current_java_exception_handler` 체인에 핸들러 레코드(저장된 r4–r14, method ptr, PC 범위 등) push
2. 에러 발생시 throw -> `handle_exception`(`wie_ktf/src/runtime/java/jvm_support/method.rs`) 발생시 exception_table에서 매칭되는 catch entry를 찾으면 `WieError::JavaExceptionUnwind { context_base, target, next_pc }`을 던지고. `run_function` 상위까지 Throw
3. resume -> ARM 내부 trampoline (`java_jump_1/2/3`, `call_native`)이 Error를 캐치해서 `JavaMethodResult { result: [context_base, target], next_pc }` 로 변환하고. `ResultWriter`가 R0/R1에 context_base/target을 쓰고 PC를 next_pc로 덮으면, next_pc 시점에서 saved 레지스터를 LDM 명령으로 복원하고 catch 블록으로 BX 명령으로 Branch합니다. 

이 상황에서, ARM trampoline (`java_jump_1/2/3`, `call_native`)이 구현되어 있지만, Rust JVM이 제일 바깥 호출 (`JavaMethod::run`) 에서 AOT 코드를 실행할때 `run_function` 위에 trampoline이 없어 throw된 에러를 캐치 못하고 있습니다

예를들어 `(KTF) 생존일기`의 경우 초기 생성시점에 try ... catch 로 openDataBase를 시도하는데

```python
49.184  openDataBase(0x4810cb80, 100, false)         # 기존 DB 열기 시도
49.188  Java exception thrown: 0x481118f0            # RecordStore 없음 예외
49.188  Java exception handler found: target=0x6d, method=0x178d80
49.188  ... (catch 블록 실행 시도)
49.703  Fatal: ...crossed into JVM caller            # 실제로 catch에 도달 못 함
```

위와같이 fatal 에러가 납니다

이를 해결하기 위해서, `core.run_function`이 아니라 `run_with_unwind` 메서드를 별도로 추가해 돌면서 에러를 캐치하고 캐치당시에 `next_pc`로 정상적으로 레지스터 복원/jmp 하도록 구현했습니다.

(`Method::run` 같이 다른데서 에러 핸들링하는건 별도로 건드리지않았기 때문에 이런 곳 사이드 이펙트없이 잘 처리될거 같습니다)

Mac M4 기준 `(KTF) 생존일기`와 `(KTF) 보글보글2` 에서 기존 Fatal Error 나는거에서 정상적으로 타이틀 스크린까지 들어가는걸 확인했습니다.

---

+ 추가 확인 사항
[AAPCS32](https://github.com/ARM-software/abi-aa/blob/main/aapcs32/aapcs32.rst)를 보면 r4–r8, r10, r11, sp(r9는 PCS variant에 따라 다름)를 서브루틴 콜 당시에 저장하지만, `wipi_types/src/ktf/java.rs::JavaExceptionHandler.context` 를 보면 r4-r14 까지 한번에 저장하고 있습니다.  좀더 정밀하게 구현하려면 필요한 레지스터만 넘기는게 더 좋아보이긴 하네요