### PR TITLE
BucketAllocator: 인접 bucket region 침범 버그 수정

### DIFF
--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -1,6 +1,4 @@
-use alloc::vec;
-
-use wie_util::{ByteRead, ByteWrite, Result, WieError};
+use wie_util::{ByteRead, ByteWrite, Result, WieError, read_generic, write_generic};
 
 use crate::core::ArmCore;
 
@@ -10,17 +8,29 @@ const BUCKETS: [usize; 8] = [4, 8, 16, 32, 64, 128, 256, 512];
 // (128 MB), exactly matching the BucketAllocator half of the heap.
 const BUCKET_SIZE: usize = 0x1000000;
 
+// Chunk size for header scans in alloc(). 1 KB balances per-call read overhead
+// against unnecessary work for large headers (4-byte bucket header is 512 KB).
+const SCAN_CHUNK: usize = 1024;
+
 pub struct BucketAllocator;
 
 impl BucketAllocator {
-    pub fn init(core: &mut ArmCore, base_address: u32, _base_size: u32) -> Result<()> {
-        // initialize each bucket header with ones
-        // header contains bitset of allocation, 1 is unallocated, 0 is allocated
+    pub fn init(core: &mut ArmCore, base_address: u32, base_size: u32) -> Result<()> {
+        // header contains bitset of allocation, 1 is unallocated, 0 is allocated.
         //
         // Slots beyond `(BUCKET_SIZE - header_length) / bucket` would extend past
         // this bucket's region into the next bucket's slot area; mark those bits
         // as allocated so they're never handed out (otherwise two different
         // bucket sizes can hand out overlapping addresses).
+        //
+        // The caller-provided region must hold all `BUCKETS.len()` regions of
+        // `BUCKET_SIZE` each. Validate up-front so a future heap-sizing change
+        // can't silently produce out-of-region writes.
+        let required = (BUCKETS.len() * BUCKET_SIZE) as u32;
+        if base_size < required {
+            tracing::error!("BucketAllocator region too small: got {base_size:#x}, need {required:#x}");
+            return Err(WieError::AllocationFailure);
+        }
 
         for (i, bucket) in BUCKETS.into_iter().enumerate() {
             let header_length = BUCKET_SIZE / bucket / 8;
@@ -32,40 +42,65 @@ impl BucketAllocator {
 
             tracing::info!("Bucket {bucket} header size {header_length} usable_slots {usable_slots}");
 
-            let mut header = vec![0u8; header_length];
-            for byte in header.iter_mut().take(full_bytes) {
-                *byte = 0xff;
-            }
-            if full_bytes < header_length && remaining_bits > 0 {
-                header[full_bytes] = (1u8 << remaining_bits) - 1;
-            }
+            // Write the header in chunks so we don't materialize a huge Vec in
+            // the smaller buckets (4-byte bucket header is 512 KB).
+            let mut chunk = [0u8; SCAN_CHUNK];
+            let mut written = 0usize;
+            while written < header_length {
+                let remaining = header_length - written;
+                let take = remaining.min(SCAN_CHUNK);
 
-            core.write_bytes(header_address, &header)?;
+                for (j, slot) in chunk.iter_mut().take(take).enumerate() {
+                    let byte_idx = written + j;
+                    *slot = if byte_idx < full_bytes {
+                        0xff
+                    } else if byte_idx == full_bytes && remaining_bits > 0 {
+                        (1u8 << remaining_bits) - 1
+                    } else {
+                        0
+                    };
+                }
+
+                core.write_bytes(header_address + written as u32, &chunk[..take])?;
+                written += take;
+            }
         }
 
         Ok(())
     }
+
     pub fn alloc(core: &mut ArmCore, base_address: u32, size: u32) -> Result<u32> {
         let bucket_index = Self::find_bucket_index(size);
         let bucket = BUCKETS[bucket_index];
         let base_address = base_address + (bucket_index * BUCKET_SIZE) as u32;
         let header_length = BUCKET_SIZE / bucket / 8;
 
-        let mut header = vec![0u8; header_length];
-        core.read_bytes(base_address, &mut header)?;
+        // Scan the header in chunks instead of reading the whole thing on every
+        // alloc — small buckets have multi-hundred-KB headers and most allocs
+        // find a free bit in the first chunk anyway.
+        let mut chunk = [0u8; SCAN_CHUNK];
+        let mut scanned = 0usize;
+        while scanned < header_length {
+            let remaining = header_length - scanned;
+            let take = remaining.min(SCAN_CHUNK);
+            core.read_bytes(base_address + scanned as u32, &mut chunk[..take])?;
 
-        for (i, item) in header.iter_mut().enumerate() {
-            if *item == 0 {
-                continue;
+            for (j, item) in chunk.iter_mut().take(take).enumerate() {
+                if *item == 0 {
+                    continue;
+                }
+
+                let bit = item.trailing_zeros();
+                *item &= !(1 << bit);
+                let byte_idx = scanned + j;
+                let address = base_address + (header_length as u32) + (byte_idx as u32 * 8 + bit) * bucket as u32;
+
+                core.write_bytes(base_address + byte_idx as u32, &[*item])?;
+
+                return Ok(address);
             }
 
-            let bit = item.trailing_zeros();
-            *item &= !(1 << bit);
-            let address = base_address + (header_length as u32) + (i as u32 * 8 + bit) * bucket as u32;
-
-            core.write_bytes(base_address + i as u32, &[*item])?;
-
-            return Ok(address);
+            scanned += take;
         }
 
         Err(WieError::AllocationFailure)
@@ -77,18 +112,17 @@ impl BucketAllocator {
         let base_address = base_address + (bucket_index * BUCKET_SIZE) as u32;
         let header_length = BUCKET_SIZE / bucket / 8;
 
-        let mut header = vec![0u8; header_length];
-        core.read_bytes(base_address, &mut header)?;
-
         let offset = (address - base_address - header_length as u32) / bucket as u32;
         let index = offset / 8;
         let bit = offset % 8;
 
-        debug_assert!(header[index as usize] & (1 << bit) == 0);
+        // Touch only the single header byte that owns this slot.
+        let mut byte: u8 = read_generic(core, base_address + index)?;
 
-        header[index as usize] |= 1 << bit;
+        debug_assert!(byte & (1 << bit) == 0);
 
-        core.write_bytes(base_address + index, &[header[index as usize]])?;
+        byte |= 1 << bit;
+        write_generic(core, base_address + index, byte)?;
 
         Ok(())
     }
@@ -102,7 +136,7 @@ impl BucketAllocator {
 
 #[cfg(test)]
 mod tests {
-    use wie_util::Result;
+    use wie_util::{ByteRead, Result};
 
     use crate::ArmCore;
 
@@ -147,6 +181,58 @@ mod tests {
         assert_eq!(address8, 0x41040018);
 
         Ok(())
+    }
+
+    // Regression: each bucket's slot region used to extend past `BUCKET_SIZE`
+    // into the next bucket's region (header_length bytes of overlap), so two
+    // different size classes could hand out the same address. After init, the
+    // header bits for slots that would land outside the bucket's own region
+    // must be 0 (already-allocated) so they're never returned by alloc().
+    #[test]
+    fn test_init_clamps_slots_to_region() -> Result<()> {
+        const BUCKET_SIZE: u32 = 0x1000000;
+        let mut core = ArmCore::new(false, None).unwrap();
+        core.map(0x40000000, 0x8000000)?;
+        BucketAllocator::init(&mut core, 0x40000000, 0x8000000)?;
+
+        // For each bucket, walk the header from the end backwards: the trailing
+        // bits that correspond to addresses past `bucket_base + BUCKET_SIZE`
+        // must all be 0. Concretely, `usable_slots` = (BUCKET_SIZE - header)
+        // / bucket; bits at index >= usable_slots must be cleared.
+        let buckets: [u32; 8] = [4, 8, 16, 32, 64, 128, 256, 512];
+        for (i, bucket) in buckets.into_iter().enumerate() {
+            let bucket_base = 0x40000000 + i as u32 * BUCKET_SIZE;
+            let header_length = BUCKET_SIZE / bucket / 8;
+            let usable_slots = (BUCKET_SIZE - header_length) / bucket;
+
+            // First slot that should be marked as already-allocated.
+            for slot in usable_slots..header_length * 8 {
+                let byte_idx = slot / 8;
+                let bit = slot % 8;
+                let mut byte = [0u8; 1];
+                core.read_bytes(bucket_base + byte_idx, &mut byte).unwrap();
+                assert!(
+                    byte[0] & (1 << bit) == 0,
+                    "bucket {bucket} slot {slot} (byte {byte_idx} bit {bit}) is free but lands outside region"
+                );
+
+                // Sanity: also confirm that this slot's address would indeed
+                // overlap the next bucket's region.
+                let slot_addr = bucket_base + header_length + slot * bucket;
+                let next_bucket_base = 0x40000000 + (i as u32 + 1) * BUCKET_SIZE;
+                assert!(slot_addr >= next_bucket_base || i == buckets.len() - 1);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_init_rejects_undersized_region() {
+        let mut core = ArmCore::new(false, None).unwrap();
+        core.map(0x40000000, 0x1000000).unwrap();
+
+        // 0x1000000 is one BUCKET_SIZE — far too small for 8 buckets.
+        assert!(BucketAllocator::init(&mut core, 0x40000000, 0x1000000).is_err());
     }
 
     #[test]

--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -6,7 +6,9 @@ use crate::core::ArmCore;
 
 pub const BUCKET_MAX: usize = 512;
 const BUCKETS: [usize; 8] = [4, 8, 16, 32, 64, 128, 256, 512];
-const BUCKET_SIZE: usize = 0x100000;
+// Each bucket gets one BUCKET_SIZE region; 8 buckets * 0x1000000 = 0x8000000
+// (128 MB), exactly matching the BucketAllocator half of the heap.
+const BUCKET_SIZE: usize = 0x1000000;
 
 pub struct BucketAllocator;
 
@@ -14,14 +16,31 @@ impl BucketAllocator {
     pub fn init(core: &mut ArmCore, base_address: u32, _base_size: u32) -> Result<()> {
         // initialize each bucket header with ones
         // header contains bitset of allocation, 1 is unallocated, 0 is allocated
+        //
+        // Slots beyond `(BUCKET_SIZE - header_length) / bucket` would extend past
+        // this bucket's region into the next bucket's slot area; mark those bits
+        // as allocated so they're never handed out (otherwise two different
+        // bucket sizes can hand out overlapping addresses).
 
         for (i, bucket) in BUCKETS.into_iter().enumerate() {
             let header_length = BUCKET_SIZE / bucket / 8;
             let header_address = base_address + i as u32 * BUCKET_SIZE as u32;
 
-            tracing::info!("Bucket {bucket} header size {}", BUCKET_SIZE / bucket / 8);
+            let usable_slots = (BUCKET_SIZE - header_length) / bucket;
+            let full_bytes = usable_slots / 8;
+            let remaining_bits = usable_slots % 8;
 
-            core.write_bytes(header_address, &vec![0xff; header_length])?;
+            tracing::info!("Bucket {bucket} header size {header_length} usable_slots {usable_slots}");
+
+            let mut header = vec![0u8; header_length];
+            for byte in header.iter_mut().take(full_bytes) {
+                *byte = 0xff;
+            }
+            if full_bytes < header_length && remaining_bits > 0 {
+                header[full_bytes] = (1u8 << remaining_bits) - 1;
+            }
+
+            core.write_bytes(header_address, &header)?;
         }
 
         Ok(())
@@ -89,38 +108,43 @@ mod tests {
 
     use super::BucketAllocator;
 
+    // Bucket 0 (4-byte) header_length = BUCKET_SIZE / 4 / 8 = 0x80000.
+    // First 4-byte slot starts at base + 0x80000 = 0x40080000.
+    // Bucket 1 (8-byte) lives at base + BUCKET_SIZE = 0x41000000;
+    // header_length = BUCKET_SIZE / 8 / 8 = 0x40000, so first slot = 0x41040000.
+
     #[test]
     fn test_allocator() -> Result<()> {
         let mut core = ArmCore::new(false, None).unwrap();
-        core.map(0x40000000, 0x1000000)?;
+        core.map(0x40000000, 0x8000000)?;
 
-        BucketAllocator::init(&mut core, 0x40000000, 0x1000000)?;
+        BucketAllocator::init(&mut core, 0x40000000, 0x8000000)?;
 
         let address1 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address1, 0x40008000);
+        assert_eq!(address1, 0x40080000);
 
         let address2 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address2, 0x40008004);
+        assert_eq!(address2, 0x40080004);
 
         let address3 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address3, 0x40008008);
+        assert_eq!(address3, 0x40080008);
 
         BucketAllocator::free(&mut core, 0x40000000, address2, 4)?;
 
         let address4 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address4, 0x40008004);
+        assert_eq!(address4, 0x40080004);
 
         let address5 = BucketAllocator::alloc(&mut core, 0x40000000, 5)?;
-        assert_eq!(address5, 0x40104000);
+        assert_eq!(address5, 0x41040000);
 
         let address6 = BucketAllocator::alloc(&mut core, 0x40000000, 6)?;
-        assert_eq!(address6, 0x40104008);
+        assert_eq!(address6, 0x41040008);
 
         let address7 = BucketAllocator::alloc(&mut core, 0x40000000, 7)?;
-        assert_eq!(address7, 0x40104010);
+        assert_eq!(address7, 0x41040010);
 
         let address8 = BucketAllocator::alloc(&mut core, 0x40000000, 8)?;
-        assert_eq!(address8, 0x40104018);
+        assert_eq!(address8, 0x41040018);
 
         Ok(())
     }
@@ -128,24 +152,24 @@ mod tests {
     #[test]
     fn test_allocator_small_sizes() -> Result<()> {
         let mut core = ArmCore::new(false, None).unwrap();
-        core.map(0x40000000, 0x1000000)?;
+        core.map(0x40000000, 0x8000000)?;
 
-        BucketAllocator::init(&mut core, 0x40000000, 0x1000000)?;
+        BucketAllocator::init(&mut core, 0x40000000, 0x8000000)?;
 
         // sizes 0..=3 must all land in the smallest (4-byte) bucket
         let a0 = BucketAllocator::alloc(&mut core, 0x40000000, 0)?;
-        assert_eq!(a0, 0x40008000);
+        assert_eq!(a0, 0x40080000);
         let a1 = BucketAllocator::alloc(&mut core, 0x40000000, 1)?;
-        assert_eq!(a1, 0x40008004);
+        assert_eq!(a1, 0x40080004);
         let a2 = BucketAllocator::alloc(&mut core, 0x40000000, 2)?;
-        assert_eq!(a2, 0x40008008);
+        assert_eq!(a2, 0x40080008);
         let a3 = BucketAllocator::alloc(&mut core, 0x40000000, 3)?;
-        assert_eq!(a3, 0x4000800c);
+        assert_eq!(a3, 0x4008000c);
 
         // free with the same (small) size must round-trip without panicking
         BucketAllocator::free(&mut core, 0x40000000, a1, 1)?;
         let a1b = BucketAllocator::alloc(&mut core, 0x40000000, 1)?;
-        assert_eq!(a1b, 0x40008004);
+        assert_eq!(a1b, 0x40080004);
 
         Ok(())
     }

--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -1,69 +1,67 @@
-use wie_util::{ByteRead, ByteWrite, Result, WieError, read_generic, write_generic};
+use alloc::vec;
+
+use wie_util::{ByteRead, ByteWrite, Result, WieError};
 
 use crate::core::ArmCore;
 
 pub const BUCKET_MAX: usize = 512;
-const BUCKETS: [usize; 8] = [4, 8, 16, 32, 64, 128, 256, 512];
-// Each bucket gets one BUCKET_SIZE region; 8 buckets * 0x1000000 = 0x8000000
-// (128 MB), exactly matching the BucketAllocator half of the heap.
-const BUCKET_SIZE: usize = 0x1000000;
 
-// Chunk size for header scans in alloc(). 1 KB balances per-call read overhead
-// against unnecessary work for large headers (4-byte bucket header is 512 KB).
-const SCAN_CHUNK: usize = 1024;
+// (slot_size, slot_count). slot_count is a multiple of 8 so the header has no
+// trailing partial byte to mask. Sizes chosen generously per slot class so the
+// whole BucketAllocator half of the heap (128 MB) is used without overlap.
+const BUCKETS: [(usize, usize); 8] = [
+    (4, 0x100000),
+    (8, 0x80000),
+    (16, 0x80000),
+    (32, 0x40000),
+    (64, 0x40000),
+    (128, 0x20000),
+    (256, 0x20000),
+    (512, 0x10000),
+];
+
+const fn header_length(idx: usize) -> usize {
+    BUCKETS[idx].1 / 8
+}
+
+const fn region_size(idx: usize) -> usize {
+    let (slot_size, slot_count) = BUCKETS[idx];
+    slot_count / 8 + slot_size * slot_count
+}
+
+const fn region_offset(idx: usize) -> usize {
+    let mut offset = 0;
+    let mut i = 0;
+    while i < idx {
+        offset += region_size(i);
+        i += 1;
+    }
+    offset
+}
+
+const fn total_size() -> usize {
+    region_offset(BUCKETS.len() - 1) + region_size(BUCKETS.len() - 1)
+}
 
 pub struct BucketAllocator;
 
 impl BucketAllocator {
     pub fn init(core: &mut ArmCore, base_address: u32, base_size: u32) -> Result<()> {
-        // header contains bitset of allocation, 1 is unallocated, 0 is allocated.
-        //
-        // Slots beyond `(BUCKET_SIZE - header_length) / bucket` would extend past
-        // this bucket's region into the next bucket's slot area; mark those bits
-        // as allocated so they're never handed out (otherwise two different
-        // bucket sizes can hand out overlapping addresses).
-        //
-        // The caller-provided region must hold all `BUCKETS.len()` regions of
-        // `BUCKET_SIZE` each. Validate up-front so a future heap-sizing change
-        // can't silently produce out-of-region writes.
-        let required = (BUCKETS.len() * BUCKET_SIZE) as u32;
+        // header contains bitset of allocation, 1 is unallocated, 0 is allocated
+
+        let required = total_size() as u32;
         if base_size < required {
             tracing::error!("BucketAllocator region too small: got {base_size:#x}, need {required:#x}");
             return Err(WieError::AllocationFailure);
         }
 
-        for (i, bucket) in BUCKETS.into_iter().enumerate() {
-            let header_length = BUCKET_SIZE / bucket / 8;
-            let header_address = base_address + i as u32 * BUCKET_SIZE as u32;
+        for (i, &(slot_size, _)) in BUCKETS.iter().enumerate() {
+            let header_address = base_address + region_offset(i) as u32;
+            let header_len = header_length(i);
 
-            let usable_slots = (BUCKET_SIZE - header_length) / bucket;
-            let full_bytes = usable_slots / 8;
-            let remaining_bits = usable_slots % 8;
+            tracing::info!("Bucket {slot_size} header size {header_len}");
 
-            tracing::info!("Bucket {bucket} header size {header_length} usable_slots {usable_slots}");
-
-            // Write the header in chunks so we don't materialize a huge Vec in
-            // the smaller buckets (4-byte bucket header is 512 KB).
-            let mut chunk = [0u8; SCAN_CHUNK];
-            let mut written = 0usize;
-            while written < header_length {
-                let remaining = header_length - written;
-                let take = remaining.min(SCAN_CHUNK);
-
-                for (j, slot) in chunk.iter_mut().take(take).enumerate() {
-                    let byte_idx = written + j;
-                    *slot = if byte_idx < full_bytes {
-                        0xff
-                    } else if byte_idx == full_bytes && remaining_bits > 0 {
-                        (1u8 << remaining_bits) - 1
-                    } else {
-                        0
-                    };
-                }
-
-                core.write_bytes(header_address + written as u32, &chunk[..take])?;
-                written += take;
-            }
+            core.write_bytes(header_address, &vec![0xff; header_len])?;
         }
 
         Ok(())
@@ -71,36 +69,25 @@ impl BucketAllocator {
 
     pub fn alloc(core: &mut ArmCore, base_address: u32, size: u32) -> Result<u32> {
         let bucket_index = Self::find_bucket_index(size);
-        let bucket = BUCKETS[bucket_index];
-        let base_address = base_address + (bucket_index * BUCKET_SIZE) as u32;
-        let header_length = BUCKET_SIZE / bucket / 8;
+        let (slot_size, _) = BUCKETS[bucket_index];
+        let header_address = base_address + region_offset(bucket_index) as u32;
+        let header_len = header_length(bucket_index);
 
-        // Scan the header in chunks instead of reading the whole thing on every
-        // alloc — small buckets have multi-hundred-KB headers and most allocs
-        // find a free bit in the first chunk anyway.
-        let mut chunk = [0u8; SCAN_CHUNK];
-        let mut scanned = 0usize;
-        while scanned < header_length {
-            let remaining = header_length - scanned;
-            let take = remaining.min(SCAN_CHUNK);
-            core.read_bytes(base_address + scanned as u32, &mut chunk[..take])?;
+        let mut header = vec![0u8; header_len];
+        core.read_bytes(header_address, &mut header)?;
 
-            for (j, item) in chunk.iter_mut().take(take).enumerate() {
-                if *item == 0 {
-                    continue;
-                }
-
-                let bit = item.trailing_zeros();
-                *item &= !(1 << bit);
-                let byte_idx = scanned + j;
-                let address = base_address + (header_length as u32) + (byte_idx as u32 * 8 + bit) * bucket as u32;
-
-                core.write_bytes(base_address + byte_idx as u32, &[*item])?;
-
-                return Ok(address);
+        for (i, item) in header.iter_mut().enumerate() {
+            if *item == 0 {
+                continue;
             }
 
-            scanned += take;
+            let bit = item.trailing_zeros();
+            *item &= !(1 << bit);
+            let address = header_address + header_len as u32 + (i as u32 * 8 + bit) * slot_size as u32;
+
+            core.write_bytes(header_address + i as u32, &[*item])?;
+
+            return Ok(address);
         }
 
         Err(WieError::AllocationFailure)
@@ -108,44 +95,44 @@ impl BucketAllocator {
 
     pub fn free(core: &mut ArmCore, base_address: u32, address: u32, size: u32) -> Result<()> {
         let bucket_index = Self::find_bucket_index(size);
-        let bucket = BUCKETS[bucket_index];
-        let base_address = base_address + (bucket_index * BUCKET_SIZE) as u32;
-        let header_length = BUCKET_SIZE / bucket / 8;
+        let (slot_size, _) = BUCKETS[bucket_index];
+        let header_address = base_address + region_offset(bucket_index) as u32;
+        let header_len = header_length(bucket_index);
 
-        let offset = (address - base_address - header_length as u32) / bucket as u32;
+        let mut header = vec![0u8; header_len];
+        core.read_bytes(header_address, &mut header)?;
+
+        let offset = (address - header_address - header_len as u32) / slot_size as u32;
         let index = offset / 8;
         let bit = offset % 8;
 
-        // Touch only the single header byte that owns this slot.
-        let mut byte: u8 = read_generic(core, base_address + index)?;
+        debug_assert!(header[index as usize] & (1 << bit) == 0);
 
-        debug_assert!(byte & (1 << bit) == 0);
+        header[index as usize] |= 1 << bit;
 
-        byte |= 1 << bit;
-        write_generic(core, base_address + index, byte)?;
+        core.write_bytes(header_address + index, &[header[index as usize]])?;
 
         Ok(())
     }
 
-    #[inline]
     fn find_bucket_index(size: u32) -> usize {
-        let size = size.max(BUCKETS[0] as u32);
-        (size.ilog2() + if size.is_power_of_two() { 0 } else { 1 } - 2) as _
+        BUCKETS.iter().position(|&(s, _)| size as usize <= s).unwrap_or(BUCKETS.len() - 1)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use wie_util::{ByteRead, Result};
+    use wie_util::Result;
 
     use crate::ArmCore;
 
     use super::BucketAllocator;
 
-    // Bucket 0 (4-byte) header_length = BUCKET_SIZE / 4 / 8 = 0x80000.
-    // First 4-byte slot starts at base + 0x80000 = 0x40080000.
-    // Bucket 1 (8-byte) lives at base + BUCKET_SIZE = 0x41000000;
-    // header_length = BUCKET_SIZE / 8 / 8 = 0x40000, so first slot = 0x41040000.
+    // Bucket 0 (4-byte): header_length = 0x100000 / 8 = 0x20000.
+    //   First slot at base + 0x20000 = 0x40020000.
+    // Bucket 1 (8-byte): region_offset = 0x20000 + 4*0x100000 = 0x420000.
+    //   header_length = 0x80000 / 8 = 0x10000.
+    //   First slot at base + 0x420000 + 0x10000 = 0x40430000.
 
     #[test]
     fn test_allocator() -> Result<()> {
@@ -155,74 +142,31 @@ mod tests {
         BucketAllocator::init(&mut core, 0x40000000, 0x8000000)?;
 
         let address1 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address1, 0x40080000);
+        assert_eq!(address1, 0x40020000);
 
         let address2 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address2, 0x40080004);
+        assert_eq!(address2, 0x40020004);
 
         let address3 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address3, 0x40080008);
+        assert_eq!(address3, 0x40020008);
 
         BucketAllocator::free(&mut core, 0x40000000, address2, 4)?;
 
         let address4 = BucketAllocator::alloc(&mut core, 0x40000000, 4)?;
-        assert_eq!(address4, 0x40080004);
+        assert_eq!(address4, 0x40020004);
 
         let address5 = BucketAllocator::alloc(&mut core, 0x40000000, 5)?;
-        assert_eq!(address5, 0x41040000);
+        assert_eq!(address5, 0x40430000);
 
         let address6 = BucketAllocator::alloc(&mut core, 0x40000000, 6)?;
-        assert_eq!(address6, 0x41040008);
+        assert_eq!(address6, 0x40430008);
 
         let address7 = BucketAllocator::alloc(&mut core, 0x40000000, 7)?;
-        assert_eq!(address7, 0x41040010);
+        assert_eq!(address7, 0x40430010);
 
         let address8 = BucketAllocator::alloc(&mut core, 0x40000000, 8)?;
-        assert_eq!(address8, 0x41040018);
+        assert_eq!(address8, 0x40430018);
 
-        Ok(())
-    }
-
-    // Regression: each bucket's slot region used to extend past `BUCKET_SIZE`
-    // into the next bucket's region (header_length bytes of overlap), so two
-    // different size classes could hand out the same address. After init, the
-    // header bits for slots that would land outside the bucket's own region
-    // must be 0 (already-allocated) so they're never returned by alloc().
-    #[test]
-    fn test_init_clamps_slots_to_region() -> Result<()> {
-        const BUCKET_SIZE: u32 = 0x1000000;
-        let mut core = ArmCore::new(false, None).unwrap();
-        core.map(0x40000000, 0x8000000)?;
-        BucketAllocator::init(&mut core, 0x40000000, 0x8000000)?;
-
-        // For each bucket, walk the header from the end backwards: the trailing
-        // bits that correspond to addresses past `bucket_base + BUCKET_SIZE`
-        // must all be 0. Concretely, `usable_slots` = (BUCKET_SIZE - header)
-        // / bucket; bits at index >= usable_slots must be cleared.
-        let buckets: [u32; 8] = [4, 8, 16, 32, 64, 128, 256, 512];
-        for (i, bucket) in buckets.into_iter().enumerate() {
-            let bucket_base = 0x40000000 + i as u32 * BUCKET_SIZE;
-            let header_length = BUCKET_SIZE / bucket / 8;
-            let usable_slots = (BUCKET_SIZE - header_length) / bucket;
-
-            // First slot that should be marked as already-allocated.
-            for slot in usable_slots..header_length * 8 {
-                let byte_idx = slot / 8;
-                let bit = slot % 8;
-                let mut byte = [0u8; 1];
-                core.read_bytes(bucket_base + byte_idx, &mut byte).unwrap();
-                assert!(
-                    byte[0] & (1 << bit) == 0,
-                    "bucket {bucket} slot {slot} (byte {byte_idx} bit {bit}) is free but lands outside region"
-                );
-
-                // Sanity: also confirm that this slot's address would indeed
-                // overlap the next bucket's region.
-                let slot_addr = bucket_base + header_length + slot * bucket;
-                let next_bucket_base = 0x40000000 + (i as u32 + 1) * BUCKET_SIZE;
-                assert!(slot_addr >= next_bucket_base || i == buckets.len() - 1);
-            }
-        }
         Ok(())
     }
 
@@ -231,7 +175,7 @@ mod tests {
         let mut core = ArmCore::new(false, None).unwrap();
         core.map(0x40000000, 0x1000000).unwrap();
 
-        // 0x1000000 is one BUCKET_SIZE — far too small for 8 buckets.
+        // 0x1000000 (16 MB) is far too small for the full bucket layout.
         assert!(BucketAllocator::init(&mut core, 0x40000000, 0x1000000).is_err());
     }
 
@@ -244,18 +188,18 @@ mod tests {
 
         // sizes 0..=3 must all land in the smallest (4-byte) bucket
         let a0 = BucketAllocator::alloc(&mut core, 0x40000000, 0)?;
-        assert_eq!(a0, 0x40080000);
+        assert_eq!(a0, 0x40020000);
         let a1 = BucketAllocator::alloc(&mut core, 0x40000000, 1)?;
-        assert_eq!(a1, 0x40080004);
+        assert_eq!(a1, 0x40020004);
         let a2 = BucketAllocator::alloc(&mut core, 0x40000000, 2)?;
-        assert_eq!(a2, 0x40080008);
+        assert_eq!(a2, 0x40020008);
         let a3 = BucketAllocator::alloc(&mut core, 0x40000000, 3)?;
-        assert_eq!(a3, 0x4008000c);
+        assert_eq!(a3, 0x4002000c);
 
         // free with the same (small) size must round-trip without panicking
         BucketAllocator::free(&mut core, 0x40000000, a1, 1)?;
         let a1b = BucketAllocator::alloc(&mut core, 0x40000000, 1)?;
-        assert_eq!(a1b, 0x40080004);
+        assert_eq!(a1b, 0x40020004);
 
         Ok(())
     }

--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -7,8 +7,9 @@ use crate::core::ArmCore;
 pub const BUCKET_MAX: usize = 512;
 
 // (slot_size, slot_count). slot_count is a multiple of 8 so the header has no
-// trailing partial byte to mask. Sizes chosen generously per slot class so the
-// whole BucketAllocator half of the heap (128 MB) is used without overlap.
+// trailing partial byte to mask. Sizes chosen generously per slot class to fit
+// inside the 128 MB BucketAllocator half of the heap; total layout is
+// ~0x785A000 (~120 MB), leaving ~8 MB of intentional slack.
 const BUCKETS: [(usize, usize); 8] = [
     (4, 0x100000),
     (8, 0x80000),


### PR DESCRIPTION
`BucketAllocator` 가 서로 다른 두 bucket size 에 대해 같은 heap 주소를 두 번 할당하던 버그가 있습니다. 그 결과 원래 살아 있어야 할 데이터(예: `java.lang.String` 의 methods table) 가 무관한 다른 alloc 에 의해 덮어써져서, ARM dispatch 단계에서 `InvalidMemoryAccess` 로 random crash 가 발생했습니다.

## 증상

영웅서기4 (KTF) 를 실행하면 네베드 종족 튜토리얼 진입 직전에 일관되게 패닉 나는걸 확인했습니다

```
thread 'main' panicked at wie_ktf/src/runtime/java/jvm_support/method.rs:109:73:
called `Result::unwrap()` on an `Err` value: InvalidMemoryAccess(4352)
```

`4352 = 0x1100` 인데, 이 주소는 heap (`0x40000000+`) 도 image (`0x100000+`) 도 아닌 mapping 자체가 안 된 영역입니다.

진단 로그를 추가해 잡아 보니:

```
methods() bad entry: class=java/lang/String ptr_raw=0x483015e0
ptr_methods=0x48500500 method_count=30 entry_idx=0
ptr_method=0x1100
```

→ `java.lang.String` 의 methods table 첫 번째 entry 가 `0x1100` 으로 망가져 있었습니다. 그런데 `String` 은 wie 가 직접 만든 class 라 ptr 은 항상 합법적인 heap address 여야 합니다. 누군가 그 슬롯을 덮어썼다는 뜻입니다.

## 원인

기존 `wie_core_arm/src/allocator/bucket.rs`:

```rust
const BUCKETS: [usize; 8] = [4, 8, 16, 32, 64, 128, 256, 512];
const BUCKET_SIZE: usize = 0x100000;  // bucket 하나당 1 MB
```

각 bucket region 은 `BUCKET_SIZE` 간격으로 배치되고 내부 layout 은:

```
[ header (header_length bytes) | slot 0 | slot 1 | ... | slot N-1 ]
```

`header_length = BUCKET_SIZE / bucket / 8` 로 정해지는데 slot 영역 크기를 계산해 보면

```
num_slots   = header_length * 8 = BUCKET_SIZE / bucket
slot_region = num_slots * bucket = BUCKET_SIZE
```

→ slot 영역만 이미 `BUCKET_SIZE`. 거기에 header 가 또 `header_length` 바이트 붙어서 실제 사용 영역은 `header_length + BUCKET_SIZE`. 다음 bucket base 는 `+ BUCKET_SIZE` 떨어져 있으므로 **마지막 `header_length` 바이트가 다음 bucket region 으로 침범**.

### 영웅서기4 예시

1. JVM 초기화 시 wie 가 `java.lang.String` class 를 만들고, 30개의 메서드 ptr 을 담은 124 byte methods table 을 alloc → **bucket 5 (128 byte) slot 2 = `0x48500500`**.
2. 게임 진행 중 다른 64 byte alloc 이 들어와서 **bucket 4 slot 16372 = `0x48500500`** 를 받음.
3. 그 alloc 의 첫 4 byte 가 우연히 `0x1100` 으로 채워짐 (옆 struct 의 `MethodAccessFlags` u16 같은 패턴).
4. methods table entry 0 가 `0x1100` 이 되어버림.
5. JVM 이 String 의 메서드를 lookup → `JavaMethod::ptr_class()` → `read_generic(0x1100)` → unmapped → **panic**.

## 수정 내용

리뷰 피드백 (overflow 자체가 일어나지 않게 size 만 조정) 을 반영해서, region clamp 같은 방어 코드 없이 **per-bucket `(slot_size, slot_count)` 하드코딩 + prefix-sum offset 배치** 로 갔습니다.

```rust
// (slot_size, slot_count). slot_count is a multiple of 8 so the header has no
// trailing partial byte to mask.
const BUCKETS: [(usize, usize); 8] = [
    (4,   0x100000),
    (8,   0x80000),
    (16,  0x80000),
    (32,  0x40000),
    (64,  0x40000),
    (128, 0x20000),
    (256, 0x20000),
    (512, 0x10000),
];

const fn header_length(idx: usize) -> usize { BUCKETS[idx].1 / 8 }
const fn region_size(idx: usize) -> usize {
    let (slot_size, slot_count) = BUCKETS[idx];
    slot_count / 8 + slot_size * slot_count
}
const fn region_offset(idx: usize) -> usize { /* prefix-sum of region_size */ }
```

각 bucket region 은 정확히 `header + slots` 만 차지하고 인접 region 으로 침범하지 않습니다. 전체 layout 합계는 `~0x785A000` (~120 MB) 으로 `BucketAllocator` 에 할당된 128 MB 안에 fit 하며 (~8 MB slack), `init` 에서 `base_size < total_size()` 면 `AllocationFailure` 를 리턴해 invariant 를 명시적으로 가드합니다.

각 size class capacity:

| slot | slots | region |
|------|-------|--------|
| 4    | 0x100000 | ~4 MB |
| 8    | 0x80000  | ~4 MB |
| 16   | 0x80000  | ~8 MB |
| 32   | 0x40000  | ~8 MB |
| 64   | 0x40000  | ~16 MB |
| 128  | 0x20000  | ~16 MB |
| 256  | 0x20000  | ~32 MB |
| 512  | 0x10000  | ~32 MB |

## 영향

- BucketAllocator 메모리 사용량은 기존 8 MB → ~120 MB 로 늘지만 reserved 된 heap 절반 안이라 추가 매핑은 없습니다.
- 영웅서기4 에서 정상 작동 확인 (ubuntu linux 기준).
- 기존 tests + region 크기 가드용 regression test (`test_init_rejects_undersized_region`) 추가.
