### PR TITLE
feat(smaf): SMAF loop & MIDI pitch bend/SysEx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "smaf"
 version = "0.1.0"
-source = "git+https://github.com/dlunch/smaf.git#a427527ad31fe9c23290ee6e2f53aeeac024085b"
+source = "git+https://github.com/dlunch/smaf.git#4c4ca836cc68d283267ab768b714d96d7acdc493"
 dependencies = [
  "anyhow",
  "nom 7.1.3",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "smaf_player"
 version = "0.1.0"
-source = "git+https://github.com/dlunch/smaf.git#a427527ad31fe9c23290ee6e2f53aeeac024085b"
+source = "git+https://github.com/dlunch/smaf.git#4c4ca836cc68d283267ab768b714d96d7acdc493"
 dependencies = [
  "smaf",
 ]

--- a/test_utils/src/platform.rs
+++ b/test_utils/src/platform.rs
@@ -191,6 +191,14 @@ impl AudioSink for TestAudioSink {
     fn midi_control_change(&self, _channel_id: u8, _control: u8, _value: u8) {
         todo!()
     }
+
+    fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {
+        todo!()
+    }
+
+    fn midi_sysex(&self, _data: &[u8]) {
+        todo!()
+    }
 }
 
 #[derive(Default)]

--- a/wie_backend/src/audio_sink.rs
+++ b/wie_backend/src/audio_sink.rs
@@ -4,4 +4,6 @@ pub trait AudioSink: Sync + Send {
     fn midi_note_off(&self, channel_id: u8, note: u8, velocity: u8);
     fn midi_program_change(&self, channel_id: u8, program: u8);
     fn midi_control_change(&self, channel_id: u8, control: u8, value: u8);
+    fn midi_pitch_bend(&self, channel_id: u8, value: u16);
+    fn midi_sysex(&self, data: &[u8]);
 }

--- a/wie_backend/src/system/audio.rs
+++ b/wie_backend/src/system/audio.rs
@@ -47,7 +47,7 @@ impl Audio {
         Ok(audio_handle)
     }
 
-    pub fn play(&mut self, system: &System, audio_handle: AudioHandle) -> Result<(), AudioError> {
+    pub fn play(&mut self, system: &System, audio_handle: AudioHandle, repeat: bool) -> Result<(), AudioError> {
         let player = match self.files.get(&audio_handle) {
             Some(AudioFile::Smaf(data)) => SmafPlayer::new(data),
             None => return Err(AudioError::InvalidHandle),
@@ -64,7 +64,7 @@ impl Audio {
 
         // TODO use dedicated audio player task
         system.spawn(async move || {
-            player.play(&mut system_clone, &**sink_clone, &stop_flag_clone).await;
+            player.play(&mut system_clone, &**sink_clone, &stop_flag_clone, repeat).await;
 
             Ok(())
         });
@@ -98,66 +98,308 @@ impl SmafPlayer {
         Self { events: parse_smaf(data) }
     }
 
-    pub async fn play(&self, system: &mut System, sink: &dyn AudioSink, stop_flag: &AtomicBool) {
-        let mut active_notes: Vec<(u8, u8)> = Vec::new();
-        let mut used_channels: BTreeSet<u8> = BTreeSet::new();
+    pub async fn play(&self, system: &mut System, sink: &dyn AudioSink, stop_flag: &AtomicBool, repeat: bool) {
+        loop {
+            let mut active_notes: Vec<(u8, u8)> = Vec::new();
+            let mut used_channels: BTreeSet<u8> = BTreeSet::new();
 
-        let start_time = system.platform().now();
-        for (time, event) in &self.events {
-            if stop_flag.load(Ordering::Relaxed) {
-                break;
-            }
-
-            let now = system.platform().now();
-            if (*time as u64) > now - start_time {
-                system.sleep(((*time as u64) - (now - start_time)) as _).await;
-
+            let start_time = system.platform().now();
+            for (time, event) in &self.events {
                 if stop_flag.load(Ordering::Relaxed) {
                     break;
                 }
+
+                let now = system.platform().now();
+                if (*time as u64) > now - start_time {
+                    system.sleep(((*time as u64) - (now - start_time)) as _).await;
+
+                    if stop_flag.load(Ordering::Relaxed) {
+                        break;
+                    }
+                }
+
+                match event {
+                    SmafEvent::Wave {
+                        channel,
+                        sampling_rate,
+                        data,
+                    } => {
+                        sink.play_wave(*channel, *sampling_rate, data);
+                    }
+                    SmafEvent::MidiNoteOn { channel, note, velocity } => {
+                        sink.midi_note_on(*channel, *note, *velocity);
+                        active_notes.push((*channel, *note));
+                        used_channels.insert(*channel);
+                    }
+                    SmafEvent::MidiNoteOff { channel, note, velocity } => {
+                        sink.midi_note_off(*channel, *note, *velocity);
+                        active_notes.retain(|(c, n)| !(*c == *channel && *n == *note));
+                    }
+                    SmafEvent::MidiProgramChange { channel, program } => {
+                        sink.midi_program_change(*channel, *program);
+                        used_channels.insert(*channel);
+                    }
+                    SmafEvent::MidiControlChange { channel, control, value } => {
+                        sink.midi_control_change(*channel, *control, *value);
+                        used_channels.insert(*channel);
+                    }
+                    SmafEvent::MidiPitchBend { channel, value } => {
+                        sink.midi_pitch_bend(*channel, *value);
+                        used_channels.insert(*channel);
+                    }
+                    SmafEvent::MidiSysEx(data) => {
+                        sink.midi_sysex(data);
+                    }
+                    SmafEvent::End => {}
+                }
             }
 
-            match event {
-                SmafEvent::Wave {
-                    channel,
-                    sampling_rate,
-                    data,
-                } => {
-                    sink.play_wave(*channel, *sampling_rate, data);
-                }
-                SmafEvent::MidiNoteOn { channel, note, velocity } => {
-                    sink.midi_note_on(*channel, *note, *velocity);
-                    active_notes.push((*channel, *note));
-                    used_channels.insert(*channel);
-                }
-                SmafEvent::MidiNoteOff { channel, note, velocity } => {
-                    sink.midi_note_off(*channel, *note, *velocity);
-                    active_notes.retain(|(c, n)| !(*c == *channel && *n == *note));
-                }
-                SmafEvent::MidiProgramChange { channel, program } => {
-                    sink.midi_program_change(*channel, *program);
-                    used_channels.insert(*channel);
-                }
-                SmafEvent::MidiControlChange { channel, control, value } => {
-                    sink.midi_control_change(*channel, *control, *value);
-                    used_channels.insert(*channel);
-                }
-                SmafEvent::End => {}
+            for (channel, note) in &active_notes {
+                sink.midi_note_off(*channel, *note, 0);
+            }
+
+            for channel in &used_channels {
+                sink.midi_control_change(*channel, 64, 0);
+                sink.midi_control_change(*channel, 120, 0);
+                sink.midi_control_change(*channel, 123, 0);
+            }
+
+            if !repeat || stop_flag.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, sync::Arc, vec};
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use smaf_player::SmafEvent;
+
+    use super::SmafPlayer;
+    use crate::{AudioSink, Database, DatabaseRepository, DefaultTaskRunner, Filesystem, Instant, Platform, Screen, System, canvas::Image};
+
+    struct NullDatabase;
+
+    #[async_trait::async_trait]
+    impl Database for NullDatabase {
+        async fn next_id(&self) -> u32 {
+            1
+        }
+
+        async fn add(&mut self, _data: &[u8]) -> u32 {
+            1
+        }
+
+        async fn get(&self, _id: u32) -> Option<alloc::vec::Vec<u8>> {
+            None
+        }
+
+        async fn set(&mut self, _id: u32, _data: &[u8]) -> bool {
+            true
+        }
+
+        async fn delete(&mut self, _id: u32) -> bool {
+            true
+        }
+
+        async fn get_record_ids(&self) -> alloc::vec::Vec<u32> {
+            vec![]
+        }
+    }
+
+    struct NullDatabaseRepository;
+
+    #[async_trait::async_trait]
+    impl DatabaseRepository for NullDatabaseRepository {
+        async fn open(&self, _name: &str, _app_id: &str) -> Box<dyn Database> {
+            Box::new(NullDatabase)
+        }
+
+        async fn exists(&self, _name: &str, _app_id: &str) -> bool {
+            false
+        }
+
+        async fn delete(&self, _name: &str, _app_id: &str) -> bool {
+            false
+        }
+    }
+
+    struct NullFilesystem;
+
+    #[async_trait::async_trait]
+    impl Filesystem for NullFilesystem {
+        async fn exists(&self, _aid: &str, _path: &str) -> bool {
+            false
+        }
+
+        async fn size(&self, _aid: &str, _path: &str) -> Option<usize> {
+            None
+        }
+
+        async fn read(&self, _aid: &str, _path: &str, _offset: usize, _count: usize, _buf: &mut [u8]) -> Option<usize> {
+            None
+        }
+
+        async fn write(&self, _aid: &str, _path: &str, _offset: usize, data: &[u8]) -> usize {
+            data.len()
+        }
+
+        async fn truncate(&self, _aid: &str, _path: &str, _len: usize) {}
+    }
+
+    struct NullScreen;
+
+    impl Screen for NullScreen {
+        fn request_redraw(&self) -> wie_util::Result<()> {
+            Ok(())
+        }
+
+        fn paint(&self, _image: &dyn Image) {}
+
+        fn width(&self) -> u32 {
+            240
+        }
+
+        fn height(&self) -> u32 {
+            320
+        }
+    }
+
+    struct NullPlatform {
+        screen: NullScreen,
+        database_repository: NullDatabaseRepository,
+        filesystem: NullFilesystem,
+        now: AtomicUsize,
+    }
+
+    impl NullPlatform {
+        fn new() -> Self {
+            Self {
+                screen: NullScreen,
+                database_repository: NullDatabaseRepository,
+                filesystem: NullFilesystem,
+                now: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Platform for NullPlatform {
+        fn screen(&self) -> &dyn Screen {
+            &self.screen
+        }
+
+        fn now(&self) -> Instant {
+            Instant::from_epoch_millis(self.now.fetch_add(8, Ordering::SeqCst) as u64)
+        }
+
+        fn database_repository(&self) -> &dyn DatabaseRepository {
+            &self.database_repository
+        }
+
+        fn filesystem(&self) -> &dyn Filesystem {
+            &self.filesystem
+        }
+
+        fn audio_sink(&self) -> Box<dyn AudioSink> {
+            Box::new(NoopAudioSink)
+        }
+
+        fn write_stdout(&self, _buf: &[u8]) {}
+
+        fn write_stderr(&self, _buf: &[u8]) {}
+
+        fn exit(&self) {}
+
+        fn vibrate(&self, _duration_ms: u64, _intensity: u8) {}
+    }
+
+    struct NoopAudioSink;
+
+    impl AudioSink for NoopAudioSink {
+        fn play_wave(&self, _channel: u8, _sampling_rate: u32, _wave_data: &[i16]) {}
+
+        fn midi_note_on(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
+
+        fn midi_note_off(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
+
+        fn midi_program_change(&self, _channel_id: u8, _program: u8) {}
+
+        fn midi_control_change(&self, _channel_id: u8, _control: u8, _value: u8) {}
+
+        fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {}
+
+        fn midi_sysex(&self, _data: &[u8]) {}
+    }
+
+    struct CountingSink {
+        program_change_count: Arc<AtomicUsize>,
+        stop_after: usize,
+        stop_flag: Arc<AtomicBool>,
+    }
+
+    impl AudioSink for CountingSink {
+        fn play_wave(&self, _channel: u8, _sampling_rate: u32, _wave_data: &[i16]) {}
+
+        fn midi_note_on(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
+
+        fn midi_note_off(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
+
+        fn midi_program_change(&self, _channel_id: u8, _program: u8) {
+            let count = self.program_change_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if count >= self.stop_after {
+                self.stop_flag.store(true, Ordering::SeqCst);
             }
         }
 
-        for (channel, note) in &active_notes {
-            sink.midi_note_off(*channel, *note, 0);
-        }
+        fn midi_control_change(&self, _channel_id: u8, _control: u8, _value: u8) {}
 
-        // Release sustain and force any lingering voices off on every channel
-        // this track touched. Tracks that set sustain pedal (CC 64) or use
-        // long release envelopes (e.g. drum voices) otherwise keep ringing
-        // after note_off.
-        for channel in &used_channels {
-            sink.midi_control_change(*channel, 64, 0); // sustain off
-            sink.midi_control_change(*channel, 120, 0); // all sound off
-            sink.midi_control_change(*channel, 123, 0); // all notes off
-        }
+        fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {}
+
+        fn midi_sysex(&self, _data: &[u8]) {}
+    }
+
+    fn new_system() -> System {
+        System::new(Box::new(NullPlatform::new()), "test-pid", "test-aid", DefaultTaskRunner)
+    }
+
+    #[futures_test::test]
+    async fn plays_once_when_repeat_is_false() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let sink = CountingSink {
+            program_change_count: counter.clone(),
+            stop_after: usize::MAX,
+            stop_flag: stop_flag.clone(),
+        };
+        let player = SmafPlayer {
+            events: vec![(0, SmafEvent::MidiProgramChange { channel: 0, program: 1 })],
+        };
+        let mut system = new_system();
+
+        player.play(&mut system, &sink, &stop_flag, false).await;
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[futures_test::test]
+    async fn repeats_until_stop_flag_is_set() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let sink = CountingSink {
+            program_change_count: counter.clone(),
+            stop_after: 2,
+            stop_flag: stop_flag.clone(),
+        };
+        let player = SmafPlayer {
+            events: vec![(0, SmafEvent::MidiProgramChange { channel: 0, program: 1 })],
+        };
+        let mut system = new_system();
+
+        player.play(&mut system, &sink, &stop_flag, true).await;
+
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
     }
 }

--- a/wie_cli/src/audio_sink.rs
+++ b/wie_cli/src/audio_sink.rs
@@ -50,4 +50,19 @@ impl wie_backend::AudioSink for AudioSink {
             x.lock().unwrap().send(&[0xC0 | channel_id, program]).unwrap()
         }
     }
+
+    fn midi_pitch_bend(&self, channel_id: u8, value: u16) {
+        if let Some(x) = self.midi_out.as_ref() {
+            x.lock()
+                .unwrap()
+                .send(&[0xE0 | channel_id, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8])
+                .unwrap();
+        }
+    }
+
+    fn midi_sysex(&self, data: &[u8]) {
+        if let Some(x) = self.midi_out.as_ref() {
+            x.lock().unwrap().send(data).unwrap();
+        }
+    }
 }

--- a/wie_midp/src/classes/net/wie/smaf_player.rs
+++ b/wie_midp/src/classes/net/wie/smaf_player.rs
@@ -18,6 +18,7 @@ impl SmafPlayer {
             methods: vec![
                 JavaMethodProto::new("<init>", "(Ljava/io/InputStream;)V", Self::init, Default::default()),
                 JavaMethodProto::new("start", "()V", Self::start, Default::default()),
+                JavaMethodProto::new("start", "(Z)V", Self::start_with_repeat, Default::default()),
                 JavaMethodProto::new("stop", "()V", Self::stop, Default::default()),
                 JavaMethodProto::new("close", "()V", Self::close, Default::default()),
             ],
@@ -40,13 +41,17 @@ impl SmafPlayer {
     }
 
     async fn start(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("net.wie.SmafPlayer::start({this:?})");
+        Self::start_with_repeat(jvm, context, this, false).await
+    }
+
+    async fn start_with_repeat(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, repeat: bool) -> Result<()> {
+        tracing::debug!("net.wie.SmafPlayer::start({this:?}, {repeat})");
 
         let audio_handle: i32 = jvm.get_field(&this, "audioHandle", "I").await?;
 
         let system = context.system();
 
-        system.audio().play(system, audio_handle as u32).unwrap();
+        system.audio().play(system, audio_handle as u32, repeat).unwrap();
 
         Ok(())
     }

--- a/wie_wipi_c/src/api/media.rs
+++ b/wie_wipi_c/src/api/media.rs
@@ -188,7 +188,7 @@ pub async fn play(context: &mut dyn WIPICContext, ptr_clip: WIPICWord, repeat: W
 
     let system = context.system();
 
-    let result = system.audio().play(system, clip.handle);
+    let result = system.audio().play(system, clip.handle, repeat != 0);
 
     if let Err(x) = result {
         tracing::error!("Failed to load audio: {x:?}");

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/player.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/player.rs
@@ -32,7 +32,7 @@ impl Player {
         let player = Clip::player(jvm, &clip).await?;
 
         if !player.is_null() {
-            let _: () = jvm.invoke_virtual(&player, "start", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&player, "start", "(Z)V", (repeat,)).await?;
 
             Ok(true)
         } else {


### PR DESCRIPTION
About: https://github.com/dlunch/smaf/pull/66

Wire the repeat parameter from WIPI C (MC_mdaPlay) and Java (org.kwis.msp.media.Player.play) down to the backend audio system.

SmafPlaye play now loops when repeat is true, stopping only when the stop flag is set.

Also extend AudioSink with midi_pitch_bend and midi_sysex methods to match the upstream smaf_player SmafEvent variants, and add regression tests for one-shot and looped playback.

2026.06.24 Update SMAF: `Cargo.lock` `4c4ca836`

Test Video:

https://github.com/user-attachments/assets/d82ff5fb-11d4-4b80-a45c-42be1eeac4ad
