### PR TITLE
Complete SKT API compatibility surface

### DIFF
--- a/wie_backend/src/canvas.rs
+++ b/wie_backend/src/canvas.rs
@@ -48,6 +48,7 @@ pub trait ImageBuffer: Send {
 #[allow(clippy::too_many_arguments)]
 pub trait Canvas: Send {
     fn image(&self) -> &dyn Image;
+    fn get_pixel(&self, x: i32, y: i32) -> Option<Color>;
     fn set_xor_mode(&mut self, xor_mode: bool);
     fn copy_area(&mut self, dx: i32, dy: i32, sx: i32, sy: i32, w: u32, h: u32, clip: Clip);
     fn draw(&mut self, dx: i32, dy: i32, w: u32, h: u32, src: &dyn Image, sx: i32, sy: i32, clip: Clip);
@@ -59,7 +60,9 @@ pub trait Canvas: Send {
     fn fill_rect(&mut self, x: i32, y: i32, w: u32, h: u32, color: Color, clip: Clip);
     fn fill_arc(&mut self, x: i32, y: i32, w: u32, h: u32, start_angle: i32, arc_angle: i32, color: Color, clip: Clip);
     fn fill_round_rect(&mut self, x: i32, y: i32, w: u32, h: u32, arc_width: u32, arc_height: u32, color: Color, clip: Clip);
+    fn invert_rect(&mut self, x: i32, y: i32, w: u32, h: u32, clip: Clip);
     fn put_pixel(&mut self, x: i32, y: i32, color: Color);
+    fn set_pixel(&mut self, x: i32, y: i32, color: Color, clip: Clip);
 }
 
 pub trait PixelType: Send {
@@ -371,10 +374,12 @@ where
         if x < 0 || y < 0 || (x as u32) >= self.image_buffer.width() || (y as u32) >= self.image_buffer.height() {
             return;
         }
-        if x < clip.x || x >= clip.x + clip.width as i32 || y < clip.y || y >= clip.y + clip.height as i32 {
+        let x = x as i64;
+        let y = y as i64;
+        if x < clip.x as i64 || x >= clip.x as i64 + clip.width as i64 || y < clip.y as i64 || y >= clip.y as i64 + clip.height as i64 {
             return;
         }
-        self.put_pixel(x, y, color);
+        self.put_pixel(x as i32, y as i32, color);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -485,6 +490,14 @@ where
         &self.image_buffer
     }
 
+    fn get_pixel(&self, x: i32, y: i32) -> Option<Color> {
+        if x < 0 || y < 0 || (x as u32) >= self.image_buffer.width() || (y as u32) >= self.image_buffer.height() {
+            return None;
+        }
+
+        Some(self.image_buffer.get_pixel(x, y))
+    }
+
     fn set_xor_mode(&mut self, xor_mode: bool) {
         self.xor_mode = xor_mode;
     }
@@ -533,17 +546,29 @@ where
             .min(self.image_buffer.height() as i64 - dy as i64)
             .min(src.height() as i64 - sy as i64);
 
-        for y in y_start..y_end {
-            for x in x_start..x_end {
+        if x_start >= x_end || y_start >= y_end {
+            return;
+        }
+
+        let x_step = if dx > sx { -1 } else { 1 };
+        let y_step = if dy > sy { -1 } else { 1 };
+        let mut y = if y_step < 0 { y_end - 1 } else { y_start };
+        while y >= y_start && y < y_end {
+            let mut x = if x_step < 0 { x_end - 1 } else { x_start };
+            while x >= x_start && x < x_end {
                 let px = (dx as i64 + x) as i32;
                 let py = (dy as i64 + y) as i32;
-                if px < clip.x || px >= clip.x + (clip.width as i32) || py < clip.y || py >= clip.y + (clip.height as i32) {
-                    continue;
+                if (px as i64) >= clip.x as i64
+                    && (px as i64) < clip.x as i64 + clip.width as i64
+                    && (py as i64) >= clip.y as i64
+                    && (py as i64) < clip.y as i64 + clip.height as i64
+                {
+                    self.blend_pixel(px, py, src.get_pixel((sx as i64 + x) as i32, (sy as i64 + y) as i32));
                 }
 
-                // TODO blend multiple pixels at once for performance
-                self.blend_pixel(px, py, src.get_pixel((sx as i64 + x) as i32, (sy as i64 + y) as i32));
+                x += x_step;
             }
+            y += y_step;
         }
     }
 
@@ -802,11 +827,45 @@ where
         }
     }
 
+    fn invert_rect(&mut self, x: i32, y: i32, w: u32, h: u32, clip: Clip) {
+        let image_width = self.image_buffer.width() as i64;
+        let image_height = self.image_buffer.height() as i64;
+        let x_start = (x as i64).max(clip.x as i64).max(0);
+        let y_start = (y as i64).max(clip.y as i64).max(0);
+        let x_end = (x as i64 + w as i64).min(clip.x as i64 + clip.width as i64).min(image_width);
+        let y_end = (y as i64 + h as i64).min(clip.y as i64 + clip.height as i64).min(image_height);
+
+        if x_start >= x_end || y_start >= y_end {
+            return;
+        }
+
+        for py in y_start..y_end {
+            for px in x_start..x_end {
+                let color = self.image_buffer.get_pixel(px as i32, py as i32);
+                self.image_buffer.put_pixel(
+                    px as i32,
+                    py as i32,
+                    Color {
+                        a: color.a,
+                        r: !color.r,
+                        g: !color.g,
+                        b: !color.b,
+                    },
+                );
+            }
+        }
+    }
+
     fn put_pixel(&mut self, x: i32, y: i32, color: Color) {
         self.compose_pixel(x, y, color, false);
     }
+
+    fn set_pixel(&mut self, x: i32, y: i32, color: Color, clip: Clip) {
+        self.plot(x, y, color, &clip);
+    }
 }
 
+#[derive(Clone, Copy)]
 pub struct Clip {
     pub x: i32,
     pub y: i32,
@@ -863,11 +922,12 @@ pub fn string_width(string: &str, pt_size: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use alloc::{borrow::Cow, sync::Arc, vec, vec::Vec};
+    use spin::Mutex;
 
     use wie_util::Result;
 
-    use crate::canvas::{Clip, Image, ImageBufferCanvas};
+    use crate::canvas::{Clip, Image, ImageBuffer, ImageBufferCanvas};
 
     use super::{ArgbPixel, Canvas, Color, Rgb332Pixel, TextAlignment, VecImageBuffer};
 
@@ -936,6 +996,70 @@ mod tests {
     fn assert_color(image: &dyn Image, x: i32, y: i32, expected: Color) {
         let actual = image.get_pixel(x, y);
         assert_eq!((actual.a, actual.r, actual.g, actual.b), (expected.a, expected.r, expected.g, expected.b));
+    }
+
+    #[derive(Clone)]
+    struct SharedImageBuffer {
+        width: u32,
+        height: u32,
+        pixels: Arc<Mutex<Vec<Color>>>,
+    }
+
+    impl SharedImageBuffer {
+        fn new(width: u32, pixels: Vec<Color>) -> Self {
+            Self {
+                width,
+                height: pixels.len() as u32 / width,
+                pixels: Arc::new(Mutex::new(pixels)),
+            }
+        }
+    }
+
+    impl Image for SharedImageBuffer {
+        fn width(&self) -> u32 {
+            self.width
+        }
+
+        fn height(&self) -> u32 {
+            self.height
+        }
+
+        fn bytes_per_pixel(&self) -> u32 {
+            4
+        }
+
+        fn get_pixel(&self, x: i32, y: i32) -> Color {
+            self.pixels.lock()[(y as u32 * self.width + x as u32) as usize]
+        }
+
+        fn raw(&self) -> Cow<'_, [u8]> {
+            Cow::Owned(Vec::new())
+        }
+
+        fn colors(&self) -> Vec<Color> {
+            self.pixels.lock().clone()
+        }
+    }
+
+    impl ImageBuffer for SharedImageBuffer {
+        fn put_pixel(&mut self, x: i32, y: i32, color: Color) {
+            self.pixels.lock()[(y as u32 * self.width + x as u32) as usize] = color;
+        }
+
+        fn put_pixels(&mut self, x: i32, y: i32, width: u32, colors: &[Color]) {
+            for (index, color) in colors.iter().enumerate() {
+                self.put_pixel(x + index as i32 % width as i32, y + index as i32 / width as i32, *color);
+            }
+        }
+
+        fn xor_pixel(&mut self, x: i32, y: i32, color: Color) {
+            let mut pixels = self.pixels.lock();
+            let pixel = &mut pixels[(y as u32 * self.width + x as u32) as usize];
+            pixel.r ^= color.r;
+            pixel.g ^= color.g;
+            pixel.b ^= color.b;
+            pixel.a = 255;
+        }
     }
 
     #[test]
@@ -1036,6 +1160,157 @@ mod tests {
         assert_color(canvas.image(), 1, 0, green);
         assert_color(canvas.image(), 2, 0, green);
         assert_color(canvas.image(), 3, 0, black);
+    }
+
+    #[test]
+    fn test_draw_preserves_sources_for_overlapping_copy_and_xor() {
+        let red = Color { a: 255, r: 255, g: 0, b: 0 };
+        let green = Color { a: 255, r: 0, g: 255, b: 0 };
+        let blue = Color { a: 255, r: 0, g: 0, b: 255 };
+        let black = Color { a: 255, r: 0, g: 0, b: 0 };
+
+        let shared = SharedImageBuffer::new(4, vec![red, green, blue, black]);
+        let source = shared.clone();
+        let mut canvas = ImageBufferCanvas::new(shared);
+        canvas.draw(1, 0, 3, 1, &source, 0, 0, full_clip(4));
+
+        assert_color(canvas.image(), 0, 0, red);
+        assert_color(canvas.image(), 1, 0, red);
+        assert_color(canvas.image(), 2, 0, green);
+        assert_color(canvas.image(), 3, 0, blue);
+
+        let shared = SharedImageBuffer::new(4, vec![red, green, blue, black]);
+        let source = shared.clone();
+        let mut canvas = ImageBufferCanvas::new(shared);
+        canvas.set_xor_mode(true);
+        canvas.draw(1, 0, 3, 1, &source, 0, 0, full_clip(4));
+
+        assert_color(canvas.image(), 0, 0, red);
+        assert_color(
+            canvas.image(),
+            1,
+            0,
+            Color {
+                a: 255,
+                r: 255,
+                g: 255,
+                b: 0,
+            },
+        );
+        assert_color(
+            canvas.image(),
+            2,
+            0,
+            Color {
+                a: 255,
+                r: 0,
+                g: 255,
+                b: 255,
+            },
+        );
+        assert_color(canvas.image(), 3, 0, blue);
+
+        let shared = SharedImageBuffer::new(4, vec![red, green, blue, black]);
+        let source = shared.clone();
+        let mut canvas = ImageBufferCanvas::new(shared);
+        canvas.draw(0, 0, 3, 1, &source, 1, 0, full_clip(4));
+
+        assert_color(canvas.image(), 0, 0, green);
+        assert_color(canvas.image(), 1, 0, blue);
+        assert_color(canvas.image(), 2, 0, black);
+        assert_color(canvas.image(), 3, 0, black);
+
+        let shared = SharedImageBuffer::new(2, vec![red, green, blue, black, green, red]);
+        let source = shared.clone();
+        let mut canvas = ImageBufferCanvas::new(shared);
+        canvas.draw(
+            0,
+            1,
+            2,
+            2,
+            &source,
+            0,
+            0,
+            Clip {
+                x: 0,
+                y: 0,
+                width: 2,
+                height: 3,
+            },
+        );
+
+        assert_color(canvas.image(), 0, 0, red);
+        assert_color(canvas.image(), 1, 0, green);
+        assert_color(canvas.image(), 0, 1, red);
+        assert_color(canvas.image(), 1, 1, green);
+        assert_color(canvas.image(), 0, 2, blue);
+        assert_color(canvas.image(), 1, 2, black);
+    }
+
+    #[test]
+    fn test_pixel_operations_respect_clip_and_invert_the_selected_area() {
+        let mut canvas = ImageBufferCanvas::new(VecImageBuffer::<ArgbPixel>::new(3, 1));
+        let clip = Clip {
+            x: 1,
+            y: 0,
+            width: 1,
+            height: 1,
+        };
+
+        canvas.set_pixel(0, 0, BACKGROUND, clip);
+        assert_color(canvas.image(), 0, 0, Color { a: 0, r: 0, g: 0, b: 0 });
+
+        canvas.set_pixel(1, 0, BACKGROUND, clip);
+        assert_color(canvas.image(), 1, 0, BACKGROUND);
+        assert_eq!(canvas.get_pixel(1, 0).map(|color| (color.r, color.g, color.b)), Some((0x12, 0x34, 0x56)));
+        assert!(canvas.get_pixel(3, 0).is_none());
+
+        canvas.invert_rect(0, 0, 3, 1, clip);
+        assert_color(
+            canvas.image(),
+            1,
+            0,
+            Color {
+                a: 255,
+                r: !BACKGROUND.r,
+                g: !BACKGROUND.g,
+                b: !BACKGROUND.b,
+            },
+        );
+        assert_color(canvas.image(), 2, 0, Color { a: 0, r: 0, g: 0, b: 0 });
+    }
+
+    #[test]
+    fn test_invert_rect_preserves_alpha() {
+        let mut canvas = ImageBufferCanvas::new(VecImageBuffer::<ArgbPixel>::new(3, 1));
+        for (x, alpha) in [0, 128, 255].into_iter().enumerate() {
+            canvas.put_pixel(
+                x as i32,
+                0,
+                Color {
+                    a: alpha,
+                    r: 0x12,
+                    g: 0x34,
+                    b: 0x56,
+                },
+            );
+        }
+
+        canvas.invert_rect(0, 0, 3, 1, full_clip(3));
+
+        for (x, alpha) in [0, 128, 255].into_iter().enumerate() {
+            assert_color(
+                canvas.image(),
+                x as i32,
+                0,
+                Color {
+                    a: alpha,
+                    r: !0x12,
+                    g: !0x34,
+                    b: !0x56,
+                },
+            );
+        }
     }
 
     #[test]

--- a/wie_backend/src/canvas.rs
+++ b/wie_backend/src/canvas.rs
@@ -61,8 +61,7 @@ pub trait Canvas: Send {
     fn fill_arc(&mut self, x: i32, y: i32, w: u32, h: u32, start_angle: i32, arc_angle: i32, color: Color, clip: Clip);
     fn fill_round_rect(&mut self, x: i32, y: i32, w: u32, h: u32, arc_width: u32, arc_height: u32, color: Color, clip: Clip);
     fn invert_rect(&mut self, x: i32, y: i32, w: u32, h: u32, clip: Clip);
-    fn put_pixel(&mut self, x: i32, y: i32, color: Color);
-    fn set_pixel(&mut self, x: i32, y: i32, color: Color, clip: Clip);
+    fn put_pixel(&mut self, x: i32, y: i32, color: Color, clip: Clip);
 }
 
 pub trait PixelType: Send {
@@ -379,7 +378,7 @@ where
         if x < clip.x as i64 || x >= clip.x as i64 + clip.width as i64 || y < clip.y as i64 || y >= clip.y as i64 + clip.height as i64 {
             return;
         }
-        self.put_pixel(x as i32, y as i32, color);
+        self.compose_pixel(x as i32, y as i32, color, false);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -856,11 +855,7 @@ where
         }
     }
 
-    fn put_pixel(&mut self, x: i32, y: i32, color: Color) {
-        self.compose_pixel(x, y, color, false);
-    }
-
-    fn set_pixel(&mut self, x: i32, y: i32, color: Color, clip: Clip) {
+    fn put_pixel(&mut self, x: i32, y: i32, color: Color, clip: Clip) {
         self.plot(x, y, color, &clip);
     }
 }
@@ -1122,10 +1117,10 @@ mod tests {
         let blue = Color { a: 255, r: 0, g: 0, b: 255 };
         let black = Color { a: 255, r: 0, g: 0, b: 0 };
 
-        canvas.put_pixel(0, 0, red);
-        canvas.put_pixel(1, 0, green);
-        canvas.put_pixel(2, 0, blue);
-        canvas.put_pixel(3, 0, black);
+        canvas.put_pixel(0, 0, red, full_clip(4));
+        canvas.put_pixel(1, 0, green, full_clip(4));
+        canvas.put_pixel(2, 0, blue, full_clip(4));
+        canvas.put_pixel(3, 0, black, full_clip(4));
 
         canvas.copy_area(1, 0, 0, 0, 3, 1, full_clip(4));
 
@@ -1149,10 +1144,10 @@ mod tests {
             height: 1,
         };
 
-        canvas.put_pixel(0, 0, red);
-        canvas.put_pixel(1, 0, green);
-        canvas.put_pixel(2, 0, blue);
-        canvas.put_pixel(3, 0, black);
+        canvas.put_pixel(0, 0, red, full_clip(4));
+        canvas.put_pixel(1, 0, green, full_clip(4));
+        canvas.put_pixel(2, 0, blue, full_clip(4));
+        canvas.put_pixel(3, 0, black, full_clip(4));
 
         canvas.copy_area(1, 0, 0, 0, 3, 1, clip);
 
@@ -1257,10 +1252,10 @@ mod tests {
             height: 1,
         };
 
-        canvas.set_pixel(0, 0, BACKGROUND, clip);
+        canvas.put_pixel(0, 0, BACKGROUND, clip);
         assert_color(canvas.image(), 0, 0, Color { a: 0, r: 0, g: 0, b: 0 });
 
-        canvas.set_pixel(1, 0, BACKGROUND, clip);
+        canvas.put_pixel(1, 0, BACKGROUND, clip);
         assert_color(canvas.image(), 1, 0, BACKGROUND);
         assert_eq!(canvas.get_pixel(1, 0).map(|color| (color.r, color.g, color.b)), Some((0x12, 0x34, 0x56)));
         assert!(canvas.get_pixel(3, 0).is_none());
@@ -1293,6 +1288,7 @@ mod tests {
                     g: 0x34,
                     b: 0x56,
                 },
+                full_clip(3),
             );
         }
 

--- a/wie_backend/src/system/file_system.rs
+++ b/wie_backend/src/system/file_system.rs
@@ -67,6 +67,35 @@ impl FilesystemOverlay {
         self.virtual_files.lock().insert(key, data);
     }
 
+    pub fn is_valid_path(&self, path: &str) -> bool {
+        normalize_guest_path(path).is_some()
+    }
+
+    async fn materialize_virtual(&self, normalized: &str) -> bool {
+        let filesystem = self.platform.filesystem();
+        if filesystem.exists(&self.aid, normalized).await {
+            return true;
+        }
+
+        let virtual_data = self.virtual_files.lock().get(normalized).cloned();
+        let Some(virtual_data) = virtual_data else {
+            return true;
+        };
+
+        let written = filesystem.write(&self.aid, normalized, 0, &virtual_data).await;
+        if written != virtual_data.len() {
+            tracing::warn!(
+                path = normalized,
+                expected = virtual_data.len(),
+                written,
+                "failed to materialize virtual file"
+            );
+            return false;
+        }
+
+        true
+    }
+
     pub async fn exists(&self, path: &str) -> bool {
         let Some(normalized) = normalize_guest_path(path) else {
             return false;
@@ -109,14 +138,22 @@ impl FilesystemOverlay {
         let Some(normalized) = normalize_guest_path(path) else {
             return 0;
         };
+        if !self.materialize_virtual(&normalized).await {
+            return 0;
+        }
         self.platform.filesystem().write(&self.aid, &normalized, offset, data).await
     }
 
-    pub async fn truncate(&self, path: &str, len: usize) {
+    pub async fn truncate(&self, path: &str, len: usize) -> bool {
         let Some(normalized) = normalize_guest_path(path) else {
-            return;
+            return false;
         };
-        self.platform.filesystem().truncate(&self.aid, &normalized, len).await;
+        if !self.materialize_virtual(&normalized).await {
+            return false;
+        }
+        let filesystem = self.platform.filesystem();
+        filesystem.truncate(&self.aid, &normalized, len).await;
+        filesystem.size(&self.aid, &normalized).await == Some(len)
     }
 }
 
@@ -146,6 +183,8 @@ mod tests {
     #[derive(Default)]
     struct StubFilesystem {
         files: Mutex<HashMap<(String, String), Vec<u8>>>,
+        write_limit: Option<usize>,
+        fail_truncate: bool,
     }
     #[async_trait::async_trait]
     impl Filesystem for StubFilesystem {
@@ -166,15 +205,19 @@ mod tests {
             Some(n)
         }
         async fn write(&self, aid: &str, path: &str, offset: usize, data: &[u8]) -> usize {
+            let write_len = self.write_limit.unwrap_or(data.len()).min(data.len());
             let mut files = self.files.lock();
             let file = files.entry((aid.to_string(), path.to_string())).or_default();
-            if file.len() < offset + data.len() {
-                file.resize(offset + data.len(), 0);
+            if file.len() < offset + write_len {
+                file.resize(offset + write_len, 0);
             }
-            file[offset..offset + data.len()].copy_from_slice(data);
-            data.len()
+            file[offset..offset + write_len].copy_from_slice(&data[..write_len]);
+            write_len
         }
         async fn truncate(&self, aid: &str, path: &str, len: usize) {
+            if self.fail_truncate {
+                return;
+            }
             let mut files = self.files.lock();
             let file = files.entry((aid.to_string(), path.to_string())).or_default();
             file.resize(len, 0);
@@ -207,9 +250,11 @@ mod tests {
     }
 
     fn setup() -> FilesystemOverlay {
-        let platform: Arc<Box<dyn Platform>> = Arc::new(Box::new(StubPlatform {
-            fs: StubFilesystem::default(),
-        }));
+        setup_with_filesystem(StubFilesystem::default())
+    }
+
+    fn setup_with_filesystem(fs: StubFilesystem) -> FilesystemOverlay {
+        let platform: Arc<Box<dyn Platform>> = Arc::new(Box::new(StubPlatform { fs }));
         FilesystemOverlay::new(platform, "test-aid")
     }
 
@@ -278,5 +323,46 @@ mod tests {
         let mut buf = [0u8; 4];
         assert_eq!(fs.read("cfg.dat", 0, 4, &mut buf).await, Some(4));
         assert_eq!(buf, [1, 2, 3, 4]);
+    }
+
+    #[futures_test::test]
+    async fn first_persistent_write_materializes_virtual_prefix() {
+        let fs = setup();
+        fs.add_virtual("append.dat", vec![0xAA, 0xBB]);
+
+        assert_eq!(fs.write("append.dat", 2, &[0xCC]).await, 1);
+
+        let mut buf = [0u8; 3];
+        assert_eq!(fs.read("append.dat", 0, 3, &mut buf).await, Some(3));
+        assert_eq!(buf, [0xAA, 0xBB, 0xCC]);
+    }
+
+    #[futures_test::test]
+    async fn first_persistent_truncate_materializes_virtual_data() {
+        let fs = setup();
+        fs.add_virtual("truncate.dat", vec![1, 2, 3, 4]);
+
+        assert!(fs.truncate("truncate.dat", 2).await);
+
+        let mut buf = [0u8; 2];
+        assert_eq!(fs.read("truncate.dat", 0, 2, &mut buf).await, Some(2));
+        assert_eq!(buf, [1, 2]);
+    }
+
+    #[futures_test::test]
+    async fn persistent_backend_exposes_short_writes_and_failed_truncation() {
+        let short_write_fs = setup_with_filesystem(StubFilesystem {
+            write_limit: Some(2),
+            ..Default::default()
+        });
+        assert_eq!(short_write_fs.write("short.dat", 0, &[1, 2, 3, 4]).await, 2);
+
+        let failed_truncate_fs = setup_with_filesystem(StubFilesystem {
+            fail_truncate: true,
+            ..Default::default()
+        });
+        assert_eq!(failed_truncate_fs.write("truncate.dat", 0, &[1, 2, 3, 4]).await, 4);
+        assert!(!failed_truncate_fs.truncate("truncate.dat", 2).await);
+        assert_eq!(failed_truncate_fs.size("truncate.dat").await, Some(4));
     }
 }

--- a/wie_jvm_support/src/runtime/file.rs
+++ b/wie_jvm_support/src/runtime/file.rs
@@ -48,6 +48,9 @@ impl File for FileImpl {
 
         let cursor = self.cursor.load(Ordering::SeqCst) as usize;
         let written = self.system.filesystem().write(&self.path, cursor, buf).await;
+        if written != buf.len() {
+            return Err(IOError::Io);
+        }
 
         self.cursor.fetch_add(written as u64, Ordering::SeqCst);
 
@@ -69,7 +72,9 @@ impl File for FileImpl {
             return Err(IOError::Unsupported);
         }
 
-        self.system.filesystem().truncate(&self.path, len as usize).await;
+        if !self.system.filesystem().truncate(&self.path, len as usize).await {
+            return Err(IOError::Io);
+        }
 
         Ok(())
     }
@@ -210,5 +215,15 @@ mod tests {
             Err(IOError::NotFound)
         ));
         assert!(matches!(FileImpl::new(system, "", false).await, Err(IOError::NotFound)));
+    }
+
+    #[futures_test::test]
+    async fn failed_writes_and_truncation_report_io_without_advancing_the_cursor() {
+        let system = new_system();
+        let mut file = FileImpl::new(system, "../escape.dat", true).await.unwrap();
+
+        assert!(matches!(file.write(&[1, 2, 3]).await, Err(IOError::Io)));
+        assert_eq!(file.tell().await.unwrap(), 0);
+        assert!(matches!(file.set_len(3).await, Err(IOError::Io)));
     }
 }

--- a/wie_skvm/src/classes/com/skt.rs
+++ b/wie_skvm/src/classes/com/skt.rs
@@ -1,1 +1,2 @@
 pub mod m;
+pub mod m3d;

--- a/wie_skvm/src/classes/com/skt/m.rs
+++ b/wie_skvm/src/classes/com/skt/m.rs
@@ -1,14 +1,24 @@
 mod audio_clip;
 mod audio_system;
 mod back_light;
+mod call;
 mod device;
 mod graphics_2d;
 mod math_fp;
+mod phone_book;
 mod progress_bar;
+mod resource_alloc_exception;
+mod sis_image;
+mod sms;
+mod sms_listener;
+mod sms_message;
 mod unsupported_format_exception;
+mod user_stop_exception;
 mod vibration;
 
 pub use {
-    audio_clip::AudioClip, audio_system::AudioSystem, back_light::BackLight, device::Device, graphics_2d::Graphics2D, math_fp::MathFP,
-    progress_bar::ProgressBar, unsupported_format_exception::UnsupportedFormatException, vibration::Vibration,
+    audio_clip::AudioClip, audio_system::AudioSystem, back_light::BackLight, call::Call, device::Device, graphics_2d::Graphics2D, math_fp::MathFP,
+    phone_book::PhoneBook, progress_bar::ProgressBar, resource_alloc_exception::ResourceAllocException, sis_image::SISImage, sms::SMS,
+    sms_listener::SMSListener, sms_message::SMSMessage, unsupported_format_exception::UnsupportedFormatException,
+    user_stop_exception::UserStopException, vibration::Vibration,
 };

--- a/wie_skvm/src/classes/com/skt/m/audio_clip.rs
+++ b/wie_skvm/src/classes/com/skt/m/audio_clip.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
 
-use java_constants::ClassAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use wie_jvm_support::WieJavaClassProto;
 
 // interface com.skt.m.AudioClip
@@ -14,9 +14,17 @@ impl AudioClip {
             name: "com/skt/m/AudioClip",
             parent_class: None,
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new_abstract("play", "()V", Default::default())],
+            methods: vec![
+                JavaMethodProto::new_abstract("open", "([BII)V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("close", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("loop", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("pause", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("play", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("resume", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("stop", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+            ],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_skvm/src/classes/com/skt/m/audio_system.rs
+++ b/wie_skvm/src/classes/com/skt/m/audio_system.rs
@@ -1,9 +1,9 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
@@ -23,40 +23,136 @@ impl AudioSystem {
                     "getAudioClip",
                     "(Ljava/lang/String;)Lcom/skt/m/AudioClip;",
                     Self::get_audio_clip,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("getMaxVolume", "(Ljava/lang/String;)I", Self::get_max_volume, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getVolume", "(Ljava/lang/String;)I", Self::get_volume, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("setVolume", "(Ljava/lang/String;I)V", Self::set_volume, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "getClipFormats",
+                    "()[Ljava/lang/String;",
+                    Self::get_clip_formats,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "getMaxVolume",
+                    "(Ljava/lang/String;)I",
+                    Self::get_max_volume,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "getVolume",
+                    "(Ljava/lang/String;)I",
+                    Self::get_volume,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "setVolume",
+                    "(Ljava/lang/String;I)V",
+                    Self::set_volume,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
     }
 
     async fn get_audio_clip(jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<ClassInstanceRef<AudioClip>> {
         tracing::debug!("com.skt.m.AudioSystem::getAudioClip({name:?})");
 
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "format is null").await);
+        }
+
         let audio_clip = jvm.new_class("net/wie/WieAudioClip", "(Ljava/lang/String;)V", (name,)).await?;
 
         Ok(audio_clip.into())
     }
 
-    async fn get_max_volume(_jvm: &Jvm, _context: &mut WieJvmContext, format: ClassInstanceRef<String>) -> JvmResult<i32> {
+    async fn get_clip_formats(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Array<String>>> {
+        tracing::warn!("stub com.skt.m.AudioSystem::getClipFormats()");
+
+        Ok(jvm.instantiate_array("Ljava/lang/String;", 0).await?.into())
+    }
+
+    async fn get_max_volume(jvm: &Jvm, _context: &mut WieJvmContext, format: ClassInstanceRef<String>) -> JvmResult<i32> {
         tracing::warn!("stub com.skt.m.AudioSystem::getMaxVolume({format:?})");
 
+        if format.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "format is null").await);
+        }
+
         Ok(0)
     }
 
-    async fn get_volume(_jvm: &Jvm, _context: &mut WieJvmContext, format: ClassInstanceRef<String>) -> JvmResult<i32> {
+    async fn get_volume(jvm: &Jvm, _context: &mut WieJvmContext, format: ClassInstanceRef<String>) -> JvmResult<i32> {
         tracing::warn!("stub com.skt.m.AudioSystem::getVolume({format:?})");
 
+        if format.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "format is null").await);
+        }
+
         Ok(0)
     }
 
-    async fn set_volume(_jvm: &Jvm, _context: &mut WieJvmContext, format: ClassInstanceRef<String>, level: i32) -> JvmResult<()> {
+    async fn set_volume(jvm: &Jvm, _context: &mut WieJvmContext, format: ClassInstanceRef<String>, level: i32) -> JvmResult<()> {
         tracing::warn!("stub com.skt.m.AudioSystem::setVolume({format:?}, {level})");
 
+        if format.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "format is null").await);
+        }
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, JavaError, Result as JvmResult};
+    use test_utils::run_jvm_test;
+
+    use crate::{classes::com::skt::m::AudioClip, get_protos};
+
+    #[test]
+    fn audio_system_rejects_null_format_arguments() {
+        let result = run_jvm_test(Box::new([wie_midp::get_protos().into(), get_protos().into()]), |jvm| async move {
+            let null_format = ClassInstanceRef::<String>::new(None);
+
+            let clip_result: JvmResult<ClassInstanceRef<AudioClip>> = jvm
+                .invoke_static(
+                    "com/skt/m/AudioSystem",
+                    "getAudioClip",
+                    "(Ljava/lang/String;)Lcom/skt/m/AudioClip;",
+                    (null_format.clone(),),
+                )
+                .await;
+            let Err(JavaError::JavaException(exception)) = clip_result else {
+                panic!("AudioSystem.getAudioClip accepted a null format");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+            for method in ["getMaxVolume", "getVolume"] {
+                let volume_result: JvmResult<i32> = jvm
+                    .invoke_static("com/skt/m/AudioSystem", method, "(Ljava/lang/String;)I", (null_format.clone(),))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = volume_result else {
+                    panic!("AudioSystem.{method} accepted a null format");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+            }
+
+            let set_result: JvmResult<()> = jvm
+                .invoke_static("com/skt/m/AudioSystem", "setVolume", "(Ljava/lang/String;I)V", (null_format, 0))
+                .await;
+            let Err(JavaError::JavaException(exception)) = set_result else {
+                panic!("AudioSystem.setVolume accepted a null format");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+            Ok(())
+        });
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
     }
 }

--- a/wie_skvm/src/classes/com/skt/m/back_light.rs
+++ b/wie_skvm/src/classes/com/skt/m/back_light.rs
@@ -1,8 +1,8 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
-use jvm::{Jvm, Result as JvmResult};
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
@@ -15,14 +15,61 @@ impl BackLight {
             name: "com/skt/m/BackLight",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("on", "(I)V", Self::on, MethodAccessFlags::STATIC)],
+            methods: vec![
+                JavaMethodProto::new("getColor", "()I", Self::get_color, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "getColorNum",
+                    "()I",
+                    Self::get_color_num,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "getColors",
+                    "()[I",
+                    Self::get_colors,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("off", "()V", Self::off, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("on", "(I)V", Self::on, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("setColor", "(I)V", Self::set_color, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+            ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
+    }
+
+    async fn get_color(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.BackLight::getColor()");
+
+        Ok(0)
+    }
+
+    async fn get_color_num(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.BackLight::getColorNum()");
+
+        Ok(0)
+    }
+
+    async fn get_colors(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Array<i32>>> {
+        tracing::warn!("stub com.skt.m.BackLight::getColors()");
+
+        Ok(jvm.instantiate_array("I", 0).await?.into())
+    }
+
+    async fn off(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.BackLight::off()");
+
+        Ok(())
     }
 
     async fn on(_jvm: &Jvm, _: &mut WieJvmContext, timeout: i32) -> JvmResult<()> {
         tracing::warn!("stub com.skt.m.BackLight::on({timeout:?})");
+
+        Ok(())
+    }
+
+    async fn set_color(_jvm: &Jvm, _context: &mut WieJvmContext, index: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.BackLight::setColor({index})");
 
         Ok(())
     }

--- a/wie_skvm/src/classes/com/skt/m/call.rs
+++ b/wie_skvm/src/classes/com/skt/m/call.rs
@@ -1,0 +1,61 @@
+use alloc::vec;
+
+use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+// class com.skt.m.Call
+pub struct Call;
+
+impl Call {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "com/skt/m/Call",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new(
+                    "connect",
+                    "(Ljava/lang/String;)Z",
+                    Self::connect,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "disconnect",
+                    "()Z",
+                    Self::disconnect,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "isSupported",
+                    "()Z",
+                    Self::is_supported,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+            ],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
+        }
+    }
+
+    async fn connect(_jvm: &Jvm, _context: &mut WieJvmContext, phone_number: ClassInstanceRef<String>) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Call::connect({phone_number:?})");
+
+        Ok(false)
+    }
+
+    async fn disconnect(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Call::disconnect()");
+
+        Ok(false)
+    }
+
+    async fn is_supported(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Call::isSupported()");
+
+        Ok(false)
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/device.rs
+++ b/wie_skvm/src/classes/com/skt/m/device.rs
@@ -1,8 +1,9 @@
 use alloc::vec;
 
-use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
-use jvm::{Jvm, Result as JvmResult};
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
@@ -16,16 +17,141 @@ impl Device {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("setColorMode", "(I)V", Self::set_color_mode, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("isBacklightEnabled", "()Z", Self::is_backlight_enabled, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("setBacklightEnabled", "(Z)V", Self::set_backlight_enabled, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("setKeyToneEnabled", "(Z)V", Self::set_key_tone_enabled, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("enableRestoreLCD", "(Z)V", Self::enable_restore_lcd, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("setKeyRepeatTime", "(II)V", Self::set_key_repeat_time, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "setBacklightEnabled",
+                    "(Z)V",
+                    Self::set_backlight_enabled,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "isBacklightEnabled",
+                    "()Z",
+                    Self::is_backlight_enabled,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "setKeyToneEnabled",
+                    "(Z)V",
+                    Self::set_key_tone_enabled,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "isKeyToneEnabled",
+                    "()Z",
+                    Self::is_key_tone_enabled,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("beep", "(II)V", Self::beep, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "invokeWapBrowser",
+                    "(Ljava/lang/String;)V",
+                    Self::invoke_wap_browser,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "enableRestoreLCD",
+                    "(Z)V",
+                    Self::enable_restore_lcd,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "setKeyRepeatTime",
+                    "(II)V",
+                    Self::set_key_repeat_time,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "setColorMode",
+                    "(I)V",
+                    Self::set_color_mode,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "setSISImage",
+                    "(ILjava/lang/String;[B)Z",
+                    Self::set_sis_image,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "setMelody",
+                    "(ILjava/lang/String;[B)Z",
+                    Self::set_melody,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("setNAI", "(I)V", Self::set_nai, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
             ],
-            fields: vec![],
-            access_flags: Default::default(),
+            fields: vec![
+                JavaFieldProto::new(
+                    "COLOR_MODE_4G",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "COLOR_MODE_256C",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "COLOR_MODE_64KC",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIS_NORMAL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIS_CALL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIS_WAP",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIS_PWR_ON",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIS_PWR_OFF",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "MELODY_MYBELL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "MELODY_MUSICBELL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.Device::<clinit>()");
+
+        jvm.put_static_field("com/skt/m/Device", "COLOR_MODE_4G", "I", 0).await?;
+        jvm.put_static_field("com/skt/m/Device", "COLOR_MODE_256C", "I", 1).await?;
+        jvm.put_static_field("com/skt/m/Device", "COLOR_MODE_64KC", "I", 2).await?;
+        jvm.put_static_field("com/skt/m/Device", "SIS_NORMAL", "I", 3).await?;
+        jvm.put_static_field("com/skt/m/Device", "SIS_CALL", "I", 4).await?;
+        jvm.put_static_field("com/skt/m/Device", "SIS_WAP", "I", 5).await?;
+        jvm.put_static_field("com/skt/m/Device", "SIS_PWR_ON", "I", 6).await?;
+        jvm.put_static_field("com/skt/m/Device", "SIS_PWR_OFF", "I", 7).await?;
+        jvm.put_static_field("com/skt/m/Device", "MELODY_MYBELL", "I", 8).await?;
+        jvm.put_static_field("com/skt/m/Device", "MELODY_MUSICBELL", "I", 9).await?;
+
+        Ok(())
     }
 
     async fn set_color_mode(_jvm: &Jvm, _context: &mut WieJvmContext, mode: i32) -> JvmResult<()> {
@@ -52,6 +178,24 @@ impl Device {
         Ok(())
     }
 
+    async fn is_key_tone_enabled(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Device::isKeyToneEnabled()");
+
+        Ok(true)
+    }
+
+    async fn beep(_jvm: &Jvm, _context: &mut WieJvmContext, frequency: i32, duration: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.Device::beep({frequency}, {duration})");
+
+        Ok(())
+    }
+
+    async fn invoke_wap_browser(_jvm: &Jvm, _context: &mut WieJvmContext, url: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.Device::invokeWapBrowser({url:?})");
+
+        Ok(())
+    }
+
     async fn enable_restore_lcd(_jvm: &Jvm, _context: &mut WieJvmContext, enabled: bool) -> JvmResult<()> {
         tracing::warn!("stub com.skt.m.Device::enableRestoreLCD({enabled:?})");
 
@@ -62,5 +206,75 @@ impl Device {
         tracing::warn!("stub com.skt.m.Device::setKeyRepeatTime({delay}, {interval})");
 
         Ok(())
+    }
+
+    async fn set_sis_image(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        image_type: i32,
+        name: ClassInstanceRef<String>,
+        data: ClassInstanceRef<Array<i8>>,
+    ) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Device::setSISImage({image_type}, {name:?}, {data:?})");
+
+        Ok(false)
+    }
+
+    async fn set_melody(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        melody_type: i32,
+        name: ClassInstanceRef<String>,
+        data: ClassInstanceRef<Array<i8>>,
+    ) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Device::setMelody({melody_type}, {name:?}, {data:?})");
+
+        Ok(false)
+    }
+
+    async fn set_nai(_jvm: &Jvm, _context: &mut WieJvmContext, nai: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.Device::setNAI({nai})");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{Array, ClassInstanceRef, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use crate::classes::com::skt::m::Call;
+
+    use super::Device;
+
+    #[test]
+    fn unsupported_call_and_device_install_operations_report_failure() {
+        run_jvm_test(Box::new([[Device::as_proto(), Call::as_proto()].into()]), |jvm| async move {
+            let phone_number: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "01012345678").await?.into();
+            let connected: bool = jvm
+                .invoke_static("com/skt/m/Call", "connect", "(Ljava/lang/String;)Z", (phone_number,))
+                .await?;
+            assert!(!connected);
+
+            let disconnected: bool = jvm.invoke_static("com/skt/m/Call", "disconnect", "()Z", ()).await?;
+            assert!(!disconnected);
+
+            let call_supported: bool = jvm.invoke_static("com/skt/m/Call", "isSupported", "()Z", ()).await?;
+            assert!(!call_supported);
+
+            let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "standby.sis").await?.into();
+            let data: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 3).await?.into();
+            let installed: bool = jvm
+                .invoke_static("com/skt/m/Device", "setSISImage", "(ILjava/lang/String;[B)Z", (0, name, data))
+                .await?;
+            assert!(!installed);
+
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/wie_skvm/src/classes/com/skt/m/graphics_2d.rs
+++ b/wie_skvm/src/classes/com/skt/m/graphics_2d.rs
@@ -1,10 +1,10 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
-use wie_backend::canvas::Clip;
+use wie_backend::canvas::{PixelType, Rgb8Pixel};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 use wie_midp::classes::javax::microedition::lcdui::{Graphics, Image};
 
@@ -12,47 +12,77 @@ use wie_midp::classes::javax::microedition::lcdui::{Graphics, Image};
 pub struct Graphics2D;
 
 impl Graphics2D {
+    const DRAW_COPY: i32 = 0;
+    const DRAW_AND: i32 = 1;
+    const DRAW_OR: i32 = 2;
+    const DRAW_XOR: i32 = 3;
+
     pub fn as_proto() -> WieJavaClassProto {
+        let public = MethodAccessFlags::PUBLIC;
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+        let public_static_field = FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL;
+
         WieJavaClassProto {
             name: "com/skt/m/Graphics2D",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Graphics;)V", Self::init, Default::default()),
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Graphics;)V", Self::init, MethodAccessFlags::PRIVATE),
                 JavaMethodProto::new(
                     "getGraphics2D",
                     "(Ljavax/microedition/lcdui/Graphics;)Lcom/skt/m/Graphics2D;",
                     Self::get_graphics2d,
-                    MethodAccessFlags::STATIC,
+                    public_static,
                 ),
-                JavaMethodProto::new(
-                    "captureLCD",
-                    "(IIII)Ljavax/microedition/lcdui/Image;",
-                    Self::capture_lcd,
-                    MethodAccessFlags::STATIC,
-                ),
-                JavaMethodProto::new(
-                    "drawImage",
-                    "(IILjavax/microedition/lcdui/Image;IIIII)V",
-                    Self::draw_image,
-                    Default::default(),
-                ),
+                JavaMethodProto::new("captureLCD", "(IIII)Ljavax/microedition/lcdui/Image;", Self::capture_lcd, public_static),
+                JavaMethodProto::new("drawImage", "(IILjavax/microedition/lcdui/Image;IIIII)V", Self::draw_image, public),
                 JavaMethodProto::new(
                     "createMaskableImage",
                     "(II)Ljavax/microedition/lcdui/Image;",
                     Self::create_maskable_image,
-                    MethodAccessFlags::STATIC,
+                    public_static,
                 ),
+                JavaMethodProto::new("getPixel", "(II)I", Self::get_pixel, public),
+                JavaMethodProto::new("getPixelMask", "(II)Z", Self::get_pixel_mask, public),
+                JavaMethodProto::new("invertRect", "(IIII)V", Self::invert_rect, public),
+                JavaMethodProto::new("setPixel", "(III)V", Self::set_pixel, public),
+                JavaMethodProto::new("setPixelMask", "(IIZ)V", Self::set_pixel_mask, public),
             ],
-            fields: vec![JavaFieldProto::new("graphics", "Ljavax/microedition/lcdui/Graphics;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![
+                JavaFieldProto::new("DRAW_COPY", "I", public_static_field),
+                JavaFieldProto::new("DRAW_AND", "I", public_static_field),
+                JavaFieldProto::new("DRAW_OR", "I", public_static_field),
+                JavaFieldProto::new("DRAW_XOR", "I", public_static_field),
+                JavaFieldProto::new("graphics", "Ljavax/microedition/lcdui/Graphics;", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.Graphics2D::<clinit>()");
+
+        for (name, value) in [
+            ("DRAW_COPY", Self::DRAW_COPY),
+            ("DRAW_AND", Self::DRAW_AND),
+            ("DRAW_OR", Self::DRAW_OR),
+            ("DRAW_XOR", Self::DRAW_XOR),
+        ] {
+            jvm.put_static_field("com/skt/m/Graphics2D", name, "I", value).await?;
+        }
+
+        Ok(())
     }
 
     async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, graphics: ClassInstanceRef<Graphics>) -> JvmResult<()> {
         tracing::debug!("com.skt.m.Graphics2D::<init>({this:?}, {graphics:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
 
         jvm.put_field(&mut this, "graphics", "Ljavax/microedition/lcdui/Graphics;", graphics)
             .await?;
@@ -63,6 +93,10 @@ impl Graphics2D {
     async fn get_graphics2d(jvm: &Jvm, _context: &mut WieJvmContext, graphics: ClassInstanceRef<Graphics>) -> JvmResult<ClassInstanceRef<Self>> {
         tracing::debug!("com.skt.m.Graphics2D::getGraphics2D({graphics:?})");
 
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
         let instance = jvm
             .new_class("com/skt/m/Graphics2D", "(Ljavax/microedition/lcdui/Graphics;)V", (graphics,))
             .await?;
@@ -72,6 +106,12 @@ impl Graphics2D {
 
     async fn capture_lcd(jvm: &Jvm, _context: &mut WieJvmContext, x: i32, y: i32, width: i32, height: i32) -> JvmResult<ClassInstanceRef<Image>> {
         tracing::warn!("stub com.skt.m.Graphics2D::captureLCD({x}, {y}, {width}, {height})");
+
+        if width <= 0 || height <= 0 {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "width and height must be positive")
+                .await);
+        }
 
         let image: ClassInstanceRef<Image> = jvm
             .invoke_static(
@@ -105,26 +145,48 @@ impl Graphics2D {
             return Err(jvm.exception("java/lang/NullPointerException", "img is null").await);
         }
 
+        if ![Self::DRAW_COPY, Self::DRAW_AND, Self::DRAW_OR, Self::DRAW_XOR].contains(&mode) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "invalid draw mode").await);
+        }
+
+        if sw < 0 || sh < 0 {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "width and height must not be negative")
+                .await);
+        }
+
+        if sw == 0 || sh == 0 {
+            return Ok(());
+        }
+
+        if mode == Self::DRAW_AND || mode == Self::DRAW_OR {
+            tracing::warn!("stub com.skt.m.Graphics2D::drawImage unsupported mode {mode}");
+            return Ok(());
+        }
+
         let mut graphics: ClassInstanceRef<Graphics> = jvm.get_field(&this, "graphics", "Ljavax/microedition/lcdui/Graphics;").await?;
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        let translate_x: i32 = jvm.get_field(&graphics, "translateX", "I").await?;
+        let translate_y: i32 = jvm.get_field(&graphics, "translateY", "I").await?;
+        let clip = Graphics::clip(jvm, &graphics).await?;
         let src_image = Image::image(jvm, &src).await?;
 
         let image = Graphics::image(jvm, &mut graphics).await?;
         let mut canvas = Image::canvas(jvm, &image).await?;
+        canvas.set_xor_mode(mode == Self::DRAW_XOR);
 
         canvas.draw(
-            tx as _,
-            ty as _,
+            tx.wrapping_add(translate_x),
+            ty.wrapping_add(translate_y),
             sw as _,
             sh as _,
             &*src_image,
             sx,
             sy,
-            Clip {
-                x: tx,
-                y: ty,
-                width: sw as _,
-                height: sh as _,
-            },
+            clip,
         );
 
         Ok(())
@@ -132,6 +194,12 @@ impl Graphics2D {
 
     async fn create_maskable_image(jvm: &Jvm, _context: &mut WieJvmContext, width: i32, height: i32) -> JvmResult<ClassInstanceRef<Image>> {
         tracing::debug!("com.skt.m.Graphics2D::createMaskableImage({width}, {height})");
+
+        if width <= 0 || height <= 0 {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "width and height must be positive")
+                .await);
+        }
 
         let image: ClassInstanceRef<Image> = jvm
             .invoke_static(
@@ -143,5 +211,341 @@ impl Graphics2D {
             .await?;
 
         Ok(image)
+    }
+
+    async fn get_pixel(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32) -> JvmResult<i32> {
+        tracing::debug!("com.skt.m.Graphics2D::getPixel({this:?}, {x}, {y})");
+
+        let mut graphics: ClassInstanceRef<Graphics> = jvm.get_field(&this, "graphics", "Ljavax/microedition/lcdui/Graphics;").await?;
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        let translate_x: i32 = jvm.get_field(&graphics, "translateX", "I").await?;
+        let translate_y: i32 = jvm.get_field(&graphics, "translateY", "I").await?;
+        let image = Graphics::image(jvm, &mut graphics).await?;
+        let canvas = Image::canvas(jvm, &image).await?;
+
+        Ok(canvas
+            .get_pixel(x.wrapping_add(translate_x), y.wrapping_add(translate_y))
+            .map(|color| ((color.r as i32) << 16) | ((color.g as i32) << 8) | color.b as i32)
+            .unwrap_or(0))
+    }
+
+    async fn get_pixel_mask(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.Graphics2D::getPixelMask({this:?}, {x}, {y})");
+        Ok(false)
+    }
+
+    async fn invert_rect(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.Graphics2D::invertRect({this:?}, {x}, {y}, {width}, {height})");
+
+        if width < 0 || height < 0 {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "width and height must not be negative")
+                .await);
+        }
+
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let mut graphics: ClassInstanceRef<Graphics> = jvm.get_field(&this, "graphics", "Ljavax/microedition/lcdui/Graphics;").await?;
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        let translate_x: i32 = jvm.get_field(&graphics, "translateX", "I").await?;
+        let translate_y: i32 = jvm.get_field(&graphics, "translateY", "I").await?;
+        let clip = Graphics::clip(jvm, &graphics).await?;
+        let image = Graphics::image(jvm, &mut graphics).await?;
+        let mut canvas = Image::canvas(jvm, &image).await?;
+        canvas.invert_rect(
+            x.wrapping_add(translate_x),
+            y.wrapping_add(translate_y),
+            width as u32,
+            height as u32,
+            clip,
+        );
+
+        Ok(())
+    }
+
+    async fn set_pixel(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32, color: i32) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.Graphics2D::setPixel({this:?}, {x}, {y}, {color})");
+
+        let mut graphics: ClassInstanceRef<Graphics> = jvm.get_field(&this, "graphics", "Ljavax/microedition/lcdui/Graphics;").await?;
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        let translate_x: i32 = jvm.get_field(&graphics, "translateX", "I").await?;
+        let translate_y: i32 = jvm.get_field(&graphics, "translateY", "I").await?;
+        let clip = Graphics::clip(jvm, &graphics).await?;
+        let image = Graphics::image(jvm, &mut graphics).await?;
+        let mut canvas = Image::canvas(jvm, &image).await?;
+        canvas.set_pixel(
+            x.wrapping_add(translate_x),
+            y.wrapping_add(translate_y),
+            Rgb8Pixel::to_color(color as u32),
+            clip,
+        );
+
+        Ok(())
+    }
+
+    async fn set_pixel_mask(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32, mask: bool) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.Graphics2D::setPixelMask({this:?}, {x}, {y}, {mask})");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use jvm::{Array, ClassInstanceRef, JavaError, Result as JvmResult};
+    use test_utils::run_jvm_test;
+
+    use wie_midp::classes::javax::microedition::lcdui::{Graphics, Image};
+
+    use crate::classes::com::skt::m::SISImage;
+
+    use super::Graphics2D;
+
+    #[test]
+    fn graphics_2d_copy_xor_clip_and_pixel_operations_use_the_target_canvas() {
+        run_jvm_test(
+            Box::new([wie_midp::get_protos().into(), [Graphics2D::as_proto()].into()]),
+            |jvm| async move {
+                let target: ClassInstanceRef<Image> = jvm
+                    .invoke_static(
+                        "javax/microedition/lcdui/Image",
+                        "createImage",
+                        "(II)Ljavax/microedition/lcdui/Image;",
+                        (4, 1),
+                    )
+                    .await?;
+                let graphics: ClassInstanceRef<Graphics> = jvm
+                    .invoke_virtual(&target, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .await?;
+                let graphics_2d: ClassInstanceRef<Graphics2D> = jvm
+                    .invoke_static(
+                        "com/skt/m/Graphics2D",
+                        "getGraphics2D",
+                        "(Ljavax/microedition/lcdui/Graphics;)Lcom/skt/m/Graphics2D;",
+                        (graphics.clone(),),
+                    )
+                    .await?;
+
+                let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (1, 0)).await?;
+                let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, 2, 1)).await?;
+                let _: () = jvm.invoke_virtual(&graphics_2d, "setPixel", "(III)V", (0, 0, 0x123456)).await?;
+                let _: () = jvm.invoke_virtual(&graphics_2d, "setPixel", "(III)V", (2, 0, 0xffffff)).await?;
+                let pixel: i32 = jvm.invoke_virtual(&graphics_2d, "getPixel", "(II)I", (0, 0)).await?;
+                assert_eq!(pixel, 0x123456);
+
+                let source: ClassInstanceRef<Image> = jvm
+                    .invoke_static(
+                        "javax/microedition/lcdui/Image",
+                        "createImage",
+                        "(II)Ljavax/microedition/lcdui/Image;",
+                        (2, 1),
+                    )
+                    .await?;
+                let source_graphics: ClassInstanceRef<Graphics> = jvm
+                    .invoke_virtual(&source, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .await?;
+                let _: () = jvm.invoke_virtual(&source_graphics, "setColor", "(I)V", (0xf00faa,)).await?;
+                let _: () = jvm.invoke_virtual(&source_graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
+                let _: () = jvm.invoke_virtual(&source_graphics, "setColor", "(I)V", (0xabcdef,)).await?;
+                let _: () = jvm.invoke_virtual(&source_graphics, "fillRect", "(IIII)V", (1, 0, 1, 1)).await?;
+
+                let copy_mode: i32 = jvm.get_static_field("com/skt/m/Graphics2D", "DRAW_COPY", "I").await?;
+                let xor_mode: i32 = jvm.get_static_field("com/skt/m/Graphics2D", "DRAW_XOR", "I").await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics_2d,
+                        "drawImage",
+                        "(IILjavax/microedition/lcdui/Image;IIIII)V",
+                        (0, 0, source.clone(), 0, 0, 2, 1, copy_mode),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics_2d,
+                        "drawImage",
+                        "(IILjavax/microedition/lcdui/Image;IIIII)V",
+                        (0, 0, source, 0, 0, 1, 1, xor_mode),
+                    )
+                    .await?;
+
+                let target_image = Image::image(&jvm, &target).await?;
+                let untouched = target_image.get_pixel(0, 0);
+                assert_eq!((untouched.r, untouched.g, untouched.b), (0, 0, 0));
+                let xored = target_image.get_pixel(1, 0);
+                assert_eq!((xored.r, xored.g, xored.b), (0, 0, 0));
+                let copied = target_image.get_pixel(2, 0);
+                assert_eq!((copied.r, copied.g, copied.b), (0xab, 0xcd, 0xef));
+                let clipped = target_image.get_pixel(3, 0);
+                assert_eq!((clipped.r, clipped.g, clipped.b), (0, 0, 0));
+
+                let _: () = jvm.invoke_virtual(&graphics_2d, "invertRect", "(IIII)V", (0, 0, 4, 1)).await?;
+                let target_image = Image::image(&jvm, &target).await?;
+                let inverted = target_image.get_pixel(1, 0);
+                assert_eq!((inverted.r, inverted.g, inverted.b), (0xff, 0xff, 0xff));
+                let outside_clip = target_image.get_pixel(3, 0);
+                assert_eq!((outside_clip.r, outside_clip.g, outside_clip.b), (0, 0, 0));
+
+                let _: () = jvm.invoke_virtual(&graphics_2d, "invertRect", "(IIII)V", (0, 0, 0, 1)).await?;
+                let negative_size: JvmResult<()> = jvm.invoke_virtual(&graphics_2d, "invertRect", "(IIII)V", (0, 0, -1, 1)).await;
+                let Err(JavaError::JavaException(exception)) = negative_size else {
+                    panic!("Graphics2D.invertRect accepted a negative width");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn sis_image_placeholder_validates_ranges_and_paints_without_panicking() {
+        run_jvm_test(
+            Box::new([wie_midp::get_protos().into(), [SISImage::as_proto()].into()]),
+            |jvm| async move {
+                let mut data: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 3).await?.into();
+                jvm.store_array(&mut data, 0, [1i8, 2, 3]).await?;
+
+                let _: () = jvm.invoke_static("com/skt/m/SISImage", "createBuffer", "(II)V", (1, 1)).await?;
+                for sizes in [(0, 1), (1, 0)] {
+                    let invalid_size: JvmResult<()> = jvm.invoke_static("com/skt/m/SISImage", "createBuffer", "(II)V", sizes).await;
+                    let Err(JavaError::JavaException(exception)) = invalid_size else {
+                        panic!("SISImage.createBuffer accepted a zero buffer size");
+                    };
+                    assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+                }
+
+                let required: i32 = jvm
+                    .invoke_static("com/skt/m/SISImage", "getRequiredBufferSize", "([BII)I", (data.clone(), 1, 2))
+                    .await?;
+                assert_eq!(required, 0);
+
+                let sis_image: ClassInstanceRef<SISImage> = jvm
+                    .invoke_static("com/skt/m/SISImage", "createSISImage", "([BII)Lcom/skt/m/SISImage;", (data.clone(), 0, 3))
+                    .await?;
+                let max_frame_id: i32 = jvm.invoke_virtual(&sis_image, "getMaxFrameID", "()I", ()).await?;
+                let max_object_id: i32 = jvm.invoke_virtual(&sis_image, "getMaxObjectID", "()I", ()).await?;
+                assert_eq!((max_frame_id, max_object_id), (0, 0));
+
+                let frame: ClassInstanceRef<Image> = jvm
+                    .invoke_virtual(&sis_image, "getFrame", "(I)Ljavax/microedition/lcdui/Image;", (0,))
+                    .await?;
+                let object: ClassInstanceRef<Image> = jvm
+                    .invoke_virtual(&sis_image, "getObject", "(IZ)Ljavax/microedition/lcdui/Image;", (0, false))
+                    .await?;
+                assert!(frame.is_null());
+                assert!(object.is_null());
+
+                let invalid_frame: JvmResult<ClassInstanceRef<Image>> = jvm
+                    .invoke_virtual(&sis_image, "getFrame", "(I)Ljavax/microedition/lcdui/Image;", (1,))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = invalid_frame else {
+                    panic!("SISImage.getFrame accepted an out-of-range ID");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+                let invalid_object: JvmResult<ClassInstanceRef<Image>> = jvm
+                    .invoke_virtual(&sis_image, "getObject", "(IZ)Ljavax/microedition/lcdui/Image;", (-1, false))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = invalid_object else {
+                    panic!("SISImage.getObject accepted an out-of-range ID");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+                let target: ClassInstanceRef<Image> = jvm
+                    .invoke_static(
+                        "javax/microedition/lcdui/Image",
+                        "createImage",
+                        "(II)Ljavax/microedition/lcdui/Image;",
+                        (1, 1),
+                    )
+                    .await?;
+                let graphics: ClassInstanceRef<Graphics> = jvm
+                    .invoke_virtual(&target, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &sis_image,
+                        "paintFrame",
+                        "(Ljavax/microedition/lcdui/Graphics;III)V",
+                        (graphics.clone(), 0, 0, 0),
+                    )
+                    .await?;
+
+                let invalid_frame: JvmResult<()> = jvm
+                    .invoke_virtual(
+                        &sis_image,
+                        "paintFrame",
+                        "(Ljavax/microedition/lcdui/Graphics;III)V",
+                        (graphics.clone(), 1, 0, 0),
+                    )
+                    .await;
+                let Err(JavaError::JavaException(exception)) = invalid_frame else {
+                    panic!("SISImage.paintFrame accepted an out-of-range ID");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+                let invalid_object: JvmResult<()> = jvm
+                    .invoke_virtual(
+                        &sis_image,
+                        "paintObject",
+                        "(Ljavax/microedition/lcdui/Graphics;IIIZ)V",
+                        (graphics.clone(), 1, 0, 0, false),
+                    )
+                    .await;
+                let Err(JavaError::JavaException(exception)) = invalid_object else {
+                    panic!("SISImage.paintObject accepted an out-of-range ID");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+                let _: () = jvm
+                    .invoke_virtual(
+                        &sis_image,
+                        "paintObject",
+                        "(Ljavax/microedition/lcdui/Graphics;IIIZ)V",
+                        (graphics, 0, 0, 0, false),
+                    )
+                    .await?;
+
+                let invalid_range: JvmResult<ClassInstanceRef<SISImage>> = jvm
+                    .invoke_static("com/skt/m/SISImage", "createSISImage", "([BII)Lcom/skt/m/SISImage;", (data, 2, 2))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = invalid_range else {
+                    panic!("SISImage.createSISImage accepted an invalid byte range");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/ArrayIndexOutOfBoundsException"));
+
+                let null_data = ClassInstanceRef::<Array<i8>>::new(None);
+                let null_result: JvmResult<i32> = jvm
+                    .invoke_static("com/skt/m/SISImage", "getRequiredBufferSize", "([BII)I", (null_data, 0, 0))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = null_result else {
+                    panic!("SISImage.getRequiredBufferSize accepted null data");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+                Ok(())
+            },
+        )
+        .unwrap();
     }
 }

--- a/wie_skvm/src/classes/com/skt/m/graphics_2d.rs
+++ b/wie_skvm/src/classes/com/skt/m/graphics_2d.rs
@@ -292,7 +292,7 @@ impl Graphics2D {
         let clip = Graphics::clip(jvm, &graphics).await?;
         let image = Graphics::image(jvm, &mut graphics).await?;
         let mut canvas = Image::canvas(jvm, &image).await?;
-        canvas.set_pixel(
+        canvas.put_pixel(
             x.wrapping_add(translate_x),
             y.wrapping_add(translate_y),
             Rgb8Pixel::to_color(color as u32),

--- a/wie_skvm/src/classes/com/skt/m/math_fp.rs
+++ b/wie_skvm/src/classes/com/skt/m/math_fp.rs
@@ -1,41 +1,628 @@
-use alloc::vec;
+use alloc::{format, string::String as RustString, vec};
 
-use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+const SCALE: i64 = 1_000_000_000;
+const HALF: i64 = SCALE / 2;
+const E: i64 = 2_718_281_828;
+const PI: i64 = 3_141_592_654;
+const HALF_PI: i64 = 1_570_796_327;
+const TAU: i64 = 6_283_185_308;
+const LN_2: i64 = 693_147_181;
 
 // class com.skt.m.MathFP
 pub struct MathFP;
 
 impl MathFP {
     pub fn as_proto() -> WieJavaClassProto {
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+        let public_static_final = FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL;
+
         WieJavaClassProto {
             name: "com/skt/m/MathFP",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new(
-                "parseFPString",
-                "(Ljava/lang/String;)J",
-                Self::parse_fp_string,
-                MethodAccessFlags::STATIC,
-            )],
-            fields: vec![],
-            access_flags: Default::default(),
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("abs", "(J)J", Self::abs, public_static),
+                JavaMethodProto::new("acos", "(J)J", Self::acos, public_static),
+                JavaMethodProto::new("add", "(JJ)J", Self::add, public_static),
+                JavaMethodProto::new("asin", "(J)J", Self::asin, public_static),
+                JavaMethodProto::new("atan", "(J)J", Self::atan, public_static),
+                JavaMethodProto::new("cos", "(J)J", Self::cos, public_static),
+                JavaMethodProto::new("divide", "(JJ)J", Self::divide, public_static),
+                JavaMethodProto::new("exp", "(J)J", Self::exp, public_static),
+                JavaMethodProto::new("log", "(J)J", Self::log, public_static),
+                JavaMethodProto::new("max", "(JJ)J", Self::max, public_static),
+                JavaMethodProto::new("min", "(JJ)J", Self::min, public_static),
+                JavaMethodProto::new("multiply", "(JJ)J", Self::multiply, public_static),
+                JavaMethodProto::new("parseFP", "(J)J", Self::parse_fp, public_static),
+                JavaMethodProto::new("parseFPString", "(Ljava/lang/String;)J", Self::parse_fp_string, public_static),
+                JavaMethodProto::new("pow", "(JJ)J", Self::pow, public_static),
+                JavaMethodProto::new("round", "(J)J", Self::round, public_static),
+                JavaMethodProto::new("sin", "(J)J", Self::sin, public_static),
+                JavaMethodProto::new("sqrt", "(J)J", Self::sqrt, public_static),
+                JavaMethodProto::new("sub", "(JJ)J", Self::sub, public_static),
+                JavaMethodProto::new("tan", "(J)J", Self::tan, public_static),
+                JavaMethodProto::new("toLong", "(J)J", Self::to_long, public_static),
+                JavaMethodProto::new("toStringE", "(J)Ljava/lang/String;", Self::to_string_e, public_static),
+                JavaMethodProto::new("toStringLF", "(JI)Ljava/lang/String;", Self::to_string_lf, public_static),
+            ],
+            fields: vec![
+                JavaFieldProto::new("E", "J", public_static_final),
+                JavaFieldProto::new("MAX_VALUE", "J", public_static_final),
+                JavaFieldProto::new("MIN_VALUE", "J", public_static_final),
+                JavaFieldProto::new("PI", "J", public_static_final),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
     }
 
-    async fn parse_fp_string(jvm: &Jvm, _context: &mut WieJvmContext, s: ClassInstanceRef<String>) -> JvmResult<i64> {
-        tracing::debug!("com.skt.m.MathFP::parseFPString({s:?})");
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.MathFP::<clinit>()");
 
-        let s = JavaLangString::to_rust_string(jvm, &s).await?;
-
-        Ok(Self::f64_to_mathfp_i64(s.parse().unwrap()))
+        jvm.put_static_field("com/skt/m/MathFP", "E", "J", E).await?;
+        jvm.put_static_field("com/skt/m/MathFP", "MAX_VALUE", "J", i64::MAX).await?;
+        jvm.put_static_field("com/skt/m/MathFP", "MIN_VALUE", "J", i64::MIN).await?;
+        jvm.put_static_field("com/skt/m/MathFP", "PI", "J", PI).await
     }
 
-    fn f64_to_mathfp_i64(f: f64) -> i64 {
-        (f * 1000000000.0) as _
+    async fn abs(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(value.saturating_abs())
+    }
+
+    async fn acos(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(HALF_PI.saturating_sub(Self::asin_fixed(value)))
+    }
+
+    async fn add(_jvm: &Jvm, _context: &mut WieJvmContext, a: i64, b: i64) -> JvmResult<i64> {
+        Ok(a.saturating_add(b))
+    }
+
+    async fn asin(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::asin_fixed(value))
+    }
+
+    async fn atan(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::atan_fixed(value))
+    }
+
+    async fn cos(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::sin_fixed(value as i128 + HALF_PI as i128))
+    }
+
+    async fn divide(jvm: &Jvm, _context: &mut WieJvmContext, a: i64, b: i64) -> JvmResult<i64> {
+        match Self::fixed_div(a, b) {
+            Some(value) => Ok(value),
+            None => Err(jvm.exception("java/lang/ArithmeticException", "division by zero").await),
+        }
+    }
+
+    async fn exp(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::exp_fixed(value))
+    }
+
+    async fn log(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::log_fixed(value))
+    }
+
+    async fn max(_jvm: &Jvm, _context: &mut WieJvmContext, a: i64, b: i64) -> JvmResult<i64> {
+        Ok(a.max(b))
+    }
+
+    async fn min(_jvm: &Jvm, _context: &mut WieJvmContext, a: i64, b: i64) -> JvmResult<i64> {
+        Ok(a.min(b))
+    }
+
+    async fn multiply(_jvm: &Jvm, _context: &mut WieJvmContext, a: i64, b: i64) -> JvmResult<i64> {
+        Ok(Self::fixed_mul(a, b))
+    }
+
+    async fn parse_fp(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::saturating_i128_to_i64(value as i128 * SCALE as i128))
+    }
+
+    async fn parse_fp_string(jvm: &Jvm, _context: &mut WieJvmContext, value: ClassInstanceRef<String>) -> JvmResult<i64> {
+        tracing::debug!("com.skt.m.MathFP::parseFPString({value:?})");
+
+        if value.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "value is null").await);
+        }
+
+        let value = JavaLangString::to_rust_string(jvm, &value).await?;
+        let input = value.trim();
+        let bytes = input.as_bytes();
+        let mut index = 0_usize;
+        let negative = match bytes.first() {
+            Some(b'-') => {
+                index = 1;
+                true
+            }
+            Some(b'+') => {
+                index = 1;
+                false
+            }
+            _ => false,
+        };
+        let mut magnitude = 0_i128;
+        let mut digits = 0_usize;
+        let mut fractional_digits = 0_i64;
+        let mut decimal_seen = false;
+
+        while index < bytes.len() {
+            match bytes[index] {
+                digit @ b'0'..=b'9' => {
+                    magnitude = match magnitude.checked_mul(10).and_then(|value| value.checked_add((digit - b'0') as i128)) {
+                        Some(value) => value,
+                        None => return Err(jvm.exception("java/lang/NumberFormatException", &value).await),
+                    };
+                    digits += 1;
+                    if decimal_seen {
+                        fractional_digits += 1;
+                    }
+                    index += 1;
+                }
+                b'.' if !decimal_seen => {
+                    decimal_seen = true;
+                    index += 1;
+                }
+                b'e' | b'E' => break,
+                _ => return Err(jvm.exception("java/lang/NumberFormatException", &value).await),
+            }
+        }
+
+        if digits == 0 {
+            return Err(jvm.exception("java/lang/NumberFormatException", &value).await);
+        }
+
+        let mut exponent = 0_i64;
+        if index < bytes.len() {
+            index += 1;
+            let exponent_negative = match bytes.get(index) {
+                Some(b'-') => {
+                    index += 1;
+                    true
+                }
+                Some(b'+') => {
+                    index += 1;
+                    false
+                }
+                _ => false,
+            };
+            let exponent_start = index;
+            while index < bytes.len() {
+                let digit = bytes[index];
+                if !digit.is_ascii_digit() {
+                    return Err(jvm.exception("java/lang/NumberFormatException", &value).await);
+                }
+                exponent = match exponent.checked_mul(10).and_then(|value| value.checked_add((digit - b'0') as i64)) {
+                    Some(value) => value,
+                    None => return Err(jvm.exception("java/lang/NumberFormatException", &value).await),
+                };
+                index += 1;
+            }
+            if index == exponent_start {
+                return Err(jvm.exception("java/lang/NumberFormatException", &value).await);
+            }
+            if exponent_negative {
+                exponent = -exponent;
+            }
+        }
+
+        let decimal_shift = match exponent.checked_add(9).and_then(|value| value.checked_sub(fractional_digits)) {
+            Some(value) => value,
+            None => return Err(jvm.exception("java/lang/NumberFormatException", &value).await),
+        };
+        let raw_magnitude = if magnitude == 0 {
+            0
+        } else if decimal_shift >= 0 {
+            if decimal_shift > 38 {
+                return Err(jvm.exception("java/lang/NumberFormatException", &value).await);
+            }
+            match magnitude.checked_mul(10_i128.pow(decimal_shift as u32)) {
+                Some(value) => value,
+                None => return Err(jvm.exception("java/lang/NumberFormatException", &value).await),
+            }
+        } else if decimal_shift < -38 {
+            0
+        } else {
+            magnitude / 10_i128.pow((-decimal_shift) as u32)
+        };
+        let raw = if negative { raw_magnitude.checked_neg() } else { Some(raw_magnitude) };
+        let Some(raw) = raw.and_then(|value| i64::try_from(value).ok()) else {
+            return Err(jvm.exception("java/lang/NumberFormatException", &value).await);
+        };
+
+        Ok(raw)
+    }
+
+    async fn pow(_jvm: &Jvm, _context: &mut WieJvmContext, base: i64, exponent: i64) -> JvmResult<i64> {
+        if exponent == 0 {
+            return Ok(SCALE);
+        }
+        if base == 0 {
+            return Ok(if exponent > 0 { 0 } else { i64::MAX });
+        }
+        if base < 0 && exponent % SCALE != 0 {
+            return Ok(0);
+        }
+
+        let magnitude = Self::exp_fixed(Self::fixed_mul(Self::log_fixed(base.saturating_abs()), exponent));
+        if base < 0 && (exponent / SCALE) % 2 != 0 {
+            Ok(magnitude.saturating_neg())
+        } else {
+            Ok(magnitude)
+        }
+    }
+
+    async fn round(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        let rounded = (value as i128 + HALF as i128).div_euclid(SCALE as i128) * SCALE as i128;
+        Ok(Self::saturating_i128_to_i64(rounded))
+    }
+
+    async fn sin(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::sin_fixed(value as i128))
+    }
+
+    async fn sqrt(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(Self::sqrt_fixed(value))
+    }
+
+    async fn sub(_jvm: &Jvm, _context: &mut WieJvmContext, a: i64, b: i64) -> JvmResult<i64> {
+        Ok(a.saturating_sub(b))
+    }
+
+    async fn tan(jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        let sin = Self::sin_fixed(value as i128);
+        let cos = Self::sin_fixed(value as i128 + HALF_PI as i128);
+        match Self::fixed_div(sin, cos) {
+            Some(value) => Ok(value),
+            None => Err(jvm.exception("java/lang/ArithmeticException", "undefined tangent").await),
+        }
+    }
+
+    async fn to_long(_jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<i64> {
+        Ok(value / SCALE)
+    }
+
+    async fn to_string_e(jvm: &Jvm, _context: &mut WieJvmContext, value: i64) -> JvmResult<ClassInstanceRef<String>> {
+        let magnitude = value.unsigned_abs();
+        let result = if magnitude == 0 {
+            RustString::from("0e0")
+        } else {
+            let digits = format!("{magnitude}");
+            let significant = digits.trim_end_matches('0');
+            let exponent = digits.len() as i32 - 10;
+            let coefficient = if significant.len() == 1 {
+                RustString::from(significant)
+            } else {
+                format!("{}.{}", &significant[..1], &significant[1..])
+            };
+            format!("{}{coefficient}e{exponent}", if value < 0 { "-" } else { "" })
+        };
+        Ok(JavaLangString::from_rust_string(jvm, &result).await?.into())
+    }
+
+    async fn to_string_lf(jvm: &Jvm, _context: &mut WieJvmContext, value: i64, precision: i32) -> JvmResult<ClassInstanceRef<String>> {
+        if !(0..=9).contains(&precision) {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "precision must be between 0 and 9")
+                .await);
+        }
+
+        let divisor = 10_u128.pow((9 - precision) as u32);
+        let magnitude = value.unsigned_abs() as u128;
+        let rounded = (magnitude + divisor / 2) / divisor * divisor;
+        let integer = rounded / SCALE as u128;
+        let result = if precision == 0 {
+            format!("{}{integer}", if value < 0 { "-" } else { "" })
+        } else {
+            let fraction = (rounded % SCALE as u128) / divisor;
+            format!(
+                "{}{integer}.{fraction:0width$}",
+                if value < 0 { "-" } else { "" },
+                width = precision as usize
+            )
+        };
+
+        Ok(JavaLangString::from_rust_string(jvm, &result).await?.into())
+    }
+
+    fn saturating_i128_to_i64(value: i128) -> i64 {
+        if value > i64::MAX as i128 {
+            i64::MAX
+        } else if value < i64::MIN as i128 {
+            i64::MIN
+        } else {
+            value as i64
+        }
+    }
+
+    fn fixed_mul(a: i64, b: i64) -> i64 {
+        Self::saturating_i128_to_i64(a as i128 * b as i128 / SCALE as i128)
+    }
+
+    fn fixed_div(a: i64, b: i64) -> Option<i64> {
+        if b == 0 {
+            None
+        } else {
+            Some(Self::saturating_i128_to_i64(a as i128 * SCALE as i128 / b as i128))
+        }
+    }
+
+    fn sin_fixed(angle: i128) -> i64 {
+        let mut x = angle % TAU as i128;
+        if x > PI as i128 {
+            x -= TAU as i128;
+        } else if x < -(PI as i128) {
+            x += TAU as i128;
+        }
+        if x > HALF_PI as i128 {
+            x = PI as i128 - x;
+        } else if x < -(HALF_PI as i128) {
+            x = -(PI as i128) - x;
+        }
+
+        let x = x as i64;
+        let x_squared = Self::fixed_mul(x, x);
+        let mut result = x;
+        let mut term = x;
+        for (index, divisor) in [6_i64, 20, 42, 72, 110, 156].into_iter().enumerate() {
+            term = Self::fixed_mul(term, x_squared) / divisor;
+            result = if index % 2 == 0 {
+                result.saturating_sub(term)
+            } else {
+                result.saturating_add(term)
+            };
+        }
+        result
+    }
+
+    fn atan_fixed(value: i64) -> i64 {
+        let negative = value < 0;
+        let magnitude = value.saturating_abs();
+        let (x, reciprocal) = if magnitude > SCALE {
+            let reciprocal = Self::saturating_i128_to_i64(SCALE as i128 * SCALE as i128 / magnitude as i128);
+            (reciprocal, true)
+        } else {
+            (magnitude, false)
+        };
+
+        // A compact approximation with less than 0.004 radians error on [0, 1].
+        let correction = Self::fixed_mul(273_000_000, SCALE - x);
+        let mut result = Self::fixed_mul(x, 785_398_164_i64.saturating_add(correction));
+        if reciprocal {
+            result = HALF_PI.saturating_sub(result);
+        }
+        if negative { result.saturating_neg() } else { result }
+    }
+
+    fn asin_fixed(value: i64) -> i64 {
+        if !(-SCALE..=SCALE).contains(&value) {
+            return 0;
+        }
+        if value == SCALE {
+            return HALF_PI;
+        }
+        if value == -SCALE {
+            return -HALF_PI;
+        }
+
+        let complement = SCALE.saturating_sub(Self::fixed_mul(value, value));
+        let root = Self::sqrt_fixed(complement);
+        match Self::fixed_div(value, root) {
+            Some(ratio) => Self::atan_fixed(ratio),
+            None => 0,
+        }
+    }
+
+    fn sqrt_fixed(value: i64) -> i64 {
+        if value <= 0 {
+            return 0;
+        }
+
+        let radicand = value as u128 * SCALE as u128;
+        let mut estimate = radicand;
+        let mut next = estimate.div_ceil(2);
+        while next < estimate {
+            estimate = next;
+            next = (estimate + radicand / estimate) / 2;
+        }
+        estimate as i64
+    }
+
+    fn exp_fixed(value: i64) -> i64 {
+        let exponent = (value as i128).div_euclid(LN_2 as i128);
+        if exponent > 62 {
+            return i64::MAX;
+        }
+        if exponent < -62 {
+            return 0;
+        }
+
+        let remainder = (value as i128 - exponent * LN_2 as i128) as i64;
+        let mut result = SCALE;
+        let mut term = SCALE;
+        for divisor in 1_i64..=16 {
+            term = Self::fixed_mul(term, remainder) / divisor;
+            result = result.saturating_add(term);
+        }
+
+        if exponent >= 0 {
+            Self::saturating_i128_to_i64((result as i128) << exponent as u32)
+        } else {
+            result >> (-exponent) as u32
+        }
+    }
+
+    fn log_fixed(value: i64) -> i64 {
+        if value <= 0 {
+            return 0;
+        }
+
+        let mut normalized = value;
+        let mut exponent = 0_i64;
+        while normalized >= SCALE * 2 {
+            normalized /= 2;
+            exponent += 1;
+        }
+        while normalized < SCALE {
+            normalized *= 2;
+            exponent -= 1;
+        }
+
+        let y = Self::saturating_i128_to_i64((normalized - SCALE) as i128 * SCALE as i128 / (normalized + SCALE) as i128);
+        let y_squared = Self::fixed_mul(y, y);
+        let mut term = y;
+        let mut series = y;
+        for divisor in (3_i64..=19).step_by(2) {
+            term = Self::fixed_mul(term, y_squared);
+            series = series.saturating_add(term / divisor);
+        }
+
+        Self::saturating_i128_to_i64(series as i128 * 2 + exponent as i128 * LN_2 as i128)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, JavaError, Result as JvmResult, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use crate::get_protos;
+
+    use super::E;
+
+    #[test]
+    fn test_fixed_point_arithmetic() {
+        let result = run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let two_point_five: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "2.5").await?.into();
+            let one_point_two_five: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "1.25").await?.into();
+
+            let a: i64 = jvm
+                .invoke_static("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (two_point_five,))
+                .await?;
+            let b: i64 = jvm
+                .invoke_static("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (one_point_two_five,))
+                .await?;
+
+            assert_eq!(a, 2_500_000_000);
+            assert_eq!(b, 1_250_000_000);
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "add", "(JJ)J", (a, b)).await?,
+                3_750_000_000
+            );
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "sub", "(JJ)J", (a, b)).await?,
+                1_250_000_000
+            );
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "multiply", "(JJ)J", (a, b)).await?,
+                3_125_000_000
+            );
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "divide", "(JJ)J", (a, b)).await?,
+                2_000_000_000
+            );
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "parseFP", "(J)J", (4_i64,)).await?,
+                4_000_000_000
+            );
+
+            let pi: i64 = jvm.get_static_field("com/skt/m/MathFP", "PI", "J").await?;
+            let sine: i64 = jvm.invoke_static("com/skt/m/MathFP", "sin", "(J)J", (pi / 2,)).await?;
+            let square_root: i64 = jvm.invoke_static("com/skt/m/MathFP", "sqrt", "(J)J", (4_000_000_000_i64,)).await?;
+            let exponential: i64 = jvm.invoke_static("com/skt/m/MathFP", "exp", "(J)J", (1_000_000_000_i64,)).await?;
+            let logarithm: i64 = jvm.invoke_static("com/skt/m/MathFP", "log", "(J)J", (exponential,)).await?;
+
+            assert!((sine - 1_000_000_000).abs() < 1_000);
+            assert_eq!(square_root, 2_000_000_000);
+            assert!((exponential - E).abs() < 1_000);
+            assert!((logarithm - 1_000_000_000).abs() < 1_000);
+
+            Ok(())
+        });
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_fp_string_reports_number_format_exception() {
+        let result = run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let invalid: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "not-a-number").await?.into();
+            let parse_result: JvmResult<i64> = jvm
+                .invoke_static("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (invalid,))
+                .await;
+            let Err(JavaError::JavaException(exception)) = parse_result else {
+                panic!("parseFPString accepted an invalid number");
+            };
+
+            assert!(jvm.is_instance(&*exception, "java/lang/NumberFormatException"));
+
+            let null_value = ClassInstanceRef::<String>::new(None);
+            let null_result: JvmResult<i64> = jvm
+                .invoke_static("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (null_value,))
+                .await;
+            let Err(JavaError::JavaException(exception)) = null_result else {
+                panic!("parseFPString accepted null");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+            let overflow: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "9223372036.854775808").await?.into();
+            let overflow_result: JvmResult<i64> = jvm
+                .invoke_static("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (overflow,))
+                .await;
+            let Err(JavaError::JavaException(exception)) = overflow_result else {
+                panic!("parseFPString accepted a value above the raw long range");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/NumberFormatException"));
+            Ok(())
+        });
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_large_fixed_point_values_preserve_raw_precision() {
+        let result = run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let decimal: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "9000000.000000001").await?.into();
+            let raw: i64 = jvm
+                .invoke_static("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (decimal,))
+                .await?;
+            assert_eq!(raw, 9_000_000_000_000_001);
+
+            let exponential: ClassInstanceRef<String> = jvm
+                .invoke_static("com/skt/m/MathFP", "toStringE", "(J)Ljava/lang/String;", (raw,))
+                .await?;
+            assert_eq!(JavaLangString::to_rust_string(&jvm, &exponential).await?, "9.000000000000001e6");
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (exponential,))
+                    .await?,
+                raw
+            );
+
+            let fixed: ClassInstanceRef<String> = jvm
+                .invoke_static("com/skt/m/MathFP", "toStringLF", "(JI)Ljava/lang/String;", (raw, 9))
+                .await?;
+            assert_eq!(JavaLangString::to_rust_string(&jvm, &fixed).await?, "9000000.000000001");
+
+            let minimum: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "-9223372036.854775808").await?.into();
+            assert_eq!(
+                jvm.invoke_static::<_, i64>("com/skt/m/MathFP", "parseFPString", "(Ljava/lang/String;)J", (minimum,))
+                    .await?,
+                i64::MIN
+            );
+            Ok(())
+        });
+
+        assert!(result.is_ok());
     }
 }

--- a/wie_skvm/src/classes/com/skt/m/phone_book.rs
+++ b/wie_skvm/src/classes/com/skt/m/phone_book.rs
@@ -1,0 +1,147 @@
+use alloc::vec;
+
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+const ALL: i32 = 0;
+const NAME: i32 = 1;
+const GROUP: i32 = 2;
+const HANDPHONE: i32 = 3;
+const HOME: i32 = 4;
+const OFFICE: i32 = 5;
+const EMAIL: i32 = 6;
+const MEMO: i32 = 7;
+
+// class com.skt.m.PhoneBook
+pub struct PhoneBook;
+
+impl PhoneBook {
+    pub fn as_proto() -> WieJavaClassProto {
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+        let public_static_final = FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL;
+
+        WieJavaClassProto {
+            name: "com/skt/m/PhoneBook",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("findRecord", "(ILjava/lang/String;)V", Self::find_record, public_static),
+                JavaMethodProto::new("first", "()V", Self::first, public_static),
+                JavaMethodProto::new("getField", "(II)Ljava/lang/String;", Self::get_field, public_static),
+                JavaMethodProto::new("getGroupNames", "()[Ljava/lang/String;", Self::get_group_names, public_static),
+                JavaMethodProto::new("getMaxRecordID", "()I", Self::get_max_record_id, public_static),
+                JavaMethodProto::new("getRecord", "(I)[Ljava/lang/String;", Self::get_record, public_static),
+                JavaMethodProto::new("isUsed", "(I)Z", Self::is_used, public_static),
+                JavaMethodProto::new("next", "()I", Self::next, public_static),
+            ],
+            fields: ["ALL", "NAME", "GROUP", "HANDPHONE", "HOME", "OFFICE", "EMAIL", "MEMO"]
+                .into_iter()
+                .map(|name| JavaFieldProto::new(name, "I", public_static_final))
+                .collect(),
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.PhoneBook::<clinit>()");
+
+        for (name, value) in [
+            ("ALL", ALL),
+            ("NAME", NAME),
+            ("GROUP", GROUP),
+            ("HANDPHONE", HANDPHONE),
+            ("HOME", HOME),
+            ("OFFICE", OFFICE),
+            ("EMAIL", EMAIL),
+            ("MEMO", MEMO),
+        ] {
+            jvm.put_static_field("com/skt/m/PhoneBook", name, "I", value).await?;
+        }
+        Ok(())
+    }
+
+    async fn find_record(jvm: &Jvm, _context: &mut WieJvmContext, field: i32, value: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.PhoneBook::findRecord({field}, {value:?})");
+        if value.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "value is null").await);
+        }
+        Ok(())
+    }
+
+    async fn first(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.PhoneBook::first()");
+        Ok(())
+    }
+
+    async fn get_field(_jvm: &Jvm, _context: &mut WieJvmContext, record_id: i32, field: i32) -> JvmResult<ClassInstanceRef<String>> {
+        tracing::warn!("stub com.skt.m.PhoneBook::getField({record_id}, {field})");
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    async fn get_group_names(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Array<String>>> {
+        tracing::warn!("stub com.skt.m.PhoneBook::getGroupNames()");
+        Ok(jvm.instantiate_array("Ljava/lang/String;", 0).await?.into())
+    }
+
+    async fn get_max_record_id(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.PhoneBook::getMaxRecordID()");
+        Ok(0)
+    }
+
+    async fn get_record(_jvm: &Jvm, _context: &mut WieJvmContext, record_id: i32) -> JvmResult<ClassInstanceRef<Array<String>>> {
+        tracing::warn!("stub com.skt.m.PhoneBook::getRecord({record_id})");
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    async fn is_used(_jvm: &Jvm, _context: &mut WieJvmContext, record_id: i32) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.PhoneBook::isUsed({record_id})");
+        Ok(false)
+    }
+
+    async fn next(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.PhoneBook::next()");
+        Ok(-1)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{Array, ClassInstanceRef};
+    use test_utils::run_jvm_test;
+
+    use crate::get_protos;
+
+    #[test]
+    fn test_empty_phone_book_uses_documented_constants_and_null_record() {
+        let result = run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            for (name, expected) in [
+                ("ALL", 0),
+                ("NAME", 1),
+                ("GROUP", 2),
+                ("HANDPHONE", 3),
+                ("HOME", 4),
+                ("OFFICE", 5),
+                ("EMAIL", 6),
+                ("MEMO", 7),
+            ] {
+                assert_eq!(jvm.get_static_field::<i32>("com/skt/m/PhoneBook", name, "I").await?, expected);
+            }
+
+            let record: ClassInstanceRef<Array<String>> = jvm
+                .invoke_static("com/skt/m/PhoneBook", "getRecord", "(I)[Ljava/lang/String;", (1,))
+                .await?;
+            assert!(record.is_null());
+            Ok(())
+        });
+
+        assert!(result.is_ok());
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/progress_bar.rs
+++ b/wie_skvm/src/classes/com/skt/m/progress_bar.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
-use java_class_proto::JavaMethodProto;
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -16,32 +17,81 @@ impl ProgressBar {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("setMaxValue", "(I)V", Self::set_max_value, Default::default()),
-                JavaMethodProto::new("setValue", "(I)V", Self::set_value, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMaxValue", "()I", Self::get_max_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getValue", "()I", Self::get_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setMaxValue", "(I)V", Self::set_max_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setValue", "(I)V", Self::set_value, MethodAccessFlags::PUBLIC),
             ],
-            fields: vec![],
-            access_flags: Default::default(),
+            fields: vec![
+                JavaFieldProto::new("maxValue", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("value", "I", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
     }
 
-    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> JvmResult<()> {
-        tracing::warn!("stub com.skt.m.ProgressBar::<init>({this:?}, {name:?})");
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.ProgressBar::<init>({this:?}, {name:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "maxValue", "I", 100).await?;
+        jvm.put_field(&mut this, "value", "I", 0).await
+    }
 
+    async fn get_max_value(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "maxValue", "I").await
+    }
+
+    async fn get_value(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "value", "I").await
+    }
+
+    async fn set_max_value(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, value: i32) -> JvmResult<()> {
+        let current: i32 = jvm.get_field(&this, "value", "I").await?;
+        jvm.put_field(&mut this, "maxValue", "I", value).await?;
+        if current > value {
+            jvm.put_field(&mut this, "value", "I", value).await?;
+        }
         Ok(())
     }
 
-    async fn set_max_value(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, value: i32) -> JvmResult<()> {
-        tracing::warn!("stub com.skt.m.ProgressBar::setMaxValue({this:?}, {value:?})");
-
-        Ok(())
+    async fn set_value(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, value: i32) -> JvmResult<()> {
+        let max_value: i32 = jvm.get_field(&this, "maxValue", "I").await?;
+        jvm.put_field(&mut this, "value", "I", value.min(max_value)).await
     }
+}
 
-    async fn set_value(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, value: i32) -> JvmResult<()> {
-        tracing::warn!("stub com.skt.m.ProgressBar::setValue({this:?}, {value:?})");
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
 
-        Ok(())
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use crate::get_protos;
+
+    use super::ProgressBar;
+
+    #[test]
+    fn test_value_and_max_value_enforce_documented_bounds() {
+        let result = run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "Loading").await?.into();
+            let progress_bar: ClassInstanceRef<ProgressBar> = jvm.new_class("com/skt/m/ProgressBar", "(Ljava/lang/String;)V", (name,)).await?.into();
+
+            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getMaxValue", "()I", ()).await?, 100);
+            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getValue", "()I", ()).await?, 0);
+
+            let _: () = jvm.invoke_virtual(&progress_bar, "setValue", "(I)V", (125,)).await?;
+            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getValue", "()I", ()).await?, 100);
+
+            let _: () = jvm.invoke_virtual(&progress_bar, "setMaxValue", "(I)V", (40,)).await?;
+            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getMaxValue", "()I", ()).await?, 40);
+            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getValue", "()I", ()).await?, 40);
+            Ok(())
+        });
+
+        assert!(result.is_ok());
     }
 }

