### PR TITLE
fix(wipi_java): add missing org.kwis.msp.lwc.EventListener interface, add GIF asset decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1137,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,9 +1312,13 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
  "moxcms",
  "num-traits",
  "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3433,6 +3453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wie_backend"
 version = "0.0.1"
 dependencies = [
@@ -4362,4 +4388,19 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/wie_backend/Cargo.toml
+++ b/wie_backend/Cargo.toml
@@ -12,7 +12,7 @@ tracing = { workspace = true }
 
 ab_glyph = { version = "^0.2", features = ["libm"], default-features = false }
 hashbrown = { version = "^0.17", features = ["default-hasher"], default-features = false }
-image = { version = "^0.25", features = ["bmp", "png"], default-features = false }
+image = { version = "^0.25", features = ["bmp", "gif", "jpeg", "png"], default-features = false }
 lazy_static = { version = "^1.5", default-features = false }
 num-traits = { version = "^0.2", default-features = false }
 zip = { version = "^8.6", features = ["deflate"], default-features = false }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc.rs
@@ -1,12 +1,13 @@
 mod annunciator_component;
 mod component;
 mod container_component;
+mod event_listener;
 mod shell_component;
 mod text_box_component;
 mod text_component;
 mod text_field_component;
 
 pub use self::{
-    annunciator_component::AnnunciatorComponent, component::Component, container_component::ContainerComponent, shell_component::ShellComponent,
-    text_box_component::TextBoxComponent, text_component::TextComponent, text_field_component::TextFieldComponent,
+    annunciator_component::AnnunciatorComponent, component::Component, container_component::ContainerComponent, event_listener::EventListener,
+    shell_component::ShellComponent, text_box_component::TextBoxComponent, text_component::TextComponent, text_field_component::TextFieldComponent,
 };

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/event_listener.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/event_listener.rs
@@ -1,0 +1,25 @@
+use alloc::vec;
+
+use java_class_proto::JavaMethodProto;
+use java_constants::ClassAccessFlags;
+use wie_jvm_support::WieJavaClassProto;
+
+// interface org.kwis.msp.lwc.EventListener
+pub struct EventListener;
+
+impl EventListener {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "org/kwis/msp/lwc/EventListener",
+            parent_class: None,
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new_abstract(
+                "eventNotify",
+                "(IIIILjava/lang/Object;)Z",
+                Default::default(),
+            )],
+            fields: vec![],
+            access_flags: ClassAccessFlags::INTERFACE,
+        }
+    }
+}

--- a/wie_wipi_java/src/lib.rs
+++ b/wie_wipi_java/src/lib.rs
@@ -6,7 +6,7 @@ pub mod classes;
 
 use wie_jvm_support::WieJavaClassProto;
 
-pub fn get_protos() -> [WieJavaClassProto; 34] {
+pub fn get_protos() -> [WieJavaClassProto; 35] {
     [
         crate::classes::org::kwis::msf::io::Network::as_proto(),
         crate::classes::org::kwis::msf::io::SchemeNotFoundException::as_proto(),
@@ -29,6 +29,7 @@ pub fn get_protos() -> [WieJavaClassProto; 34] {
         crate::classes::org::kwis::msp::lcdui::JletEventListener::as_proto(),
         crate::classes::org::kwis::msp::lwc::Component::as_proto(),
         crate::classes::org::kwis::msp::lwc::ContainerComponent::as_proto(),
+        crate::classes::org::kwis::msp::lwc::EventListener::as_proto(),
         crate::classes::org::kwis::msp::lwc::ShellComponent::as_proto(),
         crate::classes::org::kwis::msp::lwc::AnnunciatorComponent::as_proto(),
         crate::classes::org::kwis::msp::lwc::TextComponent::as_proto(),


### PR DESCRIPTION
[Report.MD](https://github.com/mirusu400/wie-test/blob/main/report.md) 에 있는 게임중하나인 `논스톱_액션_고고씽.zip` 을 실행하면 게임이 Hang되는 현상을 해결하기위해 해당 PR을 진행하였습니다.

## 원인

KTF 네이티브 바이너리(`client.bin`)의 `fn_init`이 초기화 도중 `org/kwis/msp/lwc/EventListener` 인터페이스를 JVM에 요청하는데, wie_wipi_java에 해당 클래스가 등록되어 있지 않아 `java_class_load`가 실패합니다.

이로 인해 `fn_init`이 `0xffffffff`를 반환하고, `wie_ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs:88` 의 `load_native(...).await.unwrap()` 에서 `FatalError("wipi init failed with code 0xffffffff")` 로 패닉이 발생합니다. winit 콜백 내부의 non-unwinding panic이라 unwind 없이 abort (Hang)됩니다

```
ERROR ... No such class: org/kwis/msp/lwc/EventListener
INFO  ... throwing java exception: java/lang/NoClassDefFoundError org/kwis/msp/lwc/EventListener
ERROR ... load_java_class(org/kwis/msp/lwc/EventListener) failed
thread 'main' panicked at wie_ktf/.../ktf_class_loader.rs:88:
called `Result::unwrap()` on an `Err` value: FatalError("wipi init failed with code 0xffffffff")
```

KTF WIPI 1.1 API 레퍼런스 기준 시그니처 `boolean eventNotify(int, int, int, int, Object)`를 갖는 인터페이스입니다.

## 수정

* `org.kwis.msp.lwc.EventListener` 인터페이스 stub 추가 (`JletEventListener` 패턴 따름)
* `lwc` 모듈 / `get_protos()` 배열에 등록 (34 → 35)
* 추가로 첫 논스톱_액션_고고씽.zip 실행하면 paint 단계에서 `image format Gif is not supported` → `image == null` → `MainApp.paint`에서 NPE가 발생하여, `wie_backend`의 `image` crate에 `gif`, `jpeg` feature 활성화

## 추가사항
* `wie_backend` `image`에 `gif`만 추가해도 될거같은데 언젠가 jpeg도 쓸거같아서 그냥 함께 추가했습니다. (지워야될거같으면 지우겠습니다)
