### PR TITLE
feat(graphics): fix pixel encoding for hard-coded MC_grpSetContext

### DIFF
--- a/wie_wipi_c/src/api/graphics.rs
+++ b/wie_wipi_c/src/api/graphics.rs
@@ -8,7 +8,7 @@ use alloc::{string::String, vec, vec::Vec};
 
 use wie_backend::{
     Event,
-    canvas::{Clip, Color, PixelType, Rgb8Pixel, TextAlignment, string_width},
+    canvas::{Clip, Color, PixelType, Rgb8Pixel, Rgb565Pixel, TextAlignment, string_width},
 };
 use wie_util::{Result, read_generic, read_null_terminated_string_bytes, write_generic};
 
@@ -119,7 +119,8 @@ pub async fn put_pixel(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
     let gctx: WIPICGraphicsContext = read_generic(context, p_gctx)?;
 
     let mut canvas = framebuffer.canvas(context)?;
-    canvas.put_pixel(x as _, y as _, Rgb8Pixel::to_color(gctx.fgpxl));
+    let color = framebuffer.pixel_to_color(gctx.fgpxl);
+    canvas.put_pixel(x as _, y as _, color);
     Ok(())
 }
 
@@ -137,7 +138,8 @@ pub async fn fill_rect(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
         height: h as _,
     };
 
-    canvas.fill_rect(x as _, y as _, w as _, h as _, Rgb8Pixel::to_color(gctx.fgpxl), clip);
+    let color = framebuffer.pixel_to_color(gctx.fgpxl);
+    canvas.fill_rect(x as _, y as _, w as _, h as _, color, clip);
     Ok(())
 }
 
@@ -233,20 +235,20 @@ pub async fn get_pixel_from_rgb(_context: &mut dyn WIPICContext, r: i32, g: i32,
         tracing::debug!("MC_grpGetPixelFromRGB({r:#x}, {g:#x}, {b:#x}): value clipped to 8 bits");
     }
 
-    let color = Rgb8Pixel::from_color(Color {
+    let color = Rgb565Pixel::from_color(Color {
         a: 0xff,
         r: r as u8,
         g: g as u8,
         b: b as u8,
-    }); // TODO do we need to return in screen format?
+    });
 
-    Ok(color)
+    Ok(color as WIPICWord)
 }
 
 pub async fn get_rgb_from_pixel(context: &mut dyn WIPICContext, pixel: i32, r: WIPICWord, g: WIPICWord, b: WIPICWord) -> Result<i32> {
     tracing::debug!("MC_grpGetRGBFromPixel({pixel}, {r:#x}, {g:#x}, {b:#x})");
 
-    let color = Rgb8Pixel::to_color(pixel as _);
+    let color = Rgb565Pixel::to_color(pixel as u16);
 
     write_generic(context, r, color.r as i32)?;
     write_generic(context, g, color.g as i32)?;
@@ -430,7 +432,8 @@ pub async fn draw_string(
     let string = String::from_utf8_lossy(&string_bytes);
 
     let mut canvas = framebuffer.canvas(context)?;
-    canvas.draw_text(&string, x, y, TextAlignment::Left, Rgb8Pixel::to_color(gctx.fgpxl));
+    let color = framebuffer.pixel_to_color(gctx.fgpxl);
+    canvas.draw_text(&string, x, y, TextAlignment::Left, color);
 
     Ok(())
 }
@@ -613,7 +616,8 @@ pub async fn draw_rect(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x:
         height: h as _,
     };
 
-    canvas.draw_rect(x as _, y as _, w as _, h as _, Rgb8Pixel::to_color(gctx.fgpxl), clip);
+    let color = framebuffer.pixel_to_color(gctx.fgpxl);
+    canvas.draw_rect(x as _, y as _, w as _, h as _, color, clip);
     Ok(())
 }
 
@@ -624,7 +628,8 @@ pub async fn draw_line(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x1
     let gctx: WIPICGraphicsContext = read_generic(context, pgc)?;
     let mut canvas = framebuffer.canvas(context)?;
 
-    canvas.draw_line(x1 as _, y1 as _, x2 as _, y2 as _, Rgb8Pixel::to_color(gctx.fgpxl));
+    let color = framebuffer.pixel_to_color(gctx.fgpxl);
+    canvas.draw_line(x1 as _, y1 as _, x2 as _, y2 as _, color);
     Ok(())
 }
 

--- a/wie_wipi_c/src/api/graphics/framebuffer.rs
+++ b/wie_wipi_c/src/api/graphics/framebuffer.rs
@@ -5,7 +5,7 @@ use bytemuck::pod_collect_to_vec;
 
 use wipi_types::wipic::{WIPICFramebuffer, WIPICIndirectPtr, WIPICWord};
 
-use wie_backend::canvas::{ArgbPixel, Canvas, Image, ImageBufferCanvas, Rgb565Pixel, VecImageBuffer};
+use wie_backend::canvas::{ArgbPixel, Canvas, Color, Image, ImageBufferCanvas, PixelType, Rgb8Pixel, Rgb565Pixel, VecImageBuffer};
 use wie_util::Result;
 
 use crate::context::WIPICContext;