--- a/wie_skvm/src/classes/com/skt/m/resource_alloc_exception.rs
+++ b/wie_skvm/src/classes/com/skt/m/resource_alloc_exception.rs
@@ -1,0 +1,29 @@
+use alloc::vec;
+
+use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+// class com.skt.m.ResourceAllocException
+pub struct ResourceAllocException;
+
+impl ResourceAllocException {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "com/skt/m/ResourceAllocException",
+            parent_class: Some("java/lang/Exception"),
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC)],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.ResourceAllocException::<init>({this:?})");
+
+        jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/sis_image.rs
+++ b/wie_skvm/src/classes/com/skt/m/sis_image.rs
@@ -1,0 +1,258 @@
+use alloc::vec;
+
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+use wie_midp::classes::javax::microedition::lcdui::{Graphics, Image};
+
+// class com.skt.m.SISImage
+pub struct SISImage;
+
+impl SISImage {
+    pub fn as_proto() -> WieJavaClassProto {
+        let public = MethodAccessFlags::PUBLIC;
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+        let public_static_final = FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL;
+
+        WieJavaClassProto {
+            name: "com/skt/m/SISImage",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PRIVATE),
+                JavaMethodProto::new("createBuffer", "(II)V", Self::create_buffer, public_static),
+                JavaMethodProto::new(
+                    "createSISImage",
+                    "([BII)Lcom/skt/m/SISImage;",
+                    Self::create_sis_image_from_data,
+                    public_static,
+                ),
+                JavaMethodProto::new(
+                    "createSISImage",
+                    "(Ljava/lang/String;)Lcom/skt/m/SISImage;",
+                    Self::create_sis_image_from_name,
+                    public_static,
+                ),
+                JavaMethodProto::new("freeBuffer", "()V", Self::free_buffer, public_static),
+                JavaMethodProto::new("getRequiredBufferSize", "([BII)I", Self::get_required_buffer_size, public_static),
+                JavaMethodProto::new("getBestID", "()I", Self::get_best_id, public),
+                JavaMethodProto::new("getDelay", "(I)I", Self::get_delay, public),
+                JavaMethodProto::new("getFrame", "(I)Ljavax/microedition/lcdui/Image;", Self::get_frame, public),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, public),
+                JavaMethodProto::new("getImageLevel", "()I", Self::get_image_level, public),
+                JavaMethodProto::new("getMaxFrameID", "()I", Self::get_max_frame_id, public),
+                JavaMethodProto::new("getMaxObjectID", "()I", Self::get_max_object_id, public),
+                JavaMethodProto::new("getObject", "(IZ)Ljavax/microedition/lcdui/Image;", Self::get_object, public),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, public),
+                JavaMethodProto::new("paintFrame", "(Ljavax/microedition/lcdui/Graphics;III)V", Self::paint_frame, public),
+                JavaMethodProto::new("paintObject", "(Ljavax/microedition/lcdui/Graphics;IIIZ)V", Self::paint_object, public),
+            ],
+            fields: ["IMG_LEVEL_BW", "IMG_LEVEL_4G", "IMG_LEVEL_256C"]
+                .into_iter()
+                .map(|name| JavaFieldProto::new(name, "I", public_static_final))
+                .collect(),
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.SISImage::<clinit>()");
+
+        for (name, value) in [("IMG_LEVEL_BW", 1), ("IMG_LEVEL_4G", 2), ("IMG_LEVEL_256C", 8)] {
+            jvm.put_static_field("com/skt/m/SISImage", name, "I", value).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.SISImage::<init>({this:?})");
+        jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+    }
+
+    async fn create_buffer(jvm: &Jvm, _context: &mut WieJvmContext, object_buffer_size: i32, other_buffer_size: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.SISImage::createBuffer({object_buffer_size}, {other_buffer_size})");
+
+        if object_buffer_size <= 0 || other_buffer_size <= 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "buffer sizes must be positive").await);
+        }
+
+        Ok(())
+    }
+
+    async fn create_sis_image_from_data(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        data: ClassInstanceRef<Array<i8>>,
+        offset: i32,
+        length: i32,
+    ) -> JvmResult<ClassInstanceRef<Self>> {
+        tracing::warn!("stub com.skt.m.SISImage::createSISImage({data:?}, {offset}, {length})");
+
+        if data.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "data is null").await);
+        }
+
+        let array_length = jvm.array_length(&data).await?;
+        if offset < 0 || length < 0 || (offset as usize).checked_add(length as usize).is_none_or(|end| end > array_length) {
+            return Err(jvm
+                .exception("java/lang/ArrayIndexOutOfBoundsException", "invalid offset or length")
+                .await);
+        }
+
+        Ok(jvm.new_class("com/skt/m/SISImage", "()V", ()).await?.into())
+    }
+
+    async fn create_sis_image_from_name(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        name: ClassInstanceRef<String>,
+    ) -> JvmResult<ClassInstanceRef<Self>> {
+        tracing::warn!("stub com.skt.m.SISImage::createSISImage({name:?})");
+
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
+
+        Ok(jvm.new_class("com/skt/m/SISImage", "()V", ()).await?.into())
+    }
+
+    async fn free_buffer(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.SISImage::freeBuffer()");
+        Ok(())
+    }
+
+    async fn get_required_buffer_size(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        data: ClassInstanceRef<Array<i8>>,
+        offset: i32,
+        length: i32,
+    ) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getRequiredBufferSize({data:?}, {offset}, {length})");
+
+        if data.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "data is null").await);
+        }
+
+        let array_length = jvm.array_length(&data).await?;
+        if offset < 0 || length < 0 || (offset as usize).checked_add(length as usize).is_none_or(|end| end > array_length) {
+            return Err(jvm
+                .exception("java/lang/ArrayIndexOutOfBoundsException", "invalid offset or length")
+                .await);
+        }
+
+        Ok(0)
+    }
+
+    async fn get_best_id(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getBestID({this:?})");
+        Ok(0)
+    }
+
+    async fn get_delay(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, frame_id: i32) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getDelay({this:?}, {frame_id})");
+        Ok(0)
+    }
+
+    async fn get_frame(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, frame_id: i32) -> JvmResult<ClassInstanceRef<Image>> {
+        tracing::warn!("stub com.skt.m.SISImage::getFrame({this:?}, {frame_id})");
+
+        if frame_id != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "invalid frame ID").await);
+        }
+
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    async fn get_height(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getHeight({this:?})");
+        Ok(0)
+    }
+
+    async fn get_image_level(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getImageLevel({this:?})");
+        Ok(0)
+    }
+
+    async fn get_max_frame_id(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getMaxFrameID({this:?})");
+        Ok(0)
+    }
+
+    async fn get_max_object_id(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getMaxObjectID({this:?})");
+        Ok(0)
+    }
+
+    async fn get_object(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        object_id: i32,
+        use_transparency: bool,
+    ) -> JvmResult<ClassInstanceRef<Image>> {
+        tracing::warn!("stub com.skt.m.SISImage::getObject({this:?}, {object_id}, {use_transparency})");
+
+        if object_id != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "invalid object ID").await);
+        }
+
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    async fn get_width(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        tracing::warn!("stub com.skt.m.SISImage::getWidth({this:?})");
+        Ok(0)
+    }
+
+    async fn paint_frame(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        frame_id: i32,
+        x: i32,
+        y: i32,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.SISImage::paintFrame({this:?}, {graphics:?}, {frame_id}, {x}, {y})");
+
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        if frame_id != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "invalid frame ID").await);
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_object(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        object_id: i32,
+        x: i32,
+        y: i32,
+        use_transparency: bool,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m.SISImage::paintObject({this:?}, {graphics:?}, {object_id}, {x}, {y}, {use_transparency})");
+
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        if object_id != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "invalid object ID").await);
+        }
+
+        Ok(())
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/sms.rs
+++ b/wie_skvm/src/classes/com/skt/m/sms.rs
@@ -1,0 +1,271 @@
+use alloc::vec;
+
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use super::{SMSListener, SMSMessage};
+
+// class com.skt.m.SMS
+pub struct SMS;
+
+impl SMS {
+    pub fn as_proto() -> WieJavaClassProto {
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+
+        WieJavaClassProto {
+            name: "com/skt/m/SMS",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("get", "(I)Lcom/skt/m/SMSMessage;", Self::get, public_static),
+                JavaMethodProto::new("get", "(ILcom/skt/m/SMSMessage;)Z", Self::get_into_message, public_static),
+                JavaMethodProto::new("getSMSListener", "()Lcom/skt/m/SMSListener;", Self::get_sms_listener, public_static),
+                JavaMethodProto::new("send", "(Ljava/lang/String;Lcom/skt/m/SMSMessage;)Z", Self::send, public_static),
+                JavaMethodProto::new("setSMSListener", "(Lcom/skt/m/SMSListener;)V", Self::set_sms_listener, public_static),
+            ],
+            fields: vec![JavaFieldProto::new(
+                "listener",
+                "Lcom/skt/m/SMSListener;",
+                FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC,
+            )],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        jvm.put_static_field(
+            "com/skt/m/SMS",
+            "listener",
+            "Lcom/skt/m/SMSListener;",
+            ClassInstanceRef::<SMSListener>::new(None),
+        )
+        .await
+    }
+
+    async fn get(jvm: &Jvm, _context: &mut WieJvmContext, index: i32) -> JvmResult<ClassInstanceRef<SMSMessage>> {
+        tracing::warn!("stub com.skt.m.SMS::get({index})");
+
+        if index != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "index must be zero").await);
+        }
+
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    async fn get_into_message(_jvm: &Jvm, _context: &mut WieJvmContext, index: i32, message: ClassInstanceRef<SMSMessage>) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.SMS::get({index}, {message:?})");
+
+        Ok(false)
+    }
+
+    async fn get_sms_listener(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<SMSListener>> {
+        jvm.get_static_field("com/skt/m/SMS", "listener", "Lcom/skt/m/SMSListener;").await
+    }
+
+    async fn send(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        receiver: ClassInstanceRef<String>,
+        message: ClassInstanceRef<SMSMessage>,
+    ) -> JvmResult<bool> {
+        tracing::warn!("stub com.skt.m.SMS::send({receiver:?}, {message:?})");
+
+        if receiver.is_null() || message.is_null() {
+            return Err(jvm
+                .exception("java/lang/NullPointerException", "receiver and message must not be null")
+                .await);
+        }
+
+        Ok(false)
+    }
+
+    async fn set_sms_listener(jvm: &Jvm, _context: &mut WieJvmContext, listener: ClassInstanceRef<SMSListener>) -> JvmResult<()> {
+        if listener.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "listener must not be null").await);
+        }
+
+        jvm.put_static_field("com/skt/m/SMS", "listener", "Lcom/skt/m/SMSListener;", listener)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec};
+
+    use java_class_proto::JavaMethodProto;
+    use java_constants::{ClassAccessFlags, MethodAccessFlags};
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, JavaError, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use super::SMS;
+    use crate::classes::com::skt::m::{SMSListener, SMSMessage};
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+    struct TestSMSListener;
+
+    impl TestSMSListener {
+        fn as_proto() -> WieJavaClassProto {
+            WieJavaClassProto {
+                name: "test/SMSListener",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec!["com/skt/m/SMSListener"],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("onMessage", "(Lcom/skt/m/SMSMessage;)V", Self::on_message, MethodAccessFlags::PUBLIC),
+                ],
+                fields: vec![],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+            Ok(())
+        }
+
+        async fn on_message(
+            _jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            _this: ClassInstanceRef<Self>,
+            _message: ClassInstanceRef<SMSMessage>,
+        ) -> JvmResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn listener_round_trips_and_network_operations_fail_deterministically() {
+        let result = run_jvm_test(
+            Box::new([
+                wie_midp::get_protos().into(),
+                Box::new([
+                    SMS::as_proto(),
+                    SMSListener::as_proto(),
+                    SMSMessage::as_proto(),
+                    TestSMSListener::as_proto(),
+                ]),
+            ]),
+            |jvm| async move {
+                let listener: ClassInstanceRef<SMSListener> = jvm.new_class("test/SMSListener", "()V", ()).await?.into();
+                let _: () = jvm
+                    .invoke_static("com/skt/m/SMS", "setSMSListener", "(Lcom/skt/m/SMSListener;)V", (listener.clone(),))
+                    .await?;
+                let returned: ClassInstanceRef<SMSListener> = jvm
+                    .invoke_static("com/skt/m/SMS", "getSMSListener", "()Lcom/skt/m/SMSListener;", ())
+                    .await?;
+                assert_eq!(
+                    returned.instance.as_ref().map(|instance| instance.identity()),
+                    listener.instance.as_ref().map(|instance| instance.identity())
+                );
+
+                let message: ClassInstanceRef<SMSMessage> = jvm.new_class("com/skt/m/SMSMessage", "()V", ()).await?.into();
+                let receiver: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "01098765432").await?.into();
+                let sent: bool = jvm
+                    .invoke_static(
+                        "com/skt/m/SMS",
+                        "send",
+                        "(Ljava/lang/String;Lcom/skt/m/SMSMessage;)Z",
+                        (receiver, message.clone()),
+                    )
+                    .await?;
+                let filled: bool = jvm
+                    .invoke_static("com/skt/m/SMS", "get", "(ILcom/skt/m/SMSMessage;)Z", (0, message))
+                    .await?;
+                let received: ClassInstanceRef<SMSMessage> = jvm.invoke_static("com/skt/m/SMS", "get", "(I)Lcom/skt/m/SMSMessage;", (0,)).await?;
+                assert!(!sent);
+                assert!(!filled);
+                assert!(received.is_null());
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn documented_input_errors_raise_java_exceptions_and_preserve_the_listener() {
+        let result = run_jvm_test(
+            Box::new([
+                wie_midp::get_protos().into(),
+                Box::new([
+                    SMS::as_proto(),
+                    SMSListener::as_proto(),
+                    SMSMessage::as_proto(),
+                    TestSMSListener::as_proto(),
+                ]),
+            ]),
+            |jvm| async move {
+                let listener: ClassInstanceRef<SMSListener> = jvm.new_class("test/SMSListener", "()V", ()).await?.into();
+                let _: () = jvm
+                    .invoke_static("com/skt/m/SMS", "setSMSListener", "(Lcom/skt/m/SMSListener;)V", (listener.clone(),))
+                    .await?;
+
+                let null_listener = ClassInstanceRef::<SMSListener>::new(None);
+                let listener_result: JvmResult<()> = jvm
+                    .invoke_static("com/skt/m/SMS", "setSMSListener", "(Lcom/skt/m/SMSListener;)V", (null_listener,))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = listener_result else {
+                    panic!("SMS.setSMSListener accepted null");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+                let returned: ClassInstanceRef<SMSListener> = jvm
+                    .invoke_static("com/skt/m/SMS", "getSMSListener", "()Lcom/skt/m/SMSListener;", ())
+                    .await?;
+                assert_eq!(
+                    returned.instance.as_ref().map(|instance| instance.identity()),
+                    listener.instance.as_ref().map(|instance| instance.identity())
+                );
+
+                let invalid_get: JvmResult<ClassInstanceRef<SMSMessage>> =
+                    jvm.invoke_static("com/skt/m/SMS", "get", "(I)Lcom/skt/m/SMSMessage;", (1,)).await;
+                let Err(JavaError::JavaException(exception)) = invalid_get else {
+                    panic!("SMS.get accepted an index other than zero");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+                let message: ClassInstanceRef<SMSMessage> = jvm.new_class("com/skt/m/SMSMessage", "()V", ()).await?.into();
+                let receiver: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "01098765432").await?.into();
+                let null_receiver = ClassInstanceRef::<String>::new(None);
+                let send_result: JvmResult<bool> = jvm
+                    .invoke_static(
+                        "com/skt/m/SMS",
+                        "send",
+                        "(Ljava/lang/String;Lcom/skt/m/SMSMessage;)Z",
+                        (null_receiver, message),
+                    )
+                    .await;
+                let Err(JavaError::JavaException(exception)) = send_result else {
+                    panic!("SMS.send accepted a null receiver");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+                let null_message = ClassInstanceRef::<SMSMessage>::new(None);
+                let send_result: JvmResult<bool> = jvm
+                    .invoke_static(
+                        "com/skt/m/SMS",
+                        "send",
+                        "(Ljava/lang/String;Lcom/skt/m/SMSMessage;)Z",
+                        (receiver, null_message),
+                    )
+                    .await;
+                let Err(JavaError::JavaException(exception)) = send_result else {
+                    panic!("SMS.send accepted a null message");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/sms_listener.rs
+++ b/wie_skvm/src/classes/com/skt/m/sms_listener.rs
@@ -1,0 +1,26 @@
+use alloc::vec;
+
+use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
+
+use wie_jvm_support::WieJavaClassProto;
+
+// interface com.skt.m.SMSListener
+pub struct SMSListener;
+
+impl SMSListener {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "com/skt/m/SMSListener",
+            parent_class: None,
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new_abstract(
+                "onMessage",
+                "(Lcom/skt/m/SMSMessage;)V",
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+            )],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
+        }
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/sms_message.rs
+++ b/wie_skvm/src/classes/com/skt/m/sms_message.rs
@@ -1,0 +1,267 @@
+use alloc::vec;
+
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+const APPLICATION_DATA: i32 = 0;
+const DOWNLOAD_NOTIFICATION: i32 = 1;
+const SHORT_MESSAGE: i32 = 2;
+const UNKNOWN: i32 = 3;
+
+// class com.skt.m.SMSMessage
+pub struct SMSMessage;
+
+impl SMSMessage {
+    pub fn as_proto() -> WieJavaClassProto {
+        let public_static_final = FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL;
+
+        WieJavaClassProto {
+            name: "com/skt/m/SMSMessage",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "([BLjava/lang/String;)V", Self::init_short_message, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;[B)V",
+                    Self::init_application_data,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                    Self::init_download_notification,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getAppData", "()[B", Self::get_app_data, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getCName", "()Ljava/lang/String;", Self::get_cname, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getComment", "()Ljava/lang/String;", Self::get_comment, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getName", "()Ljava/lang/String;", Self::get_name, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getSender", "()Ljava/lang/String;", Self::get_sender, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getServiceOption", "()B", Self::get_service_option, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getShortMessage", "()[B", Self::get_short_message, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getType", "()I", Self::get_type, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getURL", "()Ljava/lang/String;", Self::get_url, MethodAccessFlags::PUBLIC),
+            ],
+            fields: vec![
+                JavaFieldProto::new("APPLICATION_DATA", "I", public_static_final),
+                JavaFieldProto::new("DOWNLOAD_NOTIFICATION", "I", public_static_final),
+                JavaFieldProto::new("SHORT_MESSAGE", "I", public_static_final),
+                JavaFieldProto::new("UNKNOWN", "I", public_static_final),
+                JavaFieldProto::new("type", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("shortMessage", "[B", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("sender", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("url", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("name", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("comment", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("cname", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("appData", "[B", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        jvm.put_static_field("com/skt/m/SMSMessage", "APPLICATION_DATA", "I", APPLICATION_DATA)
+            .await?;
+        jvm.put_static_field("com/skt/m/SMSMessage", "DOWNLOAD_NOTIFICATION", "I", DOWNLOAD_NOTIFICATION)
+            .await?;
+        jvm.put_static_field("com/skt/m/SMSMessage", "SHORT_MESSAGE", "I", SHORT_MESSAGE).await?;
+        jvm.put_static_field("com/skt/m/SMSMessage", "UNKNOWN", "I", UNKNOWN).await?;
+
+        Ok(())
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.SMSMessage::<init>({this:?})");
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "type", "I", UNKNOWN).await?;
+
+        Ok(())
+    }
+
+    async fn init_short_message(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        data: ClassInstanceRef<Array<i8>>,
+        sender: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.SMSMessage::<init>({this:?}, {data:?}, {sender:?})");
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "type", "I", SHORT_MESSAGE).await?;
+        jvm.put_field(&mut this, "shortMessage", "[B", data).await?;
+        jvm.put_field(&mut this, "sender", "Ljava/lang/String;", sender).await?;
+
+        Ok(())
+    }
+
+    async fn init_application_data(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        cname: ClassInstanceRef<String>,
+        data: ClassInstanceRef<Array<i8>>,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.SMSMessage::<init>({this:?}, {cname:?}, {data:?})");
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "type", "I", APPLICATION_DATA).await?;
+        jvm.put_field(&mut this, "cname", "Ljava/lang/String;", cname).await?;
+        jvm.put_field(&mut this, "appData", "[B", data).await?;
+
+        Ok(())
+    }
+
+    async fn init_download_notification(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        url: ClassInstanceRef<String>,
+        name: ClassInstanceRef<String>,
+        comment: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.SMSMessage::<init>({this:?}, {url:?}, {name:?}, {comment:?})");
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "type", "I", DOWNLOAD_NOTIFICATION).await?;
+        jvm.put_field(&mut this, "url", "Ljava/lang/String;", url).await?;
+        jvm.put_field(&mut this, "name", "Ljava/lang/String;", name).await?;
+        jvm.put_field(&mut this, "comment", "Ljava/lang/String;", comment).await?;
+
+        Ok(())
+    }
+
+    async fn get_app_data(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Array<i8>>> {
+        jvm.get_field(&this, "appData", "[B").await
+    }
+
+    async fn get_cname(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "cname", "Ljava/lang/String;").await
+    }
+
+    async fn get_comment(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "comment", "Ljava/lang/String;").await
+    }
+
+    async fn get_name(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "name", "Ljava/lang/String;").await
+    }
+
+    async fn get_sender(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "sender", "Ljava/lang/String;").await
+    }
+
+    async fn get_service_option(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i8> {
+        tracing::warn!("stub com.skt.m.SMSMessage::getServiceOption({this:?})");
+
+        Ok(0)
+    }
+
+    async fn get_short_message(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Array<i8>>> {
+        jvm.get_field(&this, "shortMessage", "[B").await
+    }
+
+    async fn get_type(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "type", "I").await
+    }
+
+    async fn get_url(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "url", "Ljava/lang/String;").await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{Array, ClassInstanceRef, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use super::SMSMessage;
+
+    #[test]
+    fn constructors_preserve_their_message_payloads_and_types() {
+        let result = run_jvm_test(
+            Box::new([wie_midp::get_protos().into(), Box::new([SMSMessage::as_proto()])]),
+            |jvm| async move {
+                let unknown: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "UNKNOWN", "I").await?;
+                let default_message: ClassInstanceRef<SMSMessage> = jvm.new_class("com/skt/m/SMSMessage", "()V", ()).await?.into();
+                let default_type: i32 = jvm.invoke_virtual(&default_message, "getType", "()I", ()).await?;
+                assert_eq!(default_type, unknown);
+
+                let mut short_data = jvm.instantiate_array("B", 3).await?;
+                jvm.store_array(&mut short_data, 0, [1i8, 2, 3]).await?;
+                let sender = JavaLangString::from_rust_string(&jvm, "01012345678").await?;
+                let short_message: ClassInstanceRef<SMSMessage> = jvm
+                    .new_class("com/skt/m/SMSMessage", "([BLjava/lang/String;)V", (short_data.clone(), sender.clone()))
+                    .await?
+                    .into();
+                let short_type: i32 = jvm.invoke_virtual(&short_message, "getType", "()I", ()).await?;
+                let expected_short_type: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "SHORT_MESSAGE", "I").await?;
+                let returned_short_data: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&short_message, "getShortMessage", "()[B", ()).await?;
+                let returned_sender: ClassInstanceRef<String> = jvm.invoke_virtual(&short_message, "getSender", "()Ljava/lang/String;", ()).await?;
+                assert_eq!(short_type, expected_short_type);
+                assert_eq!(
+                    returned_short_data.instance.as_ref().map(|instance| instance.identity()),
+                    Some(short_data.identity())
+                );
+                assert_eq!(jvm.load_array::<i8>(&returned_short_data, 0, 3).await?, [1i8, 2, 3]);
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_sender).await?, "01012345678");
+
+                let cname = JavaLangString::from_rust_string(&jvm, "weather").await?;
+                let mut app_data = jvm.instantiate_array("B", 2).await?;
+                jvm.store_array(&mut app_data, 0, [10i8, 20]).await?;
+                let app_message: ClassInstanceRef<SMSMessage> = jvm
+                    .new_class("com/skt/m/SMSMessage", "(Ljava/lang/String;[B)V", (cname.clone(), app_data.clone()))
+                    .await?
+                    .into();
+                let app_type: i32 = jvm.invoke_virtual(&app_message, "getType", "()I", ()).await?;
+                let expected_app_type: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "APPLICATION_DATA", "I").await?;
+                let returned_cname: ClassInstanceRef<String> = jvm.invoke_virtual(&app_message, "getCName", "()Ljava/lang/String;", ()).await?;
+                let returned_app_data: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&app_message, "getAppData", "()[B", ()).await?;
+                assert_eq!(app_type, expected_app_type);
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_cname).await?, "weather");
+                assert_eq!(jvm.load_array::<i8>(&returned_app_data, 0, 2).await?, [10i8, 20]);
+
+                let url = JavaLangString::from_rust_string(&jvm, "https://example.invalid/app").await?;
+                let name = JavaLangString::from_rust_string(&jvm, "Example").await?;
+                let comment = JavaLangString::from_rust_string(&jvm, "Install").await?;
+                let download_message: ClassInstanceRef<SMSMessage> = jvm
+                    .new_class(
+                        "com/skt/m/SMSMessage",
+                        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                        (url.clone(), name.clone(), comment.clone()),
+                    )
+                    .await?
+                    .into();
+                let download_type: i32 = jvm.invoke_virtual(&download_message, "getType", "()I", ()).await?;
+                let expected_download_type: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "DOWNLOAD_NOTIFICATION", "I").await?;
+                let returned_url: ClassInstanceRef<String> = jvm.invoke_virtual(&download_message, "getURL", "()Ljava/lang/String;", ()).await?;
+                let returned_name: ClassInstanceRef<String> = jvm.invoke_virtual(&download_message, "getName", "()Ljava/lang/String;", ()).await?;
+                let returned_comment: ClassInstanceRef<String> =
+                    jvm.invoke_virtual(&download_message, "getComment", "()Ljava/lang/String;", ()).await?;
+                assert_eq!(download_type, expected_download_type);
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_url).await?, "https://example.invalid/app");
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_name).await?, "Example");
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_comment).await?, "Install");
+
+                let service_option: i8 = jvm.invoke_virtual(&download_message, "getServiceOption", "()B", ()).await?;
+                assert_eq!(service_option, 0);
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/unsupported_format_exception.rs
+++ b/wie_skvm/src/classes/com/skt/m/unsupported_format_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl UnsupportedFormatException {
             parent_class: Some("java/lang/Exception"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_skvm/src/classes/com/skt/m/user_stop_exception.rs
+++ b/wie_skvm/src/classes/com/skt/m/user_stop_exception.rs
@@ -1,0 +1,29 @@
+use alloc::vec;
+
+use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+// class com.skt.m.UserStopException
+pub struct UserStopException;
+
+impl UserStopException {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "com/skt/m/UserStopException",
+            parent_class: Some("java/lang/Exception"),
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC)],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m.UserStopException::<init>({this:?})");
+
+        jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m/vibration.rs
+++ b/wie_skvm/src/classes/com/skt/m/vibration.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -15,13 +15,23 @@ impl Vibration {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("getLevelNum", "()I", Self::get_level_num, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("start", "(II)V", Self::start, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("stop", "()V", Self::stop, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("isSupported", "()Z", Self::is_supported, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "getLevelNum",
+                    "()I",
+                    Self::get_level_num,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("start", "(II)V", Self::start, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("stop", "()V", Self::stop, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "isSupported",
+                    "()Z",
+                    Self::is_supported,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
     }
 
@@ -53,5 +63,31 @@ impl Vibration {
         tracing::debug!("com.skt.m.Vibration::isSupported()");
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use test_utils::run_jvm_test;
+
+    use super::Vibration;
+
+    #[test]
+    fn vibration_start_and_stop_use_the_supported_platform_path() {
+        run_jvm_test(Box::new([[Vibration::as_proto()].into()]), |jvm| async move {
+            let supported: bool = jvm.invoke_static("com/skt/m/Vibration", "isSupported", "()Z", ()).await?;
+            assert!(supported);
+
+            let level_count: i32 = jvm.invoke_static("com/skt/m/Vibration", "getLevelNum", "()I", ()).await?;
+            assert_eq!(level_count, 10);
+
+            let _: () = jvm.invoke_static("com/skt/m/Vibration", "start", "(II)V", (6, 250)).await?;
+            let _: () = jvm.invoke_static("com/skt/m/Vibration", "stop", "()V", ()).await?;
+
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/wie_skvm/src/classes/com/skt/m3d.rs
+++ b/wie_skvm/src/classes/com/skt/m3d.rs
@@ -1,0 +1,4 @@
+mod graphics_3d;
+mod object_3d;
+
+pub use {graphics_3d::Graphics3D, object_3d::Object3D};

--- a/wie_skvm/src/classes/com/skt/m3d/graphics_3d.rs
+++ b/wie_skvm/src/classes/com/skt/m3d/graphics_3d.rs
@@ -1,0 +1,204 @@
+use alloc::vec;
+
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+use wie_midp::classes::javax::microedition::lcdui::Graphics;
+
+use super::Object3D;
+
+// class com.skt.m3d.Graphics3D
+pub struct Graphics3D;
+
+impl Graphics3D {
+    pub fn as_proto() -> WieJavaClassProto {
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+
+        WieJavaClassProto {
+            name: "com/skt/m3d/Graphics3D",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("clearZBuffer", "()V", Self::clear_z_buffer, public_static),
+                JavaMethodProto::new("destroyZBuffer", "()V", Self::destroy_z_buffer, public_static),
+                JavaMethodProto::new(
+                    "drawWireframe",
+                    "(Ljavax/microedition/lcdui/Graphics;Lcom/skt/m3d/Object3D;)V",
+                    Self::draw_wireframe,
+                    public_static,
+                ),
+                JavaMethodProto::new("isBackfaceCulled", "()Z", Self::is_backface_culled, public_static),
+                JavaMethodProto::new("isZBufferEnabled", "()Z", Self::is_z_buffer_enabled, public_static),
+                JavaMethodProto::new(
+                    "render",
+                    "(Ljavax/microedition/lcdui/Graphics;Lcom/skt/m3d/Object3D;)V",
+                    Self::render,
+                    public_static,
+                ),
+                JavaMethodProto::new("setBackfaceCulled", "(Z)V", Self::set_backface_culled, public_static),
+                JavaMethodProto::new("setZBufferEnabled", "(Z)V", Self::set_z_buffer_enabled, public_static),
+            ],
+            fields: vec![
+                JavaFieldProto::new("backfaceCulled", "Z", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("zBufferEnabled", "Z", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        jvm.put_static_field("com/skt/m3d/Graphics3D", "backfaceCulled", "Z", false).await?;
+        jvm.put_static_field("com/skt/m3d/Graphics3D", "zBufferEnabled", "Z", false).await
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m3d.Graphics3D::<init>({this:?})");
+        jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+    }
+
+    async fn clear_z_buffer(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Graphics3D::clearZBuffer()");
+        Ok(())
+    }
+
+    async fn destroy_z_buffer(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Graphics3D::destroyZBuffer()");
+        Ok(())
+    }
+
+    async fn draw_wireframe(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        graphics: ClassInstanceRef<Graphics>,
+        object: ClassInstanceRef<Object3D>,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Graphics3D::drawWireframe({graphics:?}, {object:?})");
+
+        if graphics.is_null() || object.is_null() {
+            return Err(jvm
+                .exception("java/lang/NullPointerException", "graphics and object must not be null")
+                .await);
+        }
+
+        Ok(())
+    }
+
+    async fn is_backface_culled(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<bool> {
+        jvm.get_static_field("com/skt/m3d/Graphics3D", "backfaceCulled", "Z").await
+    }
+
+    async fn is_z_buffer_enabled(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<bool> {
+        jvm.get_static_field("com/skt/m3d/Graphics3D", "zBufferEnabled", "Z").await
+    }
+
+    async fn render(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        graphics: ClassInstanceRef<Graphics>,
+        object: ClassInstanceRef<Object3D>,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Graphics3D::render({graphics:?}, {object:?})");
+
+        if graphics.is_null() || object.is_null() {
+            return Err(jvm
+                .exception("java/lang/NullPointerException", "graphics and object must not be null")
+                .await);
+        }
+
+        Ok(())
+    }
+
+    async fn set_backface_culled(jvm: &Jvm, _context: &mut WieJvmContext, enabled: bool) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Graphics3D::setBackfaceCulled({enabled})");
+        jvm.put_static_field("com/skt/m3d/Graphics3D", "backfaceCulled", "Z", enabled).await
+    }
+
+    async fn set_z_buffer_enabled(jvm: &Jvm, _context: &mut WieJvmContext, enabled: bool) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Graphics3D::setZBufferEnabled({enabled})");
+        jvm.put_static_field("com/skt/m3d/Graphics3D", "zBufferEnabled", "Z", enabled).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+    use wie_midp::classes::javax::microedition::lcdui::{Graphics, Image};
+
+    use super::{Graphics3D, Object3D};
+
+    #[test]
+    fn flags_round_trip_and_render_operations_are_no_op() {
+        let result = run_jvm_test(
+            Box::new([wie_midp::get_protos().into(), Box::new([Graphics3D::as_proto(), Object3D::as_proto()])]),
+            |jvm| async move {
+                let _: ClassInstanceRef<Graphics3D> = jvm.new_class("com/skt/m3d/Graphics3D", "()V", ()).await?.into();
+
+                let z_buffer_enabled: bool = jvm.invoke_static("com/skt/m3d/Graphics3D", "isZBufferEnabled", "()Z", ()).await?;
+                let backface_culled: bool = jvm.invoke_static("com/skt/m3d/Graphics3D", "isBackfaceCulled", "()Z", ()).await?;
+                assert!(!z_buffer_enabled);
+                assert!(!backface_culled);
+
+                let _: () = jvm.invoke_static("com/skt/m3d/Graphics3D", "setZBufferEnabled", "(Z)V", (true,)).await?;
+                let _: () = jvm.invoke_static("com/skt/m3d/Graphics3D", "setBackfaceCulled", "(Z)V", (true,)).await?;
+                assert!(
+                    jvm.invoke_static::<_, bool>("com/skt/m3d/Graphics3D", "isZBufferEnabled", "()Z", ())
+                        .await?
+                );
+                assert!(
+                    jvm.invoke_static::<_, bool>("com/skt/m3d/Graphics3D", "isBackfaceCulled", "()Z", ())
+                        .await?
+                );
+
+                let _: () = jvm.invoke_static("com/skt/m3d/Graphics3D", "clearZBuffer", "()V", ()).await?;
+                let _: () = jvm.invoke_static("com/skt/m3d/Graphics3D", "destroyZBuffer", "()V", ()).await?;
+                assert!(
+                    jvm.invoke_static::<_, bool>("com/skt/m3d/Graphics3D", "isZBufferEnabled", "()Z", ())
+                        .await?
+                );
+
+                let image: ClassInstanceRef<Image> = jvm
+                    .invoke_static(
+                        "javax/microedition/lcdui/Image",
+                        "createImage",
+                        "(II)Ljavax/microedition/lcdui/Image;",
+                        (2, 2),
+                    )
+                    .await?;
+                let graphics: ClassInstanceRef<Graphics> = jvm
+                    .invoke_virtual(&image, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .await?;
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "triangle").await?.into();
+                let object: ClassInstanceRef<Object3D> = jvm.new_class("com/skt/m3d/Object3D", "(Ljava/lang/String;)V", (name,)).await?.into();
+
+                let _: () = jvm
+                    .invoke_static(
+                        "com/skt/m3d/Graphics3D",
+                        "render",
+                        "(Ljavax/microedition/lcdui/Graphics;Lcom/skt/m3d/Object3D;)V",
+                        (graphics.clone(), object.clone()),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_static(
+                        "com/skt/m3d/Graphics3D",
+                        "drawWireframe",
+                        "(Ljavax/microedition/lcdui/Graphics;Lcom/skt/m3d/Object3D;)V",
+                        (graphics, object),
+                    )
+                    .await?;
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+}

--- a/wie_skvm/src/classes/com/skt/m3d/object_3d.rs
+++ b/wie_skvm/src/classes/com/skt/m3d/object_3d.rs
@@ -1,0 +1,226 @@
+use alloc::vec;
+
+use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+const MATRIX_SCALE: i32 = 1_000_000_000;
+
+// class com.skt.m3d.Object3D
+pub struct Object3D;
+
+impl Object3D {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "com/skt/m3d/Object3D",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;[I[I[I[I[I[I[I)V",
+                    Self::init_with_geometry,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("addTriangle", "(IIII)V", Self::add_triangle, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("addVertex", "(III)V", Self::add_vertex, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMatrixRow0", "()[I", Self::get_matrix_row_0, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMatrixRow1", "()[I", Self::get_matrix_row_1, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMatrixRow2", "()[I", Self::get_matrix_row_2, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getName", "()Ljava/lang/String;", Self::get_name, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("rotate", "(III)V", Self::rotate, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("scale", "(III)V", Self::scale, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setName", "(Ljava/lang/String;)V", Self::set_name, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setTriangles", "([I[I[I[I)V", Self::set_triangles, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setVertices", "([I[I[I)V", Self::set_vertices, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("translate", "(III)V", Self::translate, MethodAccessFlags::PUBLIC),
+            ],
+            fields: vec![JavaFieldProto::new("name", "Ljava/lang/String;", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::debug!("com.skt.m3d.Object3D::<init>({this:?}, {name:?})");
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "name", "Ljava/lang/String;", name).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn init_with_geometry(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        name: ClassInstanceRef<String>,
+        vertices_x: ClassInstanceRef<Array<i32>>,
+        vertices_y: ClassInstanceRef<Array<i32>>,
+        vertices_z: ClassInstanceRef<Array<i32>>,
+        triangles_a: ClassInstanceRef<Array<i32>>,
+        triangles_b: ClassInstanceRef<Array<i32>>,
+        triangles_c: ClassInstanceRef<Array<i32>>,
+        triangle_colors: ClassInstanceRef<Array<i32>>,
+    ) -> JvmResult<()> {
+        tracing::warn!(
+            "stub com.skt.m3d.Object3D::<init>({this:?}, {name:?}, {vertices_x:?}, {vertices_y:?}, {vertices_z:?}, {triangles_a:?}, {triangles_b:?}, {triangles_c:?}, {triangle_colors:?})"
+        );
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "name", "Ljava/lang/String;", name).await
+    }
+
+    async fn add_triangle(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        vertex_a: i32,
+        vertex_b: i32,
+        vertex_c: i32,
+        color: i32,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::addTriangle({this:?}, {vertex_a}, {vertex_b}, {vertex_c}, {color})");
+        Ok(())
+    }
+
+    async fn add_vertex(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32, z: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::addVertex({this:?}, {x}, {y}, {z})");
+        Ok(())
+    }
+
+    async fn get_matrix_row_0(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Array<i32>>> {
+        tracing::warn!("stub com.skt.m3d.Object3D::getMatrixRow0({this:?})");
+
+        let mut row = jvm.instantiate_array("I", 4).await?;
+        jvm.store_array(&mut row, 0, [MATRIX_SCALE, 0, 0, 0]).await?;
+        Ok(row.into())
+    }
+
+    async fn get_matrix_row_1(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Array<i32>>> {
+        tracing::warn!("stub com.skt.m3d.Object3D::getMatrixRow1({this:?})");
+
+        let mut row = jvm.instantiate_array("I", 4).await?;
+        jvm.store_array(&mut row, 0, [0, MATRIX_SCALE, 0, 0]).await?;
+        Ok(row.into())
+    }
+
+    async fn get_matrix_row_2(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Array<i32>>> {
+        tracing::warn!("stub com.skt.m3d.Object3D::getMatrixRow2({this:?})");
+
+        let mut row = jvm.instantiate_array("I", 4).await?;
+        jvm.store_array(&mut row, 0, [0, 0, MATRIX_SCALE, 0]).await?;
+        Ok(row.into())
+    }
+
+    async fn get_name(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "name", "Ljava/lang/String;").await
+    }
+
+    async fn rotate(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32, z: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::rotate({this:?}, {x}, {y}, {z})");
+        Ok(())
+    }
+
+    async fn scale(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32, z: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::scale({this:?}, {x}, {y}, {z})");
+        Ok(())
+    }
+
+    async fn set_name(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> JvmResult<()> {
+        jvm.put_field(&mut this, "name", "Ljava/lang/String;", name).await
+    }
+
+    async fn set_triangles(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        vertices_a: ClassInstanceRef<Array<i32>>,
+        vertices_b: ClassInstanceRef<Array<i32>>,
+        vertices_c: ClassInstanceRef<Array<i32>>,
+        colors: ClassInstanceRef<Array<i32>>,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::setTriangles({this:?}, {vertices_a:?}, {vertices_b:?}, {vertices_c:?}, {colors:?})");
+        Ok(())
+    }
+
+    async fn set_vertices(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        vertices_x: ClassInstanceRef<Array<i32>>,
+        vertices_y: ClassInstanceRef<Array<i32>>,
+        vertices_z: ClassInstanceRef<Array<i32>>,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::setVertices({this:?}, {vertices_x:?}, {vertices_y:?}, {vertices_z:?})");
+        Ok(())
+    }
+
+    async fn translate(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32, z: i32) -> JvmResult<()> {
+        tracing::warn!("stub com.skt.m3d.Object3D::translate({this:?}, {x}, {y}, {z})");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{Array, ClassInstanceRef, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use super::{MATRIX_SCALE, Object3D};
+
+    #[test]
+    fn name_and_identity_matrix_remain_stable_across_geometry_calls() {
+        let result = run_jvm_test(Box::new([[Object3D::as_proto()].into()]), |jvm| async move {
+            let initial_name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "cube").await?.into();
+            let object: ClassInstanceRef<Object3D> = jvm
+                .new_class("com/skt/m3d/Object3D", "(Ljava/lang/String;)V", (initial_name.clone(),))
+                .await?
+                .into();
+
+            let returned_name: ClassInstanceRef<String> = jvm.invoke_virtual(&object, "getName", "()Ljava/lang/String;", ()).await?;
+            assert_eq!(
+                returned_name.instance.as_ref().map(|instance| instance.identity()),
+                initial_name.instance.as_ref().map(|instance| instance.identity())
+            );
+
+            let renamed: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "renamed").await?.into();
+            let _: () = jvm
+                .invoke_virtual(&object, "setName", "(Ljava/lang/String;)V", (renamed.clone(),))
+                .await?;
+            let returned_name: ClassInstanceRef<String> = jvm.invoke_virtual(&object, "getName", "()Ljava/lang/String;", ()).await?;
+            assert_eq!(
+                returned_name.instance.as_ref().map(|instance| instance.identity()),
+                renamed.instance.as_ref().map(|instance| instance.identity())
+            );
+
+            let _: () = jvm.invoke_virtual(&object, "addVertex", "(III)V", (1, 2, 3)).await?;
+            let _: () = jvm.invoke_virtual(&object, "addTriangle", "(IIII)V", (0, 1, 2, 0xff00ff)).await?;
+            let _: () = jvm.invoke_virtual(&object, "rotate", "(III)V", (10, 20, 30)).await?;
+            let _: () = jvm.invoke_virtual(&object, "translate", "(III)V", (40, 50, 60)).await?;
+            let _: () = jvm.invoke_virtual(&object, "scale", "(III)V", (2, 3, 4)).await?;
+
+            let row_0: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow0", "()[I", ()).await?;
+            let row_1: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow1", "()[I", ()).await?;
+            let row_2: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow2", "()[I", ()).await?;
+            assert_eq!(jvm.load_array::<i32>(&row_0, 0, 4).await?, [MATRIX_SCALE, 0, 0, 0]);
+            assert_eq!(jvm.load_array::<i32>(&row_1, 0, 4).await?, [0, MATRIX_SCALE, 0, 0]);
+            assert_eq!(jvm.load_array::<i32>(&row_2, 0, 4).await?, [0, 0, MATRIX_SCALE, 0]);
+
+            let another_row_0: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow0", "()[I", ()).await?;
+            assert_ne!(
+                another_row_0.instance.as_ref().map(|instance| instance.identity()),
+                row_0.instance.as_ref().map(|instance| instance.identity())
+            );
+
+            Ok(())
+        });
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+}

--- a/wie_skvm/src/classes/com/xce/io/file_input_stream.rs
+++ b/wie_skvm/src/classes/com/xce/io/file_input_stream.rs
@@ -1,32 +1,45 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_runtime::classes::java::{io::FileDescriptor, lang::String};
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::{io::InputStream, lang::String};
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::com::xce::io::x_file::XFile;
+use crate::classes::com::xce::io::x_file::{FILE_JAR, NORMAL, READ, READ_RESOURCE, READ_WRITE, SEEK_CUR, SEEK_SET, STDIN, STDSTREAM, XFile};
 
 // class com.xce.io.FileInputStream
 pub struct FileInputStream;
 
 impl FileInputStream {
     pub fn as_proto() -> WieJavaClassProto {
+        let public = MethodAccessFlags::PUBLIC;
+
         WieJavaClassProto {
             name: "com/xce/io/FileInputStream",
             parent_class: Some("java/io/InputStream"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Lcom/xce/io/XFile;)V", Self::init_with_file, Default::default()),
-                JavaMethodProto::new("available", "()I", Self::available, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
-                JavaMethodProto::new("read", "()I", Self::read_byte, Default::default()),
-                JavaMethodProto::new("read", "([BII)I", Self::read_array, Default::default()),
+                JavaMethodProto::new("<init>", "(I)V", Self::init_with_fd, public),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, public),
+                JavaMethodProto::new("<init>", "(Lcom/xce/io/XFile;)V", Self::init_with_file, public),
+                JavaMethodProto::new("available", "()I", Self::available, public),
+                JavaMethodProto::new("close", "()V", Self::close, public),
+                JavaMethodProto::new("mark", "(I)V", Self::mark, public),
+                JavaMethodProto::new("markSupported", "()Z", Self::mark_supported, public),
+                JavaMethodProto::new("read", "()I", Self::read_byte, public),
+                JavaMethodProto::new("read", "([B)I", Self::read_array_full, public),
+                JavaMethodProto::new("read", "([BII)I", Self::read_array, public),
+                JavaMethodProto::new("reset", "()V", Self::reset, public),
+                JavaMethodProto::new("skip", "(J)J", Self::skip, public),
             ],
-            fields: vec![JavaFieldProto::new("is", "Ljava/io/InputStream;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![
+                JavaFieldProto::new("file", "Lcom/xce/io/XFile;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("markPosition", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("marked", "Z", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -34,11 +47,26 @@ impl FileInputStream {
         tracing::debug!("com.xce.io.FileInputStream::<init>({this:?}, {name:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/InputStream", "<init>", "()V", ()).await?;
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
 
-        let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let is = jvm.new_class("java/io/FileInputStream", "(Ljava/io/File;)V", (file,)).await?;
+        let file = jvm.new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, READ)).await?;
+        jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
-        jvm.put_field(&mut this, "is", "Ljava/io/InputStream;", is).await?;
+        Ok(())
+    }
+
+    async fn init_with_fd(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, fd: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileInputStream::<init>({this:?}, {fd})");
+
+        let _: () = jvm.invoke_special(&this, "java/io/InputStream", "<init>", "()V", ()).await?;
+        if fd != STDIN {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "fd must be STDIN").await);
+        }
+
+        let file = jvm.new_class("com/xce/io/XFile", "(I)V", (fd,)).await?;
+        jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
         Ok(())
     }
@@ -51,11 +79,24 @@ impl FileInputStream {
     ) -> JvmResult<()> {
         tracing::debug!("com.xce.io.FileInputStream::<init>({this:?}, {file:?})");
 
-        let raf = XFile::raf(jvm, file).await?;
-        let fd: ClassInstanceRef<FileDescriptor> = jvm.invoke_virtual(&raf, "getFD", "()Ljava/io/FileDescriptor;", ()).await?;
-        let is = jvm.new_class("java/io/FileInputStream", "(Ljava/io/FileDescriptor;)V", (fd,)).await?;
+        let _: () = jvm.invoke_special(&this, "java/io/InputStream", "<init>", "()V", ()).await?;
+        if file.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "file is null").await);
+        }
 
-        jvm.put_field(&mut this, "is", "Ljava/io/InputStream;", is).await?;
+        let file_type: i32 = jvm.get_field(&file, "type", "I").await?;
+        let mode: i32 = jvm.get_field(&file, "mode", "I").await?;
+        let fd: i32 = jvm.get_field(&file, "fd", "I").await?;
+        let readable = match file_type {
+            STDSTREAM => fd == STDIN && mode == READ,
+            NORMAL => mode == READ || mode == READ_WRITE,
+            FILE_JAR => mode == READ_RESOURCE,
+            _ => false,
+        };
+        if !readable {
+            return Err(jvm.exception("java/io/IOException", "XFile is not open for reading").await);
+        }
+        jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
         Ok(())
     }
@@ -63,8 +104,8 @@ impl FileInputStream {
     async fn available(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.FileInputStream::available({this:?})");
 
-        let is = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
-        let available = jvm.invoke_virtual(&is, "available", "()I", ()).await?;
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let available = jvm.invoke_virtual(&file, "available", "()I", ()).await?;
 
         Ok(available)
     }
@@ -72,34 +113,136 @@ impl FileInputStream {
     async fn close(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("com.xce.io.FileInputStream::close({this:?})");
 
-        let is = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
-        let _: () = jvm.invoke_virtual(&is, "close", "()V", ()).await?;
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let _: () = jvm.invoke_virtual(&file, "close", "()V", ()).await?;
 
         Ok(())
+    }
+
+    async fn mark(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, read_limit: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileInputStream::mark({this:?}, {read_limit})");
+
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let file_type: i32 = jvm.get_field(&file, "type", "I").await?;
+        let mode: i32 = jvm.get_field(&file, "mode", "I").await?;
+        if file_type == STDSTREAM || mode == READ_RESOURCE {
+            let stream: ClassInstanceRef<InputStream> = jvm.get_field(&file, "is", "Ljava/io/InputStream;").await?;
+            let _: () = jvm.invoke_virtual(&stream, "mark", "(I)V", (read_limit,)).await?;
+            let position: i32 = jvm.get_field(&file, "offset", "I").await?;
+            jvm.put_field(&mut this, "markPosition", "I", position).await?;
+        } else {
+            let position: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (0, SEEK_CUR)).await?;
+            jvm.put_field(&mut this, "markPosition", "I", position).await?;
+        }
+        jvm.put_field(&mut this, "marked", "Z", true).await?;
+
+        Ok(())
+    }
+
+    async fn mark_supported(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        Ok(true)
     }
 
     async fn read_byte(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.FileInputStream::read({this:?})");
 
-        let is = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
-        let read = jvm.invoke_virtual(&is, "read", "()I", ()).await?;
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let buffer: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 1).await?.into();
+        let read: i32 = jvm.invoke_virtual(&file, "read", "([BII)I", (buffer.clone(), 0, 1)).await?;
+        if read <= 0 {
+            return Ok(-1);
+        }
+        let byte = jvm.load_array::<i8>(&buffer, 0, 1).await?;
 
-        Ok(read)
+        Ok(byte[0] as u8 as i32)
+    }
+
+    async fn read_array_full(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        buffer: ClassInstanceRef<Array<i8>>,
+    ) -> JvmResult<i32> {
+        tracing::debug!("com.xce.io.FileInputStream::read({this:?}, {buffer:?})");
+
+        if buffer.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "buffer is null").await);
+        }
+        let length = jvm.array_length(&buffer).await? as i32;
+
+        jvm.invoke_virtual(&this, "read", "([BII)I", (buffer, 0, length)).await
     }
 
     async fn read_array(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
-        buf: ClassInstanceRef<jvm::Array<i8>>,
+        buf: ClassInstanceRef<Array<i8>>,
         offset: i32,
         length: i32,
     ) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.FileInputStream::read({this:?}, {buf:?}, {offset}, {length})");
 
-        let is = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
-        let read = jvm.invoke_virtual(&is, "read", "([BII)I", (buf, offset, length)).await?;
+        if buf.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "buffer is null").await);
+        }
+        let array_length = jvm.array_length(&buf).await? as i32;
+        if offset < 0 || length < 0 || offset > array_length - length {
+            return Err(jvm.exception("java/lang/IndexOutOfBoundsException", "Invalid offset or length").await);
+        }
+        if length == 0 {
+            return Ok(0);
+        }
 
-        Ok(read)
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let read: i32 = jvm.invoke_virtual(&file, "read", "([BII)I", (buf, offset, length)).await?;
+
+        Ok(if read == 0 { -1 } else { read })
+    }
+
+    async fn reset(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileInputStream::reset({this:?})");
+
+        let marked: bool = jvm.get_field(&this, "marked", "Z").await?;
+        if !marked {
+            return Err(jvm.exception("java/io/IOException", "Stream has not been marked").await);
+        }
+
+        let mut file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let file_type: i32 = jvm.get_field(&file, "type", "I").await?;
+        let mode: i32 = jvm.get_field(&file, "mode", "I").await?;
+        if file_type == STDSTREAM || mode == READ_RESOURCE {
+            let stream: ClassInstanceRef<InputStream> = jvm.get_field(&file, "is", "Ljava/io/InputStream;").await?;
+            let _: () = jvm.invoke_virtual(&stream, "reset", "()V", ()).await?;
+            let position: i32 = jvm.get_field(&this, "markPosition", "I").await?;
+            jvm.put_field(&mut file, "offset", "I", position).await?;
+        } else {
+            let position: i32 = jvm.get_field(&this, "markPosition", "I").await?;
+            let _: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (position, SEEK_SET)).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn skip(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, count: i64) -> JvmResult<i64> {
+        tracing::debug!("com.xce.io.FileInputStream::skip({this:?}, {count})");
+
+        if count <= 0 {
+            return Ok(0);
+        }
+
+        let scratch_size = count.min(4096) as usize;
+        let scratch: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", scratch_size).await?.into();
+        let mut remaining = count;
+        while remaining > 0 {
+            let request = remaining.min(scratch_size as i64) as i32;
+            let read: i32 = jvm.invoke_virtual(&this, "read", "([BII)I", (scratch.clone(), 0, request)).await?;
+            if read <= 0 {
+                break;
+            }
+            remaining -= read as i64;
+        }
+
+        Ok(count - remaining)
     }
 }

--- a/wie_skvm/src/classes/com/xce/io/file_output_stream.rs
+++ b/wie_skvm/src/classes/com/xce/io/file_output_stream.rs
@@ -1,42 +1,92 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_runtime::classes::java::{io::FileDescriptor, lang::String};
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::com::xce::io::x_file::XFile;
+use crate::classes::com::xce::io::x_file::{NORMAL, READ_WRITE, SEEK_END, SEEK_SET, STDERR, STDOUT, STDSTREAM, WRITE, XFile};
 
 // class com.xce.io.FileOutputStream
 pub struct FileOutputStream;
 
 impl FileOutputStream {
     pub fn as_proto() -> WieJavaClassProto {
+        let public = MethodAccessFlags::PUBLIC;
+
         WieJavaClassProto {
             name: "com/xce/io/FileOutputStream",
             parent_class: Some("java/io/OutputStream"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Lcom/xce/io/XFile;)V", Self::init_with_file, Default::default()),
-                JavaMethodProto::new("write", "(I)V", Self::write, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
+                JavaMethodProto::new("<init>", "(I)V", Self::init_with_fd, public),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, public),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;Z)V", Self::init_with_truncate, public),
+                JavaMethodProto::new("<init>", "(Lcom/xce/io/XFile;)V", Self::init_with_file, public),
+                JavaMethodProto::new("close", "()V", Self::close, public),
+                JavaMethodProto::new("flush", "()V", Self::flush, public),
+                JavaMethodProto::new("write", "([BII)V", Self::write_array, public),
+                JavaMethodProto::new("write", "(I)V", Self::write, public),
             ],
-            fields: vec![JavaFieldProto::new("os", "Ljava/io/OutputStream;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new("file", "Lcom/xce/io/XFile;", FieldAccessFlags::PROTECTED)],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
-    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> JvmResult<()> {
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> JvmResult<()> {
         tracing::debug!("com.xce.io.FileOutputStream::<init>({this:?}, {name:?})");
 
+        let _: () = jvm
+            .invoke_special(&this, "com/xce/io/FileOutputStream", "<init>", "(Ljava/lang/String;Z)V", (name, true))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn init_with_truncate(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        name: ClassInstanceRef<String>,
+        truncate: bool,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileOutputStream::<init>({this:?}, {name:?}, {truncate})");
+
         let _: () = jvm.invoke_special(&this, "java/io/OutputStream", "<init>", "()V", ()).await?;
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
 
-        let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let os = jvm.new_class("java/io/FileOutputStream", "(Ljava/io/File;)V", (file,)).await?;
+        let existed = if truncate {
+            false
+        } else {
+            jvm.invoke_static("com/xce/io/XFile", "exists", "(Ljava/lang/String;)Z", (name.clone(),))
+                .await?
+        };
+        let file: ClassInstanceRef<XFile> = jvm.new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, WRITE)).await?.into();
+        if truncate {
+            let raf = XFile::raf(jvm, file.clone()).await?;
+            let _: () = jvm.invoke_virtual(&raf, "setLength", "(J)V", (0_i64,)).await?;
+        }
+        let whence = if !truncate && existed { SEEK_END } else { SEEK_SET };
+        let _: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (0, whence)).await?;
+        jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
-        jvm.put_field(&mut this, "os", "Ljava/io/OutputStream;", os).await?;
+        Ok(())
+    }
+
+    async fn init_with_fd(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, fd: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileOutputStream::<init>({this:?}, {fd})");
+
+        let _: () = jvm.invoke_special(&this, "java/io/OutputStream", "<init>", "()V", ()).await?;
+        if fd != STDOUT && fd != STDERR {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "fd must be STDOUT or STDERR").await);
+        }
+
+        let file = jvm.new_class("com/xce/io/XFile", "(I)V", (fd,)).await?;
+        jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
         Ok(())
     }
@@ -49,11 +99,23 @@ impl FileOutputStream {
     ) -> JvmResult<()> {
         tracing::debug!("com.xce.io.FileOutputStream::<init>({file:?})");
 
-        let raf = XFile::raf(jvm, file).await?;
-        let fd: ClassInstanceRef<FileDescriptor> = jvm.invoke_virtual(&raf, "getFD", "()Ljava/io/FileDescriptor;", ()).await?;
-        let os = jvm.new_class("java/io/FileOutputStream", "(Ljava/io/FileDescriptor;)V", (fd,)).await?;
+        let _: () = jvm.invoke_special(&this, "java/io/OutputStream", "<init>", "()V", ()).await?;
+        if file.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "file is null").await);
+        }
 
-        jvm.put_field(&mut this, "os", "Ljava/io/OutputStream;", os).await?;
+        let file_type: i32 = jvm.get_field(&file, "type", "I").await?;
+        let mode: i32 = jvm.get_field(&file, "mode", "I").await?;
+        let fd: i32 = jvm.get_field(&file, "fd", "I").await?;
+        let writable = match file_type {
+            STDSTREAM => (fd == STDOUT || fd == STDERR) && mode == WRITE,
+            NORMAL => mode == WRITE || mode == READ_WRITE,
+            _ => false,
+        };
+        if !writable {
+            return Err(jvm.exception("java/io/IOException", "XFile is not open for writing").await);
+        }
+        jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
         Ok(())
     }
@@ -61,8 +123,37 @@ impl FileOutputStream {
     async fn write(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, byte: i32) -> JvmResult<()> {
         tracing::debug!("com.xce.io.FileOutputStream::write({this:?}, {byte:?})");
 
-        let os = jvm.get_field(&this, "os", "Ljava/io/OutputStream;").await?;
-        let _: () = jvm.invoke_virtual(&os, "write", "(I)V", (byte,)).await?;
+        let mut buffer = jvm.instantiate_array("B", 1).await?;
+        jvm.store_array(&mut buffer, 0, [byte as i8]).await?;
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let _: i32 = jvm.invoke_virtual(&file, "write", "([BII)I", (buffer, 0, 1)).await?;
+
+        Ok(())
+    }
+
+    async fn write_array(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        buffer: ClassInstanceRef<Array<i8>>,
+        offset: i32,
+        length: i32,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileOutputStream::write({this:?}, {buffer:?}, {offset}, {length})");
+
+        if buffer.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "buffer is null").await);
+        }
+        let array_length = jvm.array_length(&buffer).await? as i32;
+        if offset < 0 || length < 0 || offset > array_length - length {
+            return Err(jvm.exception("java/lang/IndexOutOfBoundsException", "Invalid offset or length").await);
+        }
+        if length == 0 {
+            return Ok(());
+        }
+
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let _: i32 = jvm.invoke_virtual(&file, "write", "([BII)I", (buffer, offset, length)).await?;
 
         Ok(())
     }
@@ -70,8 +161,17 @@ impl FileOutputStream {
     async fn close(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("com.xce.io.FileOutputStream::close({this:?})");
 
-        let os = jvm.get_field(&this, "os", "Ljava/io/OutputStream;").await?;
-        let _: () = jvm.invoke_virtual(&os, "close", "()V", ()).await?;
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let _: () = jvm.invoke_virtual(&file, "close", "()V", ()).await?;
+
+        Ok(())
+    }
+
+    async fn flush(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.FileOutputStream::flush({this:?})");
+
+        let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
+        let _: () = jvm.invoke_virtual(&file, "flush", "()V", ()).await?;
 
         Ok(())
     }

--- a/wie_skvm/src/classes/com/xce/io/x_file.rs
+++ b/wie_skvm/src/classes/com/xce/io/x_file.rs
@@ -1,50 +1,158 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::{
-    io::{InputStream, RandomAccessFile},
+    io::{FileDescriptor, InputStream, OutputStream, RandomAccessFile},
     lang::String,
 };
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-const READ: i32 = 1;
-const READ_RESOURCE: i32 = 8;
+pub(super) const STDSTREAM: i32 = 0;
+pub(super) const NORMAL: i32 = 1;
+const DIRECTORY: i32 = 2;
+pub(super) const FILE_JAR: i32 = 3;
+
+pub(super) const STDIN: i32 = 0;
+pub(super) const STDOUT: i32 = 1;
+pub(super) const STDERR: i32 = 2;
+
+pub(super) const SEEK_SET: i32 = 0;
+pub(super) const SEEK_CUR: i32 = 1;
+pub(super) const SEEK_END: i32 = 2;
+
+pub(super) const READ: i32 = 1;
+pub(super) const WRITE: i32 = 2;
+pub(super) const READ_WRITE: i32 = 3;
+const READ_DIRECTORY: i32 = 4;
+pub(super) const READ_RESOURCE: i32 = 8;
 
 // class com.xce.io.XFile
 pub struct XFile;
 
 impl XFile {
     pub fn as_proto() -> WieJavaClassProto {
+        let public = MethodAccessFlags::PUBLIC;
+        let public_static = MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC;
+        let public_static_final = FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL;
+
         WieJavaClassProto {
             name: "com/xce/io/XFile",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, Default::default()),
-                JavaMethodProto::new("exists", "(Ljava/lang/String;)Z", Self::exists, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("filesize", "(Ljava/lang/String;)I", Self::filesize, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("unlink", "(Ljava/lang/String;)I", Self::unlink, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("available", "()I", Self::available, Default::default()),
-                JavaMethodProto::new("read", "([BII)I", Self::read, Default::default()),
-                JavaMethodProto::new("write", "([BII)I", Self::write, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
-                JavaMethodProto::new("seek", "(II)I", Self::seek, Default::default()),
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "(I)V", Self::init_with_fd, public),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, public),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;Ljava/lang/String;)V", Self::init_with_jar, public),
+                JavaMethodProto::new("available", "()I", Self::available, public),
+                JavaMethodProto::new("close", "()V", Self::close, public),
+                JavaMethodProto::new("flush", "()V", Self::flush, public),
+                JavaMethodProto::new("read", "([BII)I", Self::read, public),
+                JavaMethodProto::new("readdir", "()Ljava/lang/String;", Self::read_dir, public),
+                JavaMethodProto::new("seek", "(II)I", Self::seek, public),
+                JavaMethodProto::new("write", "([BII)I", Self::write, public),
+                JavaMethodProto::new("exists", "(Ljava/lang/String;)Z", Self::exists, public_static),
+                JavaMethodProto::new("filesize", "(Ljava/lang/String;)I", Self::filesize, public_static),
+                JavaMethodProto::new("fsavail", "()I", Self::fs_available, public_static),
+                JavaMethodProto::new("fsused", "()I", Self::fs_used, public_static),
+                JavaMethodProto::new("mkdir", "(Ljava/lang/String;)V", Self::make_dir, public_static),
+                JavaMethodProto::new("rmdir", "(Ljava/lang/String;)V", Self::remove_dir, public_static),
+                JavaMethodProto::new("rmrdir", "(Ljava/lang/String;)V", Self::remove_dir_recursive, public_static),
+                JavaMethodProto::new("unlink", "(Ljava/lang/String;)I", Self::unlink, public_static),
             ],
             fields: vec![
-                JavaFieldProto::new("mode", "I", Default::default()),
-                JavaFieldProto::new("is", "Ljava/io/InputStream;", Default::default()),
-                JavaFieldProto::new("raf", "Ljava/io/RandomAccessFile;", Default::default()),
+                JavaFieldProto::new("STDSTREAM", "I", public_static_final),
+                JavaFieldProto::new("NORMAL", "I", public_static_final),
+                JavaFieldProto::new("DIRECTORY", "I", public_static_final),
+                JavaFieldProto::new("FILE_JAR", "I", public_static_final),
+                JavaFieldProto::new("STDIN", "I", public_static_final),
+                JavaFieldProto::new("STDOUT", "I", public_static_final),
+                JavaFieldProto::new("STDERR", "I", public_static_final),
+                JavaFieldProto::new("SEEK_SET", "I", public_static_final),
+                JavaFieldProto::new("SEEK_CUR", "I", public_static_final),
+                JavaFieldProto::new("SEEK_END", "I", public_static_final),
+                JavaFieldProto::new("READ", "I", public_static_final),
+                JavaFieldProto::new("WRITE", "I", public_static_final),
+                JavaFieldProto::new("READ_WRITE", "I", public_static_final),
+                JavaFieldProto::new("READ_DIRECTORY", "I", public_static_final),
+                JavaFieldProto::new("READ_RESOURCE", "I", public_static_final),
+                JavaFieldProto::new("type", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("mode", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("fd", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("offset", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("buf", "[B", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("is", "Ljava/io/InputStream;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("os", "Ljava/io/OutputStream;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("raf", "Ljava/io/RandomAccessFile;", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.XFile::<clinit>()");
+
+        jvm.put_static_field("com/xce/io/XFile", "STDSTREAM", "I", STDSTREAM).await?;
+        jvm.put_static_field("com/xce/io/XFile", "NORMAL", "I", NORMAL).await?;
+        jvm.put_static_field("com/xce/io/XFile", "DIRECTORY", "I", DIRECTORY).await?;
+        jvm.put_static_field("com/xce/io/XFile", "FILE_JAR", "I", FILE_JAR).await?;
+        jvm.put_static_field("com/xce/io/XFile", "STDIN", "I", STDIN).await?;
+        jvm.put_static_field("com/xce/io/XFile", "STDOUT", "I", STDOUT).await?;
+        jvm.put_static_field("com/xce/io/XFile", "STDERR", "I", STDERR).await?;
+        jvm.put_static_field("com/xce/io/XFile", "SEEK_SET", "I", SEEK_SET).await?;
+        jvm.put_static_field("com/xce/io/XFile", "SEEK_CUR", "I", SEEK_CUR).await?;
+        jvm.put_static_field("com/xce/io/XFile", "SEEK_END", "I", SEEK_END).await?;
+        jvm.put_static_field("com/xce/io/XFile", "READ", "I", READ).await?;
+        jvm.put_static_field("com/xce/io/XFile", "WRITE", "I", WRITE).await?;
+        jvm.put_static_field("com/xce/io/XFile", "READ_WRITE", "I", READ_WRITE).await?;
+        jvm.put_static_field("com/xce/io/XFile", "READ_DIRECTORY", "I", READ_DIRECTORY).await?;
+        jvm.put_static_field("com/xce/io/XFile", "READ_RESOURCE", "I", READ_RESOURCE).await?;
+
+        Ok(())
+    }
+
+    async fn init_with_fd(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, fd: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.XFile::<init>({this:?}, {fd})");
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        if fd != STDIN && fd != STDOUT && fd != STDERR {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "Invalid standard stream descriptor")
+                .await);
+        }
+
+        jvm.put_field(&mut this, "type", "I", STDSTREAM).await?;
+        jvm.put_field(&mut this, "mode", "I", if fd == STDIN { READ } else { WRITE }).await?;
+        jvm.put_field(&mut this, "fd", "I", fd).await?;
+        jvm.put_field(&mut this, "offset", "I", 0).await?;
+
+        if fd == STDIN {
+            let empty: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 0).await?.into();
+            let stream = jvm.new_class("java/io/ByteArrayInputStream", "([B)V", (empty,)).await?;
+            jvm.put_field(&mut this, "is", "Ljava/io/InputStream;", stream).await?;
+        } else {
+            let field_name = if fd == STDOUT { "out" } else { "err" };
+            let descriptor: ClassInstanceRef<FileDescriptor> = jvm
+                .get_static_field("java/io/FileDescriptor", field_name, "Ljava/io/FileDescriptor;")
+                .await?;
+            if descriptor.is_null() {
+                return Err(jvm.exception("java/io/IOException", "Standard stream is not supported").await);
+            }
+            let stream = jvm
+                .new_class("java/io/FileOutputStream", "(Ljava/io/FileDescriptor;)V", (descriptor,))
+                .await?;
+            jvm.put_field(&mut this, "os", "Ljava/io/OutputStream;", stream).await?;
+        }
+
+        Ok(())
     }
 
     async fn init(
         jvm: &Jvm,
-        _context: &mut WieJvmContext,
+        context: &mut WieJvmContext,
         mut this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
         mode: i32,
@@ -52,33 +160,85 @@ impl XFile {
         tracing::debug!("com.xce.io.XFile::<init>({this:?}, {name:?}, {mode:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
+
+        jvm.put_field(&mut this, "mode", "I", mode).await?;
+        jvm.put_field(&mut this, "offset", "I", 0).await?;
 
         if mode == READ_RESOURCE {
             let class = jvm.invoke_virtual(&this, "getClass", "()Ljava/lang/Class;", ()).await?;
             let resource_stream: ClassInstanceRef<InputStream> = jvm
                 .invoke_virtual(&class, "getResourceAsStream", "(Ljava/lang/String;)Ljava/io/InputStream;", (name,))
                 .await?;
+            if resource_stream.is_null() {
+                return Err(jvm.exception("java/io/IOException", "Resource not found").await);
+            }
 
             jvm.put_field(&mut this, "is", "Ljava/io/InputStream;", resource_stream).await?;
-            jvm.put_field(&mut this, "mode", "I", mode).await?;
+            jvm.put_field(&mut this, "type", "I", FILE_JAR).await?;
         } else {
+            if mode == READ_DIRECTORY {
+                return Err(jvm.exception("java/io/IOException", "Directory reads are not supported").await);
+            }
+            if mode != READ && mode != WRITE && mode != READ_WRITE {
+                return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid file mode").await);
+            }
+
+            let guest_path = JavaLangString::to_rust_string(jvm, &name).await?;
+            if !context.system().filesystem().is_valid_path(&guest_path) {
+                return Err(jvm.exception("java/io/IOException", "Invalid file path").await);
+            }
+
             let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
 
             let file_mode = if mode == READ { "r" } else { "rw" };
             let file_mode = JavaLangString::from_rust_string(jvm, file_mode).await?;
 
-            let raf = jvm
+            let raf: ClassInstanceRef<RandomAccessFile> = jvm
                 .new_class("java/io/RandomAccessFile", "(Ljava/io/File;Ljava/lang/String;)V", (file, file_mode))
-                .await?;
+                .await?
+                .into();
+            let descriptor: ClassInstanceRef<FileDescriptor> = jvm.invoke_virtual(&raf, "getFD", "()Ljava/io/FileDescriptor;", ()).await?;
+            let fd: i32 = jvm.get_field(&descriptor, "fd", "I").await?;
+
+            jvm.put_field(&mut this, "type", "I", NORMAL).await?;
+            jvm.put_field(&mut this, "fd", "I", fd).await?;
             jvm.put_field(&mut this, "raf", "Ljava/io/RandomAccessFile;", raf).await?;
-            jvm.put_field(&mut this, "mode", "I", mode).await?;
         }
 
         Ok(())
     }
 
-    async fn exists(jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<bool> {
+    async fn init_with_jar(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        jar_file: ClassInstanceRef<String>,
+        name: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.XFile::<init>({this:?}, {jar_file:?}, {name:?})");
+
+        if jar_file.is_null() || name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "jarfile and name must not be null").await);
+        }
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        tracing::warn!("unsupported com.xce.io.XFile::<init>(jarfile, name)");
+        Err(jvm.exception("java/io/IOException", "JAR file selection is not supported").await)
+    }
+
+    async fn exists(jvm: &Jvm, context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<bool> {
         tracing::debug!("com.xce.io.XFile::exists({name:?})");
+
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
+        let guest_path = JavaLangString::to_rust_string(jvm, &name).await?;
+        if !context.system().filesystem().is_valid_path(&guest_path) {
+            return Err(jvm.exception("java/io/IOException", "Invalid file path").await);
+        }
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
         let exists = jvm.invoke_virtual(&file, "exists", "()Z", ()).await?;
@@ -86,17 +246,46 @@ impl XFile {
         Ok(exists)
     }
 
-    async fn filesize(jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<i32> {
+    async fn filesize(jvm: &Jvm, context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.XFile::filesize({name:?})");
 
-        let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let size: i64 = jvm.invoke_virtual(&file, "length", "()J", ()).await?;
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
+        let guest_path = JavaLangString::to_rust_string(jvm, &name).await?;
+        if !context.system().filesystem().is_valid_path(&guest_path) {
+            return Err(jvm.exception("java/io/IOException", "Invalid file path").await);
+        }
 
-        Ok(size as _)
+        let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
+        let exists: bool = jvm.invoke_virtual(&file, "exists", "()Z", ()).await?;
+        if !exists {
+            return Err(jvm.exception("java/io/IOException", "File not found").await);
+        }
+        let size: i64 = jvm.invoke_virtual(&file, "length", "()J", ()).await?;
+        if size < 0 || size > i32::MAX as i64 {
+            return Err(jvm.exception("java/io/IOException", "File is too large").await);
+        }
+
+        Ok(size as i32)
     }
 
-    async fn unlink(_jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<i32> {
-        tracing::warn!("stub com.xce.io.XFile::unlink({name:?})");
+    async fn unlink(jvm: &Jvm, context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<i32> {
+        tracing::debug!("com.xce.io.XFile::unlink({name:?})");
+
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "name is null").await);
+        }
+        let guest_path = JavaLangString::to_rust_string(jvm, &name).await?;
+        if !context.system().filesystem().is_valid_path(&guest_path) {
+            return Err(jvm.exception("java/io/IOException", "Invalid file path").await);
+        }
+
+        let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
+        let deleted: bool = jvm.invoke_virtual(&file, "delete", "()Z", ()).await?;
+        if !deleted {
+            return Err(jvm.exception("java/io/IOException", "Unable to delete file").await);
+        }
 
         Ok(0)
     }
@@ -104,9 +293,16 @@ impl XFile {
     async fn available(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.XFile::available({this:?})");
 
+        let file_type: i32 = jvm.get_field(&this, "type", "I").await?;
         let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
-        if mode == READ_RESOURCE {
+        if mode != READ && mode != READ_WRITE && mode != READ_RESOURCE {
+            return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
+        }
+        if file_type == STDSTREAM || mode == READ_RESOURCE {
             let is: ClassInstanceRef<InputStream> = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
+            if is.is_null() {
+                return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
+            }
             let available = jvm.invoke_virtual(&is, "available", "()I", ()).await?;
 
             Ok(available)
@@ -115,52 +311,96 @@ impl XFile {
             let file_length: i64 = jvm.invoke_virtual(&raf, "length", "()J", ()).await?;
             let file_pointer: i64 = jvm.invoke_virtual(&raf, "getFilePointer", "()J", ()).await?;
 
-            Ok((file_length - file_pointer) as i32)
+            Ok((file_length - file_pointer).clamp(0, i32::MAX as i64) as i32)
         }
     }
 
     async fn read(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         data: ClassInstanceRef<Array<i8>>,
         offset: i32,
         length: i32,
     ) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.XFile::read({this:?}, {data:?}, {offset}, {length})");
 
-        let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
-
-        if mode == READ_RESOURCE {
-            let is: ClassInstanceRef<InputStream> = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
-            let read: i32 = jvm.invoke_virtual(&is, "read", "([BII)I", (data, offset, length)).await?;
-
-            Ok(read)
-        } else {
-            let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-            let read: i32 = jvm.invoke_virtual(&raf, "read", "([BII)I", (data, offset, length)).await?;
-
-            Ok(read)
+        if data.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "buffer is null").await);
         }
+        let array_length = jvm.array_length(&data).await? as i32;
+        if offset < 0 || length < 0 || offset > array_length - length {
+            return Err(jvm.exception("java/lang/IndexOutOfBoundsException", "Invalid offset or length").await);
+        }
+        if length == 0 {
+            return Ok(0);
+        }
+
+        let file_type: i32 = jvm.get_field(&this, "type", "I").await?;
+        let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
+        let read = if file_type == STDSTREAM || mode == READ_RESOURCE {
+            let is: ClassInstanceRef<InputStream> = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
+            if is.is_null() {
+                return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
+            }
+
+            jvm.invoke_virtual(&is, "read", "([BII)I", (data, offset, length)).await?
+        } else {
+            if mode != READ && mode != READ_WRITE {
+                return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
+            }
+            let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
+
+            jvm.invoke_virtual(&raf, "read", "([BII)I", (data, offset, length)).await?
+        };
+
+        if read > 0 {
+            let old_offset: i32 = jvm.get_field(&this, "offset", "I").await?;
+            jvm.put_field(&mut this, "offset", "I", old_offset.saturating_add(read)).await?;
+        }
+
+        Ok(read)
     }
 
     async fn write(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         data: ClassInstanceRef<Array<i8>>,
         offset: i32,
         length: i32,
     ) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.XFile::write({this:?}, {data:?}, {offset}, {length})");
 
-        let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
-        if mode == READ_RESOURCE {
-            return Err(jvm.exception("java/io/IOException", "File not opened for writing").await);
+        if data.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "buffer is null").await);
+        }
+        let array_length = jvm.array_length(&data).await? as i32;
+        if offset < 0 || length < 0 || offset > array_length - length {
+            return Err(jvm.exception("java/lang/IndexOutOfBoundsException", "Invalid offset or length").await);
+        }
+        if length == 0 {
+            return Ok(0);
         }
 
-        let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let _: () = jvm.invoke_virtual(&raf, "write", "([BII)V", (data, offset, length)).await?;
+        let file_type: i32 = jvm.get_field(&this, "type", "I").await?;
+        let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
+        if file_type == STDSTREAM {
+            let os: ClassInstanceRef<OutputStream> = jvm.get_field(&this, "os", "Ljava/io/OutputStream;").await?;
+            if os.is_null() {
+                return Err(jvm.exception("java/io/IOException", "File is not open for writing").await);
+            }
+            let _: () = jvm.invoke_virtual(&os, "write", "([BII)V", (data, offset, length)).await?;
+        } else {
+            if mode != WRITE && mode != READ_WRITE {
+                return Err(jvm.exception("java/io/IOException", "File is not open for writing").await);
+            }
+            let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
+            let _: () = jvm.invoke_virtual(&raf, "write", "([BII)V", (data, offset, length)).await?;
+        }
+
+        let old_offset: i32 = jvm.get_field(&this, "offset", "I").await?;
+        jvm.put_field(&mut this, "offset", "I", old_offset.saturating_add(length)).await?;
 
         Ok(length)
     }
@@ -168,8 +408,11 @@ impl XFile {
     async fn close(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("com.xce.io.XFile::close({this:?})");
 
+        let file_type: i32 = jvm.get_field(&this, "type", "I").await?;
         let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
-        if mode == READ_RESOURCE {
+        if file_type == STDSTREAM {
+            return Ok(());
+        } else if mode == READ_RESOURCE {
             let is: ClassInstanceRef<InputStream> = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
             let _: () = jvm.invoke_virtual(&is, "close", "()V", ()).await?;
         } else {
@@ -180,36 +423,391 @@ impl XFile {
         Ok(())
     }
 
-    async fn seek(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, n: i32, whence: i32) -> JvmResult<i32> {
+    async fn flush(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.xce.io.XFile::flush({this:?})");
+
+        let file_type: i32 = jvm.get_field(&this, "type", "I").await?;
+        if file_type == STDSTREAM {
+            let os: ClassInstanceRef<OutputStream> = jvm.get_field(&this, "os", "Ljava/io/OutputStream;").await?;
+            if os.is_null() {
+                return Err(jvm.exception("java/io/IOException", "File is not open for writing").await);
+            }
+            let _: () = jvm.invoke_virtual(&os, "flush", "()V", ()).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn seek(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, n: i32, whence: i32) -> JvmResult<i32> {
         tracing::debug!("com.xce.io.XFile::seek({this:?}, {n}, {whence})");
 
+        let file_type: i32 = jvm.get_field(&this, "type", "I").await?;
         let mode: i32 = jvm.get_field(&this, "mode", "I").await?;
-        if mode == READ_RESOURCE {
-            return Err(jvm.exception("java/io/IOException", "File not opened for writing").await);
+        if file_type == STDSTREAM || mode == READ_RESOURCE {
+            return Err(jvm.exception("java/io/IOException", "File is not seekable").await);
         }
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
         let new_pos = match whence {
-            0 => n as i64,
-            1 => {
+            SEEK_SET => Some(n as i64),
+            SEEK_CUR => {
                 let current: i64 = jvm.invoke_virtual(&raf, "getFilePointer", "()J", ()).await?;
-                current + n as i64
+                current.checked_add(n as i64)
             }
-            2 => {
+            SEEK_END => {
                 let length: i64 = jvm.invoke_virtual(&raf, "length", "()J", ()).await?;
-                length + n as i64
+                length.checked_add(n as i64)
             }
             _ => return Err(jvm.exception("java/io/IOException", "Invalid whence").await),
         };
+        let Some(new_pos) = new_pos else {
+            return Err(jvm.exception("java/io/IOException", "Seek position overflow").await);
+        };
+        if new_pos < 0 || new_pos > i32::MAX as i64 {
+            return Err(jvm.exception("java/io/IOException", "Invalid seek position").await);
+        }
 
         let _: () = jvm.invoke_virtual(&raf, "seek", "(J)V", (new_pos,)).await?;
+        jvm.put_field(&mut this, "offset", "I", new_pos as i32).await?;
 
         Ok(new_pos as i32)
     }
 
+    async fn read_dir(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        tracing::warn!("unsupported com.xce.io.XFile::readdir({this:?})");
+
+        Err(jvm.exception("java/io/IOException", "Directory reads are not supported").await)
+    }
+
+    async fn make_dir(jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::warn!("unsupported com.xce.io.XFile::mkdir({name:?})");
+
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "dirname is null").await);
+        }
+        Err(jvm.exception("java/io/IOException", "Directory creation is not supported").await)
+    }
+
+    async fn remove_dir(jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::warn!("unsupported com.xce.io.XFile::rmdir({name:?})");
+
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "dirname is null").await);
+        }
+        Err(jvm.exception("java/io/IOException", "Directory removal is not supported").await)
+    }
+
+    async fn remove_dir_recursive(jvm: &Jvm, _context: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::warn!("unsupported com.xce.io.XFile::rmrdir({name:?})");
+
+        if name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "dirname is null").await);
+        }
+        Err(jvm.exception("java/io/IOException", "Recursive directory removal is not supported").await)
+    }
+
+    async fn fs_used(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<i32> {
+        tracing::warn!("stub com.xce.io.XFile::fsused()");
+
+        Ok(0)
+    }
+
+    async fn fs_available(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<i32> {
+        tracing::warn!("stub com.xce.io.XFile::fsavail()");
+
+        Ok(0)
+    }
+
     pub async fn raf(jvm: &Jvm, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<RandomAccessFile>> {
-        let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
+        let raf: ClassInstanceRef<RandomAccessFile> = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
+        if raf.is_null() {
+            return Err(jvm.exception("java/io/IOException", "File has no random access handle").await);
+        }
 
         Ok(raf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{Array, ClassInstanceRef, JavaError, Result as JvmResult, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use super::{FILE_JAR, READ_RESOURCE, XFile};
+    use crate::classes::com::xce::io::{file_input_stream::FileInputStream, file_output_stream::FileOutputStream};
+
+    #[test]
+    fn xfile_write_read_and_seek_round_trip() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let read_write: i32 = jvm.get_static_field("com/xce/io/XFile", "READ_WRITE", "I").await?;
+                let seek_set: i32 = jvm.get_static_field("com/xce/io/XFile", "SEEK_SET", "I").await?;
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "xfile-round-trip.dat").await?.into();
+                let file: ClassInstanceRef<XFile> = jvm
+                    .new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, read_write))
+                    .await?
+                    .into();
+
+                let mut source = jvm.instantiate_array("B", 4).await?;
+                jvm.store_array(&mut source, 0, [10_i8, 20, 30, 40]).await?;
+                let written: i32 = jvm.invoke_virtual(&file, "write", "([BII)I", (source, 1, 2)).await?;
+                assert_eq!(written, 2);
+
+                let position: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (0, seek_set)).await?;
+                assert_eq!(position, 0);
+
+                let target: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 4).await?.into();
+                let read: i32 = jvm.invoke_virtual(&file, "read", "([BII)I", (target.clone(), 1, 2)).await?;
+                assert_eq!(read, 2);
+                assert_eq!(jvm.load_array::<i8>(&target, 0, 4).await?, [0, 20, 30, 0]);
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn stream_overloads_preserve_mark_skip_and_eof_behavior() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "stream-overloads.dat").await?.into();
+                let output: ClassInstanceRef<FileOutputStream> = jvm
+                    .new_class("com/xce/io/FileOutputStream", "(Ljava/lang/String;Z)V", (name.clone(), true))
+                    .await?
+                    .into();
+                let mut source = jvm.instantiate_array("B", 4).await?;
+                jvm.store_array(&mut source, 0, [1_i8, 2, 3, 4]).await?;
+                let _: () = jvm.invoke_virtual(&output, "write", "([BII)V", (source, 1, 2)).await?;
+                let _: () = jvm.invoke_virtual(&output, "flush", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&output, "close", "()V", ()).await?;
+
+                let append_output: ClassInstanceRef<FileOutputStream> = jvm
+                    .new_class("com/xce/io/FileOutputStream", "(Ljava/lang/String;Z)V", (name.clone(), false))
+                    .await?
+                    .into();
+                let _: () = jvm.invoke_virtual(&append_output, "write", "(I)V", (4,)).await?;
+                let _: () = jvm.invoke_virtual(&append_output, "close", "()V", ()).await?;
+
+                let input: ClassInstanceRef<FileInputStream> = jvm
+                    .new_class("com/xce/io/FileInputStream", "(Ljava/lang/String;)V", (name,))
+                    .await?
+                    .into();
+                assert!(jvm.invoke_virtual::<_, bool>(&input, "markSupported", "()Z", ()).await?);
+                let _: () = jvm.invoke_virtual(&input, "mark", "(I)V", (8,)).await?;
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 2);
+                let _: () = jvm.invoke_virtual(&input, "reset", "()V", ()).await?;
+                assert_eq!(jvm.invoke_virtual::<_, i64>(&input, "skip", "(J)J", (1_i64,)).await?, 1);
+
+                let target: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 2).await?.into();
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "([B)I", (target.clone(),)).await?, 2);
+                assert_eq!(jvm.load_array::<i8>(&target, 0, 2).await?, [3, 4]);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, -1);
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn file_array_errors_are_java_exceptions() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let read_write: i32 = jvm.get_static_field("com/xce/io/XFile", "READ_WRITE", "I").await?;
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "xfile-errors.dat").await?.into();
+                let file: ClassInstanceRef<XFile> = jvm
+                    .new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, read_write))
+                    .await?
+                    .into();
+                let data: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 2).await?.into();
+
+                let range_result: JvmResult<i32> = jvm.invoke_virtual(&file, "read", "([BII)I", (data, i32::MAX, 1)).await;
+                let Err(JavaError::JavaException(exception)) = range_result else {
+                    panic!("XFile.read accepted an invalid range");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IndexOutOfBoundsException"));
+
+                let null_data = ClassInstanceRef::<Array<i8>>::new(None);
+                let null_result: JvmResult<i32> = jvm.invoke_virtual(&file, "write", "([BII)I", (null_data, 0, 1)).await;
+                let Err(JavaError::JavaException(exception)) = null_result else {
+                    panic!("XFile.write accepted null");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn append_mode_creates_a_missing_file() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "append-new.dat").await?.into();
+                let output: ClassInstanceRef<FileOutputStream> = jvm
+                    .new_class("com/xce/io/FileOutputStream", "(Ljava/lang/String;Z)V", (name.clone(), false))
+                    .await?
+                    .into();
+                let _: () = jvm.invoke_virtual(&output, "write", "(I)V", (0xAB,)).await?;
+                let _: () = jvm.invoke_virtual(&output, "close", "()V", ()).await?;
+
+                let input: ClassInstanceRef<FileInputStream> = jvm
+                    .new_class("com/xce/io/FileInputStream", "(Ljava/lang/String;)V", (name,))
+                    .await?
+                    .into();
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 0xAB);
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn invalid_paths_and_unsupported_jar_selection_raise_io_exception() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let write: i32 = jvm.get_static_field("com/xce/io/XFile", "WRITE", "I").await?;
+                let traversal: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "../escape.dat").await?.into();
+                let open_result: JvmResult<ClassInstanceRef<XFile>> = jvm
+                    .new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (traversal, write))
+                    .await
+                    .map(Into::into);
+                let Err(JavaError::JavaException(exception)) = open_result else {
+                    panic!("XFile accepted a traversal path");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                let trailing: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "missing/").await?.into();
+                let metadata_result: JvmResult<bool> = jvm
+                    .invoke_static("com/xce/io/XFile", "exists", "(Ljava/lang/String;)Z", (trailing,))
+                    .await;
+                let Err(JavaError::JavaException(exception)) = metadata_result else {
+                    panic!("XFile.exists accepted a trailing-slash path");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                let jar: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "other.jar").await?.into();
+                let entry: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "entry.dat").await?.into();
+                let jar_result: JvmResult<ClassInstanceRef<XFile>> = jvm
+                    .new_class("com/xce/io/XFile", "(Ljava/lang/String;Ljava/lang/String;)V", (jar, entry))
+                    .await
+                    .map(Into::into);
+                let Err(JavaError::JavaException(exception)) = jar_result else {
+                    panic!("XFile silently ignored the selected JAR");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn standard_streams_have_neutral_input_and_non_owning_output_close() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let input: ClassInstanceRef<FileInputStream> = jvm.new_class("com/xce/io/FileInputStream", "(I)V", (0,)).await?.into();
+                assert!(jvm.invoke_virtual::<_, bool>(&input, "markSupported", "()Z", ()).await?);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "available", "()I", ()).await?, 0);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, -1);
+                let _: () = jvm.invoke_virtual(&input, "mark", "(I)V", (1,)).await?;
+                let _: () = jvm.invoke_virtual(&input, "reset", "()V", ()).await?;
+
+                let first: ClassInstanceRef<FileOutputStream> = jvm.new_class("com/xce/io/FileOutputStream", "(I)V", (1,)).await?.into();
+                let _: () = jvm.invoke_virtual(&first, "write", "(I)V", (1,)).await?;
+                let _: () = jvm.invoke_virtual(&first, "close", "()V", ()).await?;
+                let second: ClassInstanceRef<FileOutputStream> = jvm.new_class("com/xce/io/FileOutputStream", "(I)V", (1,)).await?.into();
+                let _: () = jvm.invoke_virtual(&second, "write", "(I)V", (2,)).await?;
+                let _: () = jvm.invoke_virtual(&second, "close", "()V", ()).await?;
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn stream_constructors_validate_mode_and_resource_reset_restores_offset() {
+        let result = run_jvm_test(
+            Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
+            |jvm| async move {
+                let write: i32 = jvm.get_static_field("com/xce/io/XFile", "WRITE", "I").await?;
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "write-only.dat").await?.into();
+                let write_only: ClassInstanceRef<XFile> = jvm.new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, write)).await?.into();
+                let available_result: JvmResult<i32> = jvm.invoke_virtual(&write_only, "available", "()I", ()).await;
+                let Err(JavaError::JavaException(exception)) = available_result else {
+                    panic!("write-only XFile reported readable bytes");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                let input_result: JvmResult<ClassInstanceRef<FileInputStream>> = jvm
+                    .new_class("com/xce/io/FileInputStream", "(Lcom/xce/io/XFile;)V", (write_only.clone(),))
+                    .await
+                    .map(Into::into);
+                let Err(JavaError::JavaException(exception)) = input_result else {
+                    panic!("FileInputStream accepted a write-only XFile");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                let mut one_byte = jvm.instantiate_array("B", 1).await?;
+                jvm.store_array(&mut one_byte, 0, [1_i8]).await?;
+                let _: i32 = jvm.invoke_virtual(&write_only, "write", "([BII)I", (one_byte, 0, 1)).await?;
+                let _: () = jvm.invoke_virtual(&write_only, "close", "()V", ()).await?;
+
+                let read: i32 = jvm.get_static_field("com/xce/io/XFile", "READ", "I").await?;
+                let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "write-only.dat").await?.into();
+                let read_only: ClassInstanceRef<XFile> = jvm.new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, read)).await?.into();
+                let output_result: JvmResult<ClassInstanceRef<FileOutputStream>> = jvm
+                    .new_class("com/xce/io/FileOutputStream", "(Lcom/xce/io/XFile;)V", (read_only,))
+                    .await
+                    .map(Into::into);
+                let Err(JavaError::JavaException(exception)) = output_result else {
+                    panic!("FileOutputStream accepted a read-only XFile");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                let mut resource: ClassInstanceRef<XFile> = jvm.new_class("com/xce/io/XFile", "(I)V", (0,)).await?.into();
+                let mut bytes = jvm.instantiate_array("B", 2).await?;
+                jvm.store_array(&mut bytes, 0, [7_i8, 8]).await?;
+                let stream = jvm.new_class("java/io/ByteArrayInputStream", "([B)V", (bytes,)).await?;
+                jvm.put_field(&mut resource, "type", "I", FILE_JAR).await?;
+                jvm.put_field(&mut resource, "mode", "I", READ_RESOURCE).await?;
+                jvm.put_field(&mut resource, "is", "Ljava/io/InputStream;", stream).await?;
+
+                let input: ClassInstanceRef<FileInputStream> = jvm
+                    .new_class("com/xce/io/FileInputStream", "(Lcom/xce/io/XFile;)V", (resource.clone(),))
+                    .await?
+                    .into();
+                let _: () = jvm.invoke_virtual(&input, "mark", "(I)V", (2,)).await?;
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 7);
+                assert_eq!(jvm.get_field::<i32>(&resource, "offset", "I").await?, 1);
+                let _: () = jvm.invoke_virtual(&input, "reset", "()V", ()).await?;
+                assert_eq!(jvm.get_field::<i32>(&resource, "offset", "I").await?, 0);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 7);
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
     }
 }

--- a/wie_skvm/src/classes/com/xce/lcdui/toolkit.rs
+++ b/wie_skvm/src/classes/com/xce/lcdui/toolkit.rs
@@ -1,31 +1,230 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{FieldAccessFlags, MethodAccessFlags};
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use java_runtime::classes::java::lang::String;
+use jvm::{
+    ClassInstanceRef, Jvm, Result as JvmResult,
+    runtime::{JavaIoInputStream, JavaLangClassLoader, JavaLangString},
+};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 use wie_midp::classes::javax::microedition::{
-    lcdui::{Display, Font, Graphics},
+    lcdui::{Display, Font, Graphics, Image},
     midlet::MIDlet,
 };
+
+macro_rules! define_image_accessors {
+    ($(($getter:ident, $setter:ident, $field:literal)),+ $(,)?) => {
+        $(
+            async fn $getter(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Image>> {
+                jvm.get_static_field("com/xce/lcdui/Toolkit", $field, "Ljavax/microedition/lcdui/Image;").await
+            }
+
+            async fn $setter(jvm: &Jvm, _context: &mut WieJvmContext, image: ClassInstanceRef<Image>) -> JvmResult<()> {
+                jvm.put_static_field("com/xce/lcdui/Toolkit", $field, "Ljavax/microedition/lcdui/Image;", image).await
+            }
+        )+
+    };
+}
 
 // class com.xce.lcdui.Toolkit
 pub struct Toolkit;
 
 impl Toolkit {
     pub fn as_proto() -> WieJavaClassProto {
+        let mut methods = vec![
+            JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+            JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+            JavaMethodProto::new(
+                "createImage",
+                "(Ljava/lang/String;)Ljavax/microedition/lcdui/Image;",
+                Self::create_image,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+            ),
+            JavaMethodProto::new(
+                "createExImage",
+                "(Ljava/lang/String;Ljava/lang/String;)Ljavax/microedition/lcdui/Image;",
+                Self::create_ex_image,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+            ),
+            JavaMethodProto::new(
+                "splitString",
+                "(Ljava/lang/String;I)I",
+                Self::split_string,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+            ),
+            JavaMethodProto::new(
+                "paintPopup",
+                "(Ljava/lang/String;Ljava/lang/String;)V",
+                Self::paint_popup,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+            ),
+            JavaMethodProto::new(
+                "paintPopup",
+                "(Ljava/lang/String;Ljava/lang/String;Z)V",
+                Self::paint_popup_with_button,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+            ),
+        ];
+        let mut fields = vec![
+            JavaFieldProto::new(
+                "DEFAULT_FONT",
+                "Ljavax/microedition/lcdui/Font;",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "FONT_HEIGHT",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "FONT_GAP",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "MAX_CHARWIDTH",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "BLACK",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "DK_GRAY",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "LT_GRAY",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "WHITE",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "black",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "dk_gray",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "lt_gray",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "white",
+                "I",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new(
+                "graphics",
+                "Ljavax/microedition/lcdui/Graphics;",
+                FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+            ),
+            JavaFieldProto::new("IMG_HEIGHT", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+            JavaFieldProto::new("IS_KOREAN", "Z", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+            JavaFieldProto::new("selected", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+            JavaFieldProto::new("ext", "Ljava/lang/String;", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+            JavaFieldProto::new("iconsDir", "Ljava/lang/String;", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+            JavaFieldProto::new("MIDP_RES", "Lcom/xce/lcdui/MIDPRes;", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+        ];
+
+        macro_rules! register_image_accessors {
+            ($(($getter_name:literal, $getter:ident, $setter_name:literal, $setter:ident, $field:literal)),+ $(,)?) => {
+                $(
+                    methods.push(JavaMethodProto::new(
+                        $getter_name,
+                        "()Ljavax/microedition/lcdui/Image;",
+                        Self::$getter,
+                        MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                    ));
+                    methods.push(JavaMethodProto::new(
+                        $setter_name,
+                        "(Ljavax/microedition/lcdui/Image;)V",
+                        Self::$setter,
+                        MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                    ));
+                    fields.push(JavaFieldProto::new(
+                        $field,
+                        "Ljavax/microedition/lcdui/Image;",
+                        FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC,
+                    ));
+                )+
+            };
+        }
+
+        register_image_accessors!(
+            ("titleImg", title_img, "setTitleImg", set_title_img, "titleImg"),
+            (
+                "buttonBackLeftImg",
+                button_back_left_img,
+                "setButtonBackLeftImg",
+                set_button_back_left_img,
+                "buttonBackLeftImg"
+            ),
+            (
+                "buttonBackRightImg",
+                button_back_right_img,
+                "setButtonBackRightImg",
+                set_button_back_right_img,
+                "buttonBackRightImg"
+            ),
+            ("screenIconImg", screen_icon_img, "setScreenIconImg", set_screen_icon_img, "screenIconImg"),
+            ("backIconImg", back_icon_img, "setBackIconImg", set_back_icon_img, "backIconImg"),
+            ("cancelIconImg", cancel_icon_img, "setCancelIconImg", set_cancel_icon_img, "cancelIconImg"),
+            ("helpIconImg", help_icon_img, "setHelpIconImg", set_help_icon_img, "helpIconImg"),
+            ("okIconImg", ok_icon_img, "setOkIconImg", set_ok_icon_img, "okIconImg"),
+            ("stopIconImg", stop_icon_img, "setStopIconImg", set_stop_icon_img, "stopIconImg"),
+            ("exitIconImg", exit_icon_img, "setExitIconImg", set_exit_icon_img, "exitIconImg"),
+            ("itemIconImg", item_icon_img, "setItemIconImg", set_item_icon_img, "itemIconImg"),
+            ("menuIconImg", menu_icon_img, "setMenuIconImg", set_menu_icon_img, "menuIconImg"),
+            ("ueimImg", ueim_img, "setUEimImg", set_ueim_img, "ueimImg"),
+            ("leimImg", leim_img, "setLEimImg", set_leim_img, "leimImg"),
+            ("kimImg", kim_img, "setKimImg", set_kim_img, "kimImg"),
+            ("simImg", sim_img, "setSimImg", set_sim_img, "simImg"),
+            ("nimImg", nim_img, "setNimImg", set_nim_img, "nimImg"),
+            ("imHintImg", im_hint_img, "setIMHintImg", set_im_hint_img, "imHintImg"),
+            ("sExclusive", s_exclusive, "setSExclusive", set_s_exclusive, "sExclusive"),
+            ("uExclusive", u_exclusive, "setUExclusive", set_u_exclusive, "uExclusive"),
+            ("sMultiple", s_multiple, "setSMultiple", set_s_multiple, "sMultiple"),
+            ("uMultiple", u_multiple, "setUMultiple", set_u_multiple, "uMultiple"),
+            ("sBackImg", s_back_img, "setSBackImg", set_s_back_img, "sBackImg"),
+            ("gBackImg", g_back_img, "setGBackImg", set_g_back_img, "gBackImg"),
+            ("gForeImg", g_fore_img, "setGForeImg", set_g_fore_img, "gForeImg"),
+            ("scrollImg", scroll_img, "setScrollImg", set_scroll_img, "scrollImg"),
+        );
+        methods.push(JavaMethodProto::new(
+            "appImg",
+            "()Ljavax/microedition/lcdui/Image;",
+            Self::app_img,
+            MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+        ));
+        methods.push(JavaMethodProto::new(
+            "castleImg",
+            "()Ljavax/microedition/lcdui/Image;",
+            Self::castle_img,
+            MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+        ));
+
         WieJavaClassProto {
             name: "com/xce/lcdui/Toolkit",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC)],
-            fields: vec![
-                JavaFieldProto::new("graphics", "Ljavax/microedition/lcdui/Graphics;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("DEFAULT_FONT", "Ljavax/microedition/lcdui/Font;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("FONT_HEIGHT", "I", FieldAccessFlags::STATIC),
-            ],
-            access_flags: Default::default(),
+            methods,
+            fields,
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -40,25 +239,297 @@ impl Toolkit {
 
         let font_height: i32 = jvm.invoke_virtual(&font, "getHeight", "()I", ()).await?;
         jvm.put_static_field("com/xce/lcdui/Toolkit", "FONT_HEIGHT", "I", font_height).await?;
+        jvm.put_static_field("com/xce/lcdui/Toolkit", "FONT_GAP", "I", 0).await?;
+
+        let max_char_width: i32 = jvm.invoke_virtual(&font, "charWidth", "(C)I", ('W' as u16,)).await?;
+        jvm.put_static_field("com/xce/lcdui/Toolkit", "MAX_CHARWIDTH", "I", max_char_width)
+            .await?;
+
+        for (field, value) in [
+            ("BLACK", 0x000000),
+            ("DK_GRAY", 0x555555),
+            ("LT_GRAY", 0xaaaaaa),
+            ("WHITE", 0xffffff),
+            ("black", 0x000000),
+            ("dk_gray", 0x555555),
+            ("lt_gray", 0xaaaaaa),
+            ("white", 0xffffff),
+        ] {
+            jvm.put_static_field("com/xce/lcdui/Toolkit", field, "I", value).await?;
+        }
 
         let current_midlet: ClassInstanceRef<MIDlet> = jvm
             .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
             .await?;
 
-        let display: ClassInstanceRef<Display> = jvm
-            .invoke_static(
-                "javax/microedition/lcdui/Display",
-                "getDisplay",
-                "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
-                (current_midlet,),
-            )
-            .await?;
+        if !current_midlet.is_null() {
+            let display: ClassInstanceRef<Display> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Display",
+                    "getDisplay",
+                    "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
+                    (current_midlet,),
+                )
+                .await?;
+            let graphics: ClassInstanceRef<Graphics> = Display::screen_graphics(jvm, &display).await?;
 
-        let graphics: ClassInstanceRef<Graphics> = Display::screen_graphics(jvm, &display).await?;
-
-        jvm.put_static_field("com/xce/lcdui/Toolkit", "graphics", "Ljavax/microedition/lcdui/Graphics;", graphics)
-            .await?;
+            jvm.put_static_field("com/xce/lcdui/Toolkit", "graphics", "Ljavax/microedition/lcdui/Graphics;", graphics)
+                .await?;
+        }
 
         Ok(())
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.Toolkit::<init>({this:?})");
+        jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+    }
+
+    async fn create_image(jvm: &Jvm, _context: &mut WieJvmContext, file_name: ClassInstanceRef<String>) -> JvmResult<ClassInstanceRef<Image>> {
+        tracing::debug!("com.xce.lcdui.Toolkit::createImage({file_name:?})");
+
+        if file_name.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "fileName is null").await);
+        }
+
+        let resource_name = JavaLangString::to_rust_string(jvm, &file_name).await?;
+        let class_loader = jvm.current_class_loader().await?;
+        let Some(stream) = JavaLangClassLoader::get_resource_as_stream(jvm, &class_loader, &resource_name).await? else {
+            return Err(jvm.exception("java/io/IOException", "image resource was not found").await);
+        };
+
+        let image_data = match JavaIoInputStream::read_until_end(jvm, &stream).await {
+            Ok(image_data) => {
+                let _: () = jvm.invoke_virtual(&stream, "close", "()V", ()).await?;
+                image_data
+            }
+            Err(error) => {
+                let _: JvmResult<()> = jvm.invoke_virtual(&stream, "close", "()V", ()).await;
+                return Err(error);
+            }
+        };
+        let Ok(image_data_len) = i32::try_from(image_data.len()) else {
+            return Err(jvm.exception("java/io/IOException", "image resource is too large").await);
+        };
+        let mut image_array = jvm.instantiate_array("B", image_data.len()).await?;
+        jvm.array_raw_buffer_mut(&mut image_array).await?.write(0, &image_data)?;
+
+        jvm.invoke_static(
+            "javax/microedition/lcdui/Image",
+            "createImage",
+            "([BII)Ljavax/microedition/lcdui/Image;",
+            (image_array, 0, image_data_len),
+        )
+        .await
+    }
+
+    async fn create_ex_image(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        dir_name: ClassInstanceRef<String>,
+        file_name: ClassInstanceRef<String>,
+    ) -> JvmResult<ClassInstanceRef<Image>> {
+        tracing::debug!("com.xce.lcdui.Toolkit::createExImage({dir_name:?}, {file_name:?})");
+
+        if dir_name.is_null() || file_name.is_null() {
+            return Err(jvm
+                .exception("java/lang/NullPointerException", "dirName and fileName must not be null")
+                .await);
+        }
+
+        let mut path = JavaLangString::to_rust_string(jvm, &dir_name).await?;
+        let file_name = JavaLangString::to_rust_string(jvm, &file_name).await?;
+        if !path.is_empty() && !path.ends_with('/') {
+            path.push('/');
+        }
+        path.push_str(&file_name);
+        let path: ClassInstanceRef<String> = JavaLangString::from_rust_string(jvm, &path).await?.into();
+
+        jvm.invoke_static(
+            "com/xce/lcdui/Toolkit",
+            "createImage",
+            "(Ljava/lang/String;)Ljavax/microedition/lcdui/Image;",
+            (path,),
+        )
+        .await
+    }
+
+    async fn split_string(jvm: &Jvm, _context: &mut WieJvmContext, string: ClassInstanceRef<String>, max_width: i32) -> JvmResult<i32> {
+        tracing::debug!("com.xce.lcdui.Toolkit::splitString({string:?}, {max_width})");
+
+        if string.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "string is null").await);
+        }
+        if max_width <= 0 {
+            return Ok(0);
+        }
+
+        let font: ClassInstanceRef<Font> = jvm
+            .get_static_field("com/xce/lcdui/Toolkit", "DEFAULT_FONT", "Ljavax/microedition/lcdui/Font;")
+            .await?;
+        let string_length: i32 = jvm.invoke_virtual(&string, "length", "()I", ()).await?;
+        let mut fitting_length = 0;
+        for length in 1..=string_length {
+            let width: i32 = jvm
+                .invoke_virtual(&font, "substringWidth", "(Ljava/lang/String;II)I", (string.clone(), 0, length))
+                .await?;
+            if width > max_width {
+                break;
+            }
+            fitting_length = length;
+        }
+
+        Ok(fitting_length)
+    }
+
+    async fn paint_popup(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        message_1: ClassInstanceRef<String>,
+        message_2: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.xce.lcdui.Toolkit::paintPopup({message_1:?}, {message_2:?})");
+        Ok(())
+    }
+
+    async fn paint_popup_with_button(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        message_1: ClassInstanceRef<String>,
+        message_2: ClassInstanceRef<String>,
+        button: bool,
+    ) -> JvmResult<()> {
+        tracing::warn!("stub com.xce.lcdui.Toolkit::paintPopup({message_1:?}, {message_2:?}, {button})");
+        Ok(())
+    }
+
+    async fn app_img(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Image>> {
+        tracing::warn!("stub com.xce.lcdui.Toolkit::appImg()");
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    async fn castle_img(_jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Image>> {
+        tracing::warn!("stub com.xce.lcdui.Toolkit::castleImg()");
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    define_image_accessors!(
+        (title_img, set_title_img, "titleImg"),
+        (button_back_left_img, set_button_back_left_img, "buttonBackLeftImg"),
+        (button_back_right_img, set_button_back_right_img, "buttonBackRightImg"),
+        (screen_icon_img, set_screen_icon_img, "screenIconImg"),
+        (back_icon_img, set_back_icon_img, "backIconImg"),
+        (cancel_icon_img, set_cancel_icon_img, "cancelIconImg"),
+        (help_icon_img, set_help_icon_img, "helpIconImg"),
+        (ok_icon_img, set_ok_icon_img, "okIconImg"),
+        (stop_icon_img, set_stop_icon_img, "stopIconImg"),
+        (exit_icon_img, set_exit_icon_img, "exitIconImg"),
+        (item_icon_img, set_item_icon_img, "itemIconImg"),
+        (menu_icon_img, set_menu_icon_img, "menuIconImg"),
+        (ueim_img, set_ueim_img, "ueimImg"),
+        (leim_img, set_leim_img, "leimImg"),
+        (kim_img, set_kim_img, "kimImg"),
+        (sim_img, set_sim_img, "simImg"),
+        (nim_img, set_nim_img, "nimImg"),
+        (im_hint_img, set_im_hint_img, "imHintImg"),
+        (s_exclusive, set_s_exclusive, "sExclusive"),
+        (u_exclusive, set_u_exclusive, "uExclusive"),
+        (s_multiple, set_s_multiple, "sMultiple"),
+        (u_multiple, set_u_multiple, "uMultiple"),
+        (s_back_img, set_s_back_img, "sBackImg"),
+        (g_back_img, set_g_back_img, "gBackImg"),
+        (g_fore_img, set_g_fore_img, "gForeImg"),
+        (scroll_img, set_scroll_img, "scrollImg"),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, JavaError, Result as JvmResult, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+    use wie_midp::classes::javax::microedition::lcdui::Image;
+
+    use super::Toolkit;
+
+    #[test]
+    fn image_accessor_preserves_the_image_reference() {
+        let result = run_jvm_test(
+            Box::new([wie_midp::get_protos().into(), [Toolkit::as_proto()].into()]),
+            |jvm| async move {
+                let image: ClassInstanceRef<Image> = jvm
+                    .invoke_static(
+                        "javax/microedition/lcdui/Image",
+                        "createImage",
+                        "(II)Ljavax/microedition/lcdui/Image;",
+                        (2, 3),
+                    )
+                    .await?;
+
+                let _: () = jvm
+                    .invoke_static(
+                        "com/xce/lcdui/Toolkit",
+                        "setTitleImg",
+                        "(Ljavax/microedition/lcdui/Image;)V",
+                        (image.clone(),),
+                    )
+                    .await?;
+                let returned: ClassInstanceRef<Image> = jvm
+                    .invoke_static("com/xce/lcdui/Toolkit", "titleImg", "()Ljavax/microedition/lcdui/Image;", ())
+                    .await?;
+                assert!(returned.equals(&**image)?);
+
+                let app_image: ClassInstanceRef<Image> = jvm
+                    .invoke_static("com/xce/lcdui/Toolkit", "appImg", "()Ljavax/microedition/lcdui/Image;", ())
+                    .await?;
+                let castle_image: ClassInstanceRef<Image> = jvm
+                    .invoke_static("com/xce/lcdui/Toolkit", "castleImg", "()Ljavax/microedition/lcdui/Image;", ())
+                    .await?;
+                assert!(app_image.is_null());
+                assert!(castle_image.is_null());
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn split_string_returns_a_utf16_index_and_missing_images_throw_io_exception() {
+        let result = run_jvm_test(
+            Box::new([wie_midp::get_protos().into(), [Toolkit::as_proto()].into()]),
+            |jvm| async move {
+                let text: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "A\u{1f600}B").await?.into();
+                let font = jvm
+                    .get_static_field("com/xce/lcdui/Toolkit", "DEFAULT_FONT", "Ljavax/microedition/lcdui/Font;")
+                    .await?;
+                let width: i32 = jvm.invoke_virtual(&font, "stringWidth", "(Ljava/lang/String;)I", (text.clone(),)).await?;
+                let split: i32 = jvm
+                    .invoke_static("com/xce/lcdui/Toolkit", "splitString", "(Ljava/lang/String;I)I", (text, width))
+                    .await?;
+                assert_eq!(split, 4);
+
+                let missing: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "/missing.png").await?.into();
+                let image_result: JvmResult<ClassInstanceRef<Image>> = jvm
+                    .invoke_static(
+                        "com/xce/lcdui/Toolkit",
+                        "createImage",
+                        "(Ljava/lang/String;)Ljavax/microedition/lcdui/Image;",
+                        (missing,),
+                    )
+                    .await;
+                let Err(JavaError::JavaException(exception)) = image_result else {
+                    panic!("Toolkit.createImage accepted a missing resource");
+                };
+                assert!(jvm.is_instance(&*exception, "java/io/IOException"));
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
     }
 }

--- a/wie_skvm/src/classes/com/xce/lcdui/x_text_field.rs
+++ b/wie_skvm/src/classes/com/xce/lcdui/x_text_field.rs
@@ -1,8 +1,9 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm::{ClassInstanceRef, JavaChar, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 use wie_midp::classes::javax::microedition::lcdui::{Canvas, Graphics};
@@ -21,18 +22,34 @@ impl XTextField {
                     "<init>",
                     "(Ljava/lang/String;IILjavax/microedition/lcdui/Canvas;)V",
                     Self::init,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("setFocus", "(Z)V", Self::set_focus, Default::default()),
-                JavaMethodProto::new("setBounds", "(IIII)V", Self::set_bounds, Default::default()),
-                JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, Default::default()),
-                JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, Default::default()),
-                JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, Default::default()),
-                JavaMethodProto::new("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Self::paint, Default::default()),
-                JavaMethodProto::new("getText", "()Ljava/lang/String;", Self::get_text, Default::default()),
+                JavaMethodProto::new("getMaxSize", "()I", Self::get_max_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getText", "()Ljava/lang/String;", Self::get_text, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("hasFocus", "()Z", Self::has_focus, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("inputChar", "(C)V", Self::input_char, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Self::paint, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("repaint", "()V", Self::repaint, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setBounds", "(IIII)V", Self::set_bounds, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setFocus", "(Z)V", Self::set_focus, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setMaxSize", "(I)V", Self::set_max_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setText", "(Ljava/lang/String;)V", Self::set_text, MethodAccessFlags::PUBLIC),
             ],
-            fields: vec![JavaFieldProto::new("text", "Ljava/lang/String;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![
+                JavaFieldProto::new("text", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("maxSize", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("constraints", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("focus", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("x", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("y", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("width", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("height", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("canvas", "Ljavax/microedition/lcdui/Canvas;", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -40,51 +57,115 @@ impl XTextField {
         jvm: &Jvm,
         _context: &mut WieJvmContext,
         mut this: ClassInstanceRef<Self>,
-        text2: ClassInstanceRef<String>,
+        text: ClassInstanceRef<String>,
         max_size: i32,
         constraints: i32,
         canvas: ClassInstanceRef<Canvas>,
     ) -> JvmResult<()> {
-        tracing::debug!("com.xce.lcdui.XTextField::<init>({this:?}, {text2:?}, {max_size}, {constraints}, {canvas:?})");
+        tracing::debug!("com.xce.lcdui.XTextField::<init>({this:?}, {text:?}, {max_size}, {constraints}, {canvas:?})");
 
-        // Call the parent constructor
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
-        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text2).await?;
+        if text.is_null() || canvas.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "text and canvas must not be null").await);
+        }
+        if max_size < 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "maxSize must not be negative").await);
+        }
+
+        let text = Self::truncate_text(jvm, text, max_size).await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "maxSize", "I", max_size).await?;
+        jvm.put_field(&mut this, "constraints", "I", constraints).await?;
+        jvm.put_field(&mut this, "canvas", "Ljavax/microedition/lcdui/Canvas;", canvas).await?;
 
         Ok(())
     }
 
-    async fn set_focus(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, focus: bool) -> JvmResult<()> {
-        tracing::warn!("stub com.xce.lcdui.XTextField::setFocus({this:?}, {focus})");
+    async fn truncate_text(jvm: &Jvm, text: ClassInstanceRef<String>, max_size: i32) -> JvmResult<ClassInstanceRef<String>> {
+        let length: i32 = jvm.invoke_virtual(&text, "length", "()I", ()).await?;
+        if length > max_size {
+            jvm.invoke_virtual(&text, "substring", "(II)Ljava/lang/String;", (0, max_size)).await
+        } else {
+            Ok(text)
+        }
+    }
 
-        Ok(())
+    async fn get_max_size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "maxSize", "I").await
+    }
+
+    async fn get_text(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        tracing::debug!("com.xce.lcdui.XTextField::getText({this:?})");
+        jvm.get_field(&this, "text", "Ljava/lang/String;").await
+    }
+
+    async fn has_focus(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        jvm.get_field(&this, "focus", "Z").await
+    }
+
+    async fn input_char(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, key: JavaChar) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::inputChar({this:?}, {key})");
+
+        let text: ClassInstanceRef<String> = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
+        let length: i32 = jvm.invoke_virtual(&text, "length", "()I", ()).await?;
+        let max_size: i32 = jvm.get_field(&this, "maxSize", "I").await?;
+        if length >= max_size {
+            return Ok(());
+        }
+
+        let char_string: ClassInstanceRef<String> = jvm.invoke_static("java/lang/String", "valueOf", "(C)Ljava/lang/String;", (key,)).await?;
+        let text: ClassInstanceRef<String> = jvm
+            .invoke_virtual(&text, "concat", "(Ljava/lang/String;)Ljava/lang/String;", (char_string,))
+            .await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await
+    }
+
+    async fn set_focus(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, focus: bool) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::setFocus({this:?}, {focus})");
+        jvm.put_field(&mut this, "focus", "Z", focus).await
     }
 
     async fn set_bounds(
-        _jvm: &Jvm,
+        jvm: &Jvm,
         _context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         x: i32,
         y: i32,
         width: i32,
         height: i32,
     ) -> JvmResult<()> {
-        tracing::warn!("stub com.xce.lcdui.XTextField::setBounds({this:?}, {x}, {y}, {width}, {height})");
+        tracing::debug!("com.xce.lcdui.XTextField::setBounds({this:?}, {x}, {y}, {width}, {height})");
 
+        if width < 0 || height < 0 {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "width and height must not be negative")
+                .await);
+        }
+
+        jvm.put_field(&mut this, "x", "I", x).await?;
+        jvm.put_field(&mut this, "y", "I", y).await?;
+        jvm.put_field(&mut this, "width", "I", width).await?;
+        jvm.put_field(&mut this, "height", "I", height).await
+    }
+
+    async fn key_pressed(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, key_code: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::keyPressed({this:?}, {key_code})");
+
+        let focus: bool = jvm.get_field(&this, "focus", "Z").await?;
+        if !focus {
+            return Ok(());
+        }
+
+        if (32..=126).contains(&key_code) {
+            return Self::input_char(jvm, context, this, key_code as JavaChar).await;
+        }
         Ok(())
     }
 
-    async fn key_pressed(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, key_code: i32) -> JvmResult<()> {
-        tracing::warn!("stub com.xce.lcdui.XTextField::keyPressed({this:?}, {key_code})");
-
-        Ok(())
-    }
-
-    async fn key_repeated(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, key_code: i32) -> JvmResult<()> {
-        tracing::warn!("stub com.xce.lcdui.XTextField::keyRepeated({this:?}, {key_code})");
-
-        Ok(())
+    async fn key_repeated(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, key_code: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::keyRepeated({this:?}, {key_code})");
+        Self::key_pressed(jvm, context, this, key_code).await
     }
 
     async fn key_released(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, key_code: i32) -> JvmResult<()> {
@@ -93,16 +174,320 @@ impl XTextField {
         Ok(())
     }
 
-    async fn paint(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, graphics: ClassInstanceRef<Graphics>) -> JvmResult<()> {
-        tracing::warn!("stub com.xce.lcdui.XTextField::paint({this:?}, {graphics:?})");
+    async fn paint(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, graphics: ClassInstanceRef<Graphics>) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::paint({this:?}, {graphics:?})");
 
-        Ok(())
+        if graphics.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "graphics is null").await);
+        }
+
+        let text: ClassInstanceRef<String> = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
+        let x: i32 = jvm.get_field(&this, "x", "I").await?;
+        let y: i32 = jvm.get_field(&this, "y", "I").await?;
+        let width: i32 = jvm.get_field(&this, "width", "I").await?;
+        let height: i32 = jvm.get_field(&this, "height", "I").await?;
+        let clip_x: i32 = jvm.invoke_virtual(&graphics, "getClipX", "()I", ()).await?;
+        let clip_y: i32 = jvm.invoke_virtual(&graphics, "getClipY", "()I", ()).await?;
+        let clip_width: i32 = jvm.invoke_virtual(&graphics, "getClipWidth", "()I", ()).await?;
+        let clip_height: i32 = jvm.invoke_virtual(&graphics, "getClipHeight", "()I", ()).await?;
+
+        let _: () = jvm.invoke_virtual(&graphics, "clipRect", "(IIII)V", (x, y, width, height)).await?;
+        let draw_result: JvmResult<()> = jvm
+            .invoke_virtual(&graphics, "drawString", "(Ljava/lang/String;III)V", (text, x, y, 20))
+            .await;
+        let restore_result: JvmResult<()> = jvm
+            .invoke_virtual(&graphics, "setClip", "(IIII)V", (clip_x, clip_y, clip_width, clip_height))
+            .await;
+        draw_result?;
+        restore_result
     }
 
-    async fn get_text(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
-        tracing::debug!("com.xce.lcdui.XTextField::getText({this:?})");
+    async fn repaint(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::repaint({this:?})");
 
-        let text = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
-        Ok(text)
+        let canvas: ClassInstanceRef<Canvas> = jvm.get_field(&this, "canvas", "Ljavax/microedition/lcdui/Canvas;").await?;
+        let x: i32 = jvm.get_field(&this, "x", "I").await?;
+        let y: i32 = jvm.get_field(&this, "y", "I").await?;
+        let width: i32 = jvm.get_field(&this, "width", "I").await?;
+        let height: i32 = jvm.get_field(&this, "height", "I").await?;
+        jvm.invoke_virtual(&canvas, "repaint", "(IIII)V", (x, y, width, height)).await
+    }
+
+    async fn set_max_size(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, max_size: i32) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::setMaxSize({this:?}, {max_size})");
+
+        if max_size < 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "maxSize must not be negative").await);
+        }
+
+        let text: ClassInstanceRef<String> = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
+        let text = Self::truncate_text(jvm, text, max_size).await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "maxSize", "I", max_size).await
+    }
+
+    async fn set_text(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::debug!("com.xce.lcdui.XTextField::setText({this:?}, {text:?})");
+
+        if text.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "text is null").await);
+        }
+
+        let max_size: i32 = jvm.get_field(&this, "maxSize", "I").await?;
+        let text = Self::truncate_text(jvm, text, max_size).await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, vec};
+
+    use java_class_proto::{JavaFieldProto, JavaMethodProto};
+    use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+    use java_runtime::classes::java::lang::String;
+    use jvm::{ClassInstanceRef, JavaChar, JavaError, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_midp::classes::javax::microedition::lcdui::{Canvas, Graphics, Image};
+
+    use super::XTextField;
+
+    struct TrackingCanvas;
+    struct TrackingGraphics;
+
+    impl TrackingCanvas {
+        fn as_proto() -> WieJavaClassProto {
+            WieJavaClassProto {
+                name: "test/TrackingCanvas",
+                parent_class: Some("javax/microedition/lcdui/Canvas"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("repaint", "(IIII)V", Self::repaint, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Self::paint, MethodAccessFlags::PUBLIC),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("repaintCount", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("repaintX", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("repaintY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("repaintWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("repaintHeight", "I", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/lcdui/Canvas", "<init>", "()V", ()).await
+        }
+
+        async fn repaint(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "repaintCount", "I").await?;
+            jvm.put_field(&mut this, "repaintCount", "I", count + 1).await?;
+            jvm.put_field(&mut this, "repaintX", "I", x).await?;
+            jvm.put_field(&mut this, "repaintY", "I", y).await?;
+            jvm.put_field(&mut this, "repaintWidth", "I", width).await?;
+            jvm.put_field(&mut this, "repaintHeight", "I", height).await
+        }
+
+        async fn paint(
+            _jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            _this: ClassInstanceRef<Self>,
+            _graphics: ClassInstanceRef<wie_midp::classes::javax::microedition::lcdui::Graphics>,
+        ) -> JvmResult<()> {
+            Ok(())
+        }
+    }
+
+    impl TrackingGraphics {
+        fn as_proto() -> WieJavaClassProto {
+            WieJavaClassProto {
+                name: "javax/microedition/lcdui/TrackingGraphics",
+                parent_class: Some("javax/microedition/lcdui/Graphics"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("drawString", "(Ljava/lang/String;III)V", Self::draw_string, MethodAccessFlags::PUBLIC),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("observedClipX", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("observedClipY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("observedClipWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("observedClipHeight", "I", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            let image: ClassInstanceRef<Image> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Image",
+                    "createImage",
+                    "(II)Ljavax/microedition/lcdui/Image;",
+                    (20, 20),
+                )
+                .await?;
+            jvm.invoke_special(
+                &this,
+                "javax/microedition/lcdui/Graphics",
+                "<init>",
+                "(Ljavax/microedition/lcdui/Image;)V",
+                (image,),
+            )
+            .await
+        }
+
+        async fn draw_string(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            _string: ClassInstanceRef<String>,
+            _x: i32,
+            _y: i32,
+            _anchor: i32,
+        ) -> JvmResult<()> {
+            let clip_x: i32 = jvm.invoke_virtual(&this, "getClipX", "()I", ()).await?;
+            let clip_y: i32 = jvm.invoke_virtual(&this, "getClipY", "()I", ()).await?;
+            let clip_width: i32 = jvm.invoke_virtual(&this, "getClipWidth", "()I", ()).await?;
+            let clip_height: i32 = jvm.invoke_virtual(&this, "getClipHeight", "()I", ()).await?;
+            jvm.put_field(&mut this, "observedClipX", "I", clip_x).await?;
+            jvm.put_field(&mut this, "observedClipY", "I", clip_y).await?;
+            jvm.put_field(&mut this, "observedClipWidth", "I", clip_width).await?;
+            jvm.put_field(&mut this, "observedClipHeight", "I", clip_height).await
+        }
+    }
+
+    #[test]
+    fn text_state_input_limit_and_repaint_work_as_one_flow() {
+        let result = run_jvm_test(
+            Box::new([
+                wie_midp::get_protos().into(),
+                [XTextField::as_proto(), TrackingCanvas::as_proto(), TrackingGraphics::as_proto()].into(),
+            ]),
+            |jvm| async move {
+                let canvas: ClassInstanceRef<Canvas> = jvm.new_class("test/TrackingCanvas", "()V", ()).await?.into();
+                let initial: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "abc").await?.into();
+                let field: ClassInstanceRef<XTextField> = jvm
+                    .new_class(
+                        "com/xce/lcdui/XTextField",
+                        "(Ljava/lang/String;IILjavax/microedition/lcdui/Canvas;)V",
+                        (initial, 5, 0, canvas.clone()),
+                    )
+                    .await?
+                    .into();
+
+                let max_size: i32 = jvm.invoke_virtual(&field, "getMaxSize", "()I", ()).await?;
+                let focused: bool = jvm.invoke_virtual(&field, "hasFocus", "()Z", ()).await?;
+                assert_eq!(max_size, 5);
+                assert!(!focused);
+
+                let _: () = jvm.invoke_virtual(&field, "keyPressed", "(I)V", ('z' as i32,)).await?;
+                let text: ClassInstanceRef<String> = jvm.invoke_virtual(&field, "getText", "()Ljava/lang/String;", ()).await?;
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &text).await?, "abc");
+
+                let _: () = jvm.invoke_virtual(&field, "setFocus", "(Z)V", (true,)).await?;
+                let _: () = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", (3, 5, 40, 12)).await?;
+                let _: () = jvm.invoke_virtual(&field, "keyPressed", "(I)V", ('d' as i32,)).await?;
+                let _: () = jvm.invoke_virtual(&field, "keyRepeated", "(I)V", ('e' as i32,)).await?;
+                let _: () = jvm.invoke_virtual(&field, "inputChar", "(C)V", ('f' as JavaChar,)).await?;
+
+                let text: ClassInstanceRef<String> = jvm.invoke_virtual(&field, "getText", "()Ljava/lang/String;", ()).await?;
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &text).await?, "abcde");
+                assert!(jvm.invoke_virtual::<_, bool>(&field, "hasFocus", "()Z", ()).await?);
+
+                for bounds in [(9, 8, -1, 4), (7, 6, 4, -1)] {
+                    let bounds_result: JvmResult<()> = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", bounds).await;
+                    let Err(JavaError::JavaException(exception)) = bounds_result else {
+                        panic!("XTextField.setBounds accepted a negative size");
+                    };
+                    assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+                }
+
+                let _: () = jvm.invoke_virtual(&field, "setMaxSize", "(I)V", (3,)).await?;
+                let replacement: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "wxyz").await?.into();
+                let _: () = jvm.invoke_virtual(&field, "setText", "(Ljava/lang/String;)V", (replacement,)).await?;
+                let text: ClassInstanceRef<String> = jvm.invoke_virtual(&field, "getText", "()Ljava/lang/String;", ()).await?;
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &text).await?, "wxy");
+
+                let _: () = jvm.invoke_virtual(&field, "repaint", "()V", ()).await?;
+                assert_eq!(jvm.get_field::<i32>(&canvas, "repaintCount", "I").await?, 1);
+                assert_eq!(jvm.get_field::<i32>(&canvas, "repaintX", "I").await?, 3);
+                assert_eq!(jvm.get_field::<i32>(&canvas, "repaintY", "I").await?, 5);
+                assert_eq!(jvm.get_field::<i32>(&canvas, "repaintWidth", "I").await?, 40);
+                assert_eq!(jvm.get_field::<i32>(&canvas, "repaintHeight", "I").await?, 12);
+
+                let _: () = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", (1, 2, 0, 0)).await?;
+
+                let negative_result: JvmResult<()> = jvm.invoke_virtual(&field, "setMaxSize", "(I)V", (-1,)).await;
+                let Err(JavaError::JavaException(exception)) = negative_result else {
+                    panic!("XTextField.setMaxSize accepted a negative value");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+                let null_text = ClassInstanceRef::<String>::new(None);
+                let null_result: JvmResult<()> = jvm.invoke_virtual(&field, "setText", "(Ljava/lang/String;)V", (null_text,)).await;
+                let Err(JavaError::JavaException(exception)) = null_result else {
+                    panic!("XTextField.setText accepted null");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
+    }
+
+    #[test]
+    fn paint_uses_the_bounds_clip_and_restores_the_original_clip() {
+        let result = run_jvm_test(
+            Box::new([
+                wie_midp::get_protos().into(),
+                [XTextField::as_proto(), TrackingCanvas::as_proto(), TrackingGraphics::as_proto()].into(),
+            ]),
+            |jvm| async move {
+                let canvas: ClassInstanceRef<Canvas> = jvm.new_class("test/TrackingCanvas", "()V", ()).await?.into();
+                let text: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "long text").await?.into();
+                let field: ClassInstanceRef<XTextField> = jvm
+                    .new_class(
+                        "com/xce/lcdui/XTextField",
+                        "(Ljava/lang/String;IILjavax/microedition/lcdui/Canvas;)V",
+                        (text, 20, 0, canvas),
+                    )
+                    .await?
+                    .into();
+                let graphics: ClassInstanceRef<Graphics> = jvm.new_class("javax/microedition/lcdui/TrackingGraphics", "()V", ()).await?.into();
+
+                let _: () = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", (3, 5, 4, 6)).await?;
+                let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (1, 2, 10, 11)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "paint", "(Ljavax/microedition/lcdui/Graphics;)V", (graphics.clone(),))
+                    .await?;
+
+                assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipX", "I").await?, 3);
+                assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipY", "I").await?, 5);
+                assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipWidth", "I").await?, 4);
+                assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipHeight", "I").await?, 6);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipX", "()I", ()).await?, 1);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipY", "()I", ()).await?, 2);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipWidth", "()I", ()).await?, 10);
+                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipHeight", "()I", ()).await?, 11);
+
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
     }
 }

--- a/wie_skvm/src/classes/net/wie/wie_audio_clip.rs
+++ b/wie_skvm/src/classes/net/wie/wie_audio_clip.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -16,15 +17,17 @@ impl WieAudioClip {
             parent_class: Some("java/lang/Object"),
             interfaces: vec!["com/skt/m/AudioClip"],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("open", "([BII)V", Self::open, Default::default()),
-                JavaMethodProto::new("play", "()V", Self::play, Default::default()),
-                JavaMethodProto::new("loop", "()V", Self::r#loop, Default::default()),
-                JavaMethodProto::new("stop", "()V", Self::stop, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("open", "([BII)V", Self::open, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("close", "()V", Self::close, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("loop", "()V", Self::r#loop, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("pause", "()V", Self::pause, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("play", "()V", Self::play, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("resume", "()V", Self::resume, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("stop", "()V", Self::stop, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -37,7 +40,7 @@ impl WieAudioClip {
     }
 
     async fn open(
-        _jvm: &Jvm,
+        jvm: &Jvm,
         _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         data: ClassInstanceRef<Array<i8>>,
@@ -45,6 +48,17 @@ impl WieAudioClip {
         buffer_size: i32,
     ) -> JvmResult<()> {
         tracing::warn!("stub net.wie.WieAudioClip::open({this:?}, {data:?}, {offset}, {buffer_size})");
+
+        if data.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "data is null").await);
+        }
+
+        let array_length = jvm.array_length(&data).await?;
+        if offset < 0 || buffer_size < 0 || (offset as usize).checked_add(buffer_size as usize).is_none_or(|end| end > array_length) {
+            return Err(jvm
+                .exception("java/lang/ArrayIndexOutOfBoundsException", "Invalid offset or length")
+                .await);
+        }
 
         Ok(())
     }
@@ -61,6 +75,18 @@ impl WieAudioClip {
         Ok(())
     }
 
+    async fn pause(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::warn!("stub net.wie.WieAudioClip::pause({this:?})");
+
+        Ok(())
+    }
+
+    async fn resume(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        tracing::warn!("stub net.wie.WieAudioClip::resume({this:?})");
+
+        Ok(())
+    }
+
     async fn stop(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::warn!("stub net.wie.WieAudioClip::stop({this:?})");
 
@@ -71,5 +97,74 @@ impl WieAudioClip {
         tracing::warn!("stub net.wie.WieAudioClip::close({this:?})");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use java_runtime::classes::java::lang::String;
+    use jvm::{Array, ClassInstanceRef, JavaError, Result as JvmResult, runtime::JavaLangString};
+    use test_utils::run_jvm_test;
+
+    use crate::{classes::com::skt::m::AudioClip, get_protos};
+
+    #[test]
+    fn audio_clip_accepts_valid_slices_and_rejects_invalid_ranges() {
+        let result = run_jvm_test(Box::new([wie_midp::get_protos().into(), get_protos().into()]), |jvm| async move {
+            let formats: ClassInstanceRef<Array<String>> = jvm
+                .invoke_static("com/skt/m/AudioSystem", "getClipFormats", "()[Ljava/lang/String;", ())
+                .await?;
+            assert_eq!(jvm.array_length(&formats).await?, 0);
+
+            let name = JavaLangString::from_rust_string(&jvm, "audio/mpeg").await?;
+            let clip: ClassInstanceRef<AudioClip> = jvm
+                .invoke_static(
+                    "com/skt/m/AudioSystem",
+                    "getAudioClip",
+                    "(Ljava/lang/String;)Lcom/skt/m/AudioClip;",
+                    (name,),
+                )
+                .await?;
+            let mut data = jvm.instantiate_array("B", 3).await?;
+            jvm.store_array(&mut data, 0, [1i8, 2, 3]).await?;
+            let empty_data = jvm.instantiate_array("B", 0).await?;
+
+            for (array, offset, length) in [
+                (empty_data, 0, 0),
+                (data.clone(), 0, 0),
+                (data.clone(), 3, 0),
+                (data.clone(), 0, 3),
+                (data.clone(), 1, 2),
+            ] {
+                let _: () = jvm.invoke_virtual(&clip, "open", "([BII)V", (array, offset, length)).await?;
+            }
+            let _: () = jvm.invoke_virtual(&clip, "play", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "loop", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "pause", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "resume", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "stop", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "close", "()V", ()).await?;
+
+            for (offset, length) in [(-1, 1), (0, -1), (3, 1), (2, 2)] {
+                let invalid: JvmResult<()> = jvm.invoke_virtual(&clip, "open", "([BII)V", (data.clone(), offset, length)).await;
+                let Err(JavaError::JavaException(exception)) = invalid else {
+                    panic!("AudioClip.open accepted invalid range ({offset}, {length})");
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/ArrayIndexOutOfBoundsException"));
+            }
+
+            let null_data = ClassInstanceRef::<Array<i8>>::new(None);
+            let null_result: JvmResult<()> = jvm.invoke_virtual(&clip, "open", "([BII)V", (null_data, 0, 0)).await;
+            let Err(JavaError::JavaException(exception)) = null_result else {
+                panic!("AudioClip.open accepted a null byte array");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/NullPointerException"));
+
+            Ok(())
+        });
+
+        assert!(result.is_ok(), "JVM test failed: {result:?}");
     }
 }

--- a/wie_skvm/src/lib.rs
+++ b/wie_skvm/src/lib.rs
@@ -5,17 +5,27 @@ use wie_jvm_support::WieJavaClassProto;
 
 pub mod classes;
 
-pub fn get_protos() -> [WieJavaClassProto; 16] {
+pub fn get_protos() -> [WieJavaClassProto; 26] {
     [
         classes::com::skt::m::AudioClip::as_proto(),
         classes::com::skt::m::AudioSystem::as_proto(),
         classes::com::skt::m::BackLight::as_proto(),
+        classes::com::skt::m::Call::as_proto(),
         classes::com::skt::m::Device::as_proto(),
         classes::com::skt::m::Graphics2D::as_proto(),
         classes::com::skt::m::MathFP::as_proto(),
-        classes::com::skt::m::Vibration::as_proto(),
+        classes::com::skt::m::PhoneBook::as_proto(),
         classes::com::skt::m::ProgressBar::as_proto(),
+        classes::com::skt::m::ResourceAllocException::as_proto(),
+        classes::com::skt::m::SISImage::as_proto(),
+        classes::com::skt::m::SMS::as_proto(),
+        classes::com::skt::m::SMSListener::as_proto(),
+        classes::com::skt::m::SMSMessage::as_proto(),
         classes::com::skt::m::UnsupportedFormatException::as_proto(),
+        classes::com::skt::m::UserStopException::as_proto(),
+        classes::com::skt::m::Vibration::as_proto(),
+        classes::com::skt::m3d::Graphics3D::as_proto(),
+        classes::com::skt::m3d::Object3D::as_proto(),
         classes::com::xce::io::FileInputStream::as_proto(),
         classes::com::xce::io::FileOutputStream::as_proto(),
         classes::com::xce::io::XFile::as_proto(),

--- a/wie_wipi_c/src/api/graphics.rs
+++ b/wie_wipi_c/src/api/graphics.rs
@@ -120,7 +120,17 @@ pub async fn put_pixel(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
 
     let mut canvas = framebuffer.canvas(context)?;
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.put_pixel(x as _, y as _, color);
+    canvas.put_pixel(
+        x as _,
+        y as _,
+        color,
+        Clip {
+            x: 0,
+            y: 0,
+            width: framebuffer.0.width,
+            height: framebuffer.0.height,
+        },
+    );
     canvas.flush()?;
 
     Ok(())
@@ -657,13 +667,19 @@ pub async fn set_rgb_pixels(
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
     let mut canvas = framebuffer.canvas(context)?;
+    let clip = Clip {
+        x: 0,
+        y: 0,
+        width: framebuffer.0.width,
+        height: framebuffer.0.height,
+    };
     for dy in 0..h {
         for dx in 0..w {
             let off = ((dy as usize) * (w as usize) + dx as usize) * 4;
             // WIPI spec: pixels are 0x00RRGGBB.
             let rgb = u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]);
             let color = Rgb8Pixel::to_color(rgb);
-            canvas.put_pixel(x + dx, y + dy, color);
+            canvas.put_pixel(x + dx, y + dy, color, clip);
         }
     }
     canvas.flush()?;


### PR DESCRIPTION
## Summary

- complete the 2003 SKT Java API surface across `com.skt.m`, `com.skt.m3d`, `com.xce.io`, and `com.xce.lcdui`
- register all 24 documented types while preserving the existing compatibility classes
- keep pixel composition in the backend canvas, including COPY/XOR, clipping, and overlapping self-draws
- implement SKT file streams with virtual-file copy-on-write and explicit short-write/truncate error propagation

## Behavior

Unsupported handset, network, SIS decoding, and 3D rendering operations use deterministic neutral stubs so applications can link and follow their fallback paths. API-only inventory tests were intentionally avoided; the tests exercise JVM calls, exceptions, state, filesystem behavior, and canvas pixels.

## Known limitations

- `WieAudioClip` remains a no-op after input validation
- concurrent first-write materialization of the same virtual file is not serialized
- early `Toolkit` initialization can leave `Toolkit.graphics` null until a recovery path is added
- an actual SKT game smoke test was not available

## Validation

- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test --workspace` (222 passed)
- `git diff --check`