### PR TITLE
fix: add missing font constants and update initialization logic

### DIFF
--- a/wie_midp/src/classes/javax/microedition/lcdui/font.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/font.rs
@@ -39,10 +39,16 @@ impl Font {
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::STATIC),
                 JavaFieldProto::new("FACE_SYSTEM", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("FACE_PROPORTIONAL", "I", FieldAccessFlags::STATIC),
                 JavaFieldProto::new("STYLE_PLAIN", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_BOLD", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_ITALIC", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_UNDERLINED", "I", FieldAccessFlags::STATIC),
                 JavaFieldProto::new("SIZE_SMALL", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_MEDIUM", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_LARGE", "I", FieldAccessFlags::STATIC),
             ],
             access_flags: Default::default(),
         }
@@ -51,10 +57,17 @@ impl Font {
     async fn cl_init(jvm: &Jvm, _: &mut WieJvmContext) -> JvmResult<()> {
         tracing::debug!("javax.microedition.msp.lcdui.Font::<clinit>");
 
-        jvm.put_static_field("javax/microedition/lcdui/Font", "FACE_MONOSPACE", "I", 32).await?;
         jvm.put_static_field("javax/microedition/lcdui/Font", "FACE_SYSTEM", "I", 0).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "FACE_MONOSPACE", "I", 32).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "FACE_PROPORTIONAL", "I", 64)
+            .await?;
         jvm.put_static_field("javax/microedition/lcdui/Font", "STYLE_PLAIN", "I", 0).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "STYLE_BOLD", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "STYLE_ITALIC", "I", 2).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "STYLE_UNDERLINED", "I", 4).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "SIZE_MEDIUM", "I", 0).await?;
         jvm.put_static_field("javax/microedition/lcdui/Font", "SIZE_SMALL", "I", 8).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Font", "SIZE_LARGE", "I", 16).await?;
 
         Ok(())
     }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/font.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/font.rs
@@ -35,10 +35,16 @@ impl Font {
             ],
             fields: vec![
                 JavaFieldProto::new("midpFont", "Ljavax/microedition/lcdui/Font;", Default::default()),
-                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::STATIC),
                 JavaFieldProto::new("FACE_SYSTEM", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("FACE_PROPORTIONAL", "I", FieldAccessFlags::STATIC),
                 JavaFieldProto::new("STYLE_PLAIN", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_BOLD", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_ITALIC", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_UNDERLINED", "I", FieldAccessFlags::STATIC),
                 JavaFieldProto::new("SIZE_SMALL", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_MEDIUM", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_LARGE", "I", FieldAccessFlags::STATIC),
             ],
             access_flags: Default::default(),
         }
@@ -47,16 +53,30 @@ impl Font {
     async fn cl_init(jvm: &Jvm, _: &mut WieJvmContext) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Font::<clinit>");
 
-        let face_monospace: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "FACE_MONOSPACE", "I").await?;
         let face_system: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "FACE_SYSTEM", "I").await?;
+        let face_monospace: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "FACE_MONOSPACE", "I").await?;
+        let face_proportional: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "FACE_PROPORTIONAL", "I").await?;
         let style_plain: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "STYLE_PLAIN", "I").await?;
+        let style_bold: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "STYLE_BOLD", "I").await?;
+        let style_italic: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "STYLE_ITALIC", "I").await?;
+        let style_underlined: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "STYLE_UNDERLINED", "I").await?;
         let size_small: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "SIZE_SMALL", "I").await?;
+        let size_medium: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "SIZE_MEDIUM", "I").await?;
+        let size_large: i32 = jvm.get_static_field("javax/microedition/lcdui/Font", "SIZE_LARGE", "I").await?;
 
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "FACE_SYSTEM", "I", face_system).await?;
         jvm.put_static_field("org/kwis/msp/lcdui/Font", "FACE_MONOSPACE", "I", face_monospace)
             .await?;
-        jvm.put_static_field("org/kwis/msp/lcdui/Font", "FACE_SYSTEM", "I", face_system).await?;
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "FACE_PROPORTIONAL", "I", face_proportional)
+            .await?;
         jvm.put_static_field("org/kwis/msp/lcdui/Font", "STYLE_PLAIN", "I", style_plain).await?;
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "STYLE_BOLD", "I", style_bold).await?;
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "STYLE_ITALIC", "I", style_italic).await?;
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "STYLE_UNDERLINED", "I", style_underlined)
+            .await?;
         jvm.put_static_field("org/kwis/msp/lcdui/Font", "SIZE_SMALL", "I", size_small).await?;
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "SIZE_MEDIUM", "I", size_medium).await?;
+        jvm.put_static_field("org/kwis/msp/lcdui/Font", "SIZE_LARGE", "I", size_large).await?;
 
         Ok(())
     }


### PR DESCRIPTION
`(KTF) 다마고치M.zip` 실행 시 다음 에러로 fatal 종료되고 있습니다

```
net/wie/WieError: Fatal error: Field FACE_PROPORTIONALI@37 not found from org/kwis/msp/lcdui/Font
    at GochiGame.startApp([Ljava/lang/String;)V
    at net/wie/WIPIMIDlet.startApp()V
    at net/wie/Launcher.startMIDlet(Ljavax/microedition/midlet/MIDlet;)V
    at org/kwis/msp/lcdui/Main.main([Ljava/lang/String;)V
```

`org/kwis/msp/lcdui/Font` 클래스에 `FACE_PROPORTIONAL` static 필드가 정의되지 않아 `getstatic` 명령이 필드 lookup에 실패해서 해당 문제가 발생하고있습니다

상위 `javax/microedition/lcdui/Font` (MIDP) 도 동일하게 4개 상수만 정의되어 있었음. KTF WIPI Font는 `cl_init`에서 MIDP Font 값을 읽어 자기 자신에게 복사하는 구조이므로 두 클래스를 함께 보강.

## 변경 내용

<img width="509" height="616" alt="image" src="https://github.com/user-attachments/assets/a7f650eb-db33-428b-b28c-9b7dad81cea5" />

[레퍼런스](https://nikita36078.github.io/J2ME_Docs/docs/WIPI_API_1_1_1/)

### `wie_midp/src/classes/javax/microedition/lcdui/font.rs`
- 필드 추가: `FACE_PROPORTIONAL`, `STYLE_BOLD`, `STYLE_ITALIC`, `STYLE_UNDERLINED`, `SIZE_MEDIUM`, `SIZE_LARGE`
- `<clinit>` 에서 MIDP 표준 상수값으로 초기화
  - FACE: SYSTEM=0, MONOSPACE=32, PROPORTIONAL=64
  - STYLE: PLAIN=0, BOLD=1, ITALIC=2, UNDERLINED=4
  - SIZE: MEDIUM=0, SMALL=8, LARGE=16

### `wie_wipi_java/src/classes/org/kwis/msp/lcdui/font.rs`
- 동일한 6개 필드 추가
- `<clinit>` 에서 MIDP Font의 정적 필드를 읽어 KTF Font로 그대로 복사하는 기존 패턴 확장


## 참고
의도적으로 필드중에서 필요한것만 넣어서 구현을 하신건지 모르겠네요... 일단 작동은 해서 PR남겨봅니다