@@ -103,6 +103,13 @@ impl FrameBuffer {
 
     pub fn write(&self, context: &mut dyn WIPICContext, data: &[u8]) -> Result<()> {
         context.write_bytes(context.data_ptr(self.0.buf)?, data)
+    }
+
+    pub fn pixel_to_color(&self, pixel: WIPICWord) -> Color {
+        match self.0.bpp {
+            16 => Rgb565Pixel::to_color(pixel as u16),
+            _ => Rgb8Pixel::to_color(pixel),
+        }
     }
 }
 


### PR DESCRIPTION
WIPI 문서에서 `MH_fnGetCharGlyph` 문서 등을 살펴보면 WIPI 그래픽 컨텍스트의 `fgpxl`/`bgpxl`은 LCD 네이티브 포맷의 픽셀 값입니다. `wie_wipi_c`에서는 화면 프레임버퍼를 `FRAMEBUFFER_DEPTH = 16` (RGB565)로 고정 생성하고 있으므로 (`wie_wipi_c/src/api/graphics.rs`), 게임이 컨텍스트에 저장하는 픽셀도 RGB565로 해석해야 합니다.

기존 코드는 모든 픽셀 값을 `Rgb8Pixel` (`0x00RRGGBB`, 24bpp)로 인코딩/디코딩하고 있었습니다.

```
get_pixel_from_rgb(r,g,b)  ->  0x00RRGGBB           # Rgb8Pixel::from_color
fgpxl 저장 (불투명 24비트 토큰)
fill_rect: Rgb8Pixel::to_color(fgpxl) -> Color      # 다시 디코딩
Canvas<Rgb565Pixel>가 Color -> RGB565로 다시 변환해서 그림
```

`get_pixel_from_rgb` 반환값을 그대로 `MC_grpSetContext(FgPixelIdx, ...)`에 넣고 `fill_rect`로 그리는 패턴은 인코더/디코더가 모두 Rgb8라 우연치 않게 정상 동작했는데, LCD 네이티브 픽셀 값을 직접 하드코딩하는 앱은 색이 깨졌습니다.

예를 들어 #1127 에서 언급한 `(LGT) 와일드프론티어`는 흰색을 표현할 때 RGB565 흰색 값 `0xFFFF`를 직접 넣습니다.

```python
MC_grpSetContext(FgPixelIdx, 0xffff)   # RGB565 흰색
MC_grpFillRect(...)
# 기존 동작: Rgb8Pixel::to_color(0xFFFF) = Color(r=0, g=255, b=255) -> cyan
# ex 검은 글씨 위 흰 배경이 cyan으로 그려져서 텍스트가 초록/청록색으로 보임
```

이를 해결하기 위해 다음과 같이 수정했습니다.

1. `FrameBuffer`에 메서드 `pixel_to_color`를 추가해 `canvas()`/`image()`가 16/32bpp 분기로 디코딩하도록 구현하였습니다

   ```rust
   pub fn pixel_to_color(&self, pixel: WIPICWord) -> Color {
       match self.0.bpp {
           16 => Rgb565Pixel::to_color(pixel as u16),
           _  => Rgb8Pixel::to_color(pixel),
       }
   }
   ```

2. `put_pixel`/`fill_rect`/`draw_line`/`draw_rect`/`draw_string` 등 `gctx.fgpxl`을 `Color`로 디코딩하던 모든 호출부를 위 메서드로 교체했습니다.
3. `get_pixel_from_rgb` / `get_rgb_from_pixel`도 RGB8에서 RGB565 인코딩/디코딩으로 변경했습니다. `fgpxl`이 이제 "불투명 24비트 토큰"이 아니라 "네이티브 LCD 픽셀"이라, 인코더 쪽도 같은 포맷이어야 정상 작동합니다.
4. 기존 PR #1177에서 구현했던 `MC_grpGetRGBPixels` / `MC_grpSetRGBPixels`는 WIPI 스펙상 `0x00RRGGBB` 포맷이 명시되어 있으므로 `Rgb8Pixel`형태를 그대로 유지했습니다.

기존 화면 출력패턴 패턴 (`get_pixel_from_rgb` → `fgpxl` → `fill_rect`) 만 쓰는 앱은 정밀도 면에서 24비트 → RGB565 변환 과정이 다른위치로 옮겨갔을 뿐이고 어차피 캔버스가 RGB565로 변환하던 단계라 화면상 결과는 동일할거라 판단됩니다 (메이플 도적편, 생존일기, 보글보글 등으로 테스트 완료)

---

`FRAMEBUFFER_DEPTH = 16` 이 그래픽스 모듈 내부 상수로 하드코딩되어 있어, 본 PR의 `get_pixel_from_rgb` / `get_rgb_from_pixel`도 RGB565 고정으로 두었습니다. 그럴일 없겠지만 프레임버퍼 값을 24등으로 바꾼다면 분기 검사해서 RGB8로 출력하게도 바꾸는걸 생각해봐야 될거 같습니다