### PR TITLE
KTF WIPI-C 데이터베이스 사용 가능 저장 공간 보고

### DIFF
--- a/test_utils/src/platform.rs
+++ b/test_utils/src/platform.rs
@@ -121,6 +121,16 @@ impl DatabaseRepository for MemoryDatabaseRepository {
     async fn delete(&self, name: &str, app_id: &str) -> bool {
         self.store.lock().remove(&(app_id.to_string(), name.to_string())).is_some()
     }
+
+    async fn usage(&self, app_id: &str) -> u64 {
+        self.store
+            .lock()
+            .iter()
+            .filter(|((record_app_id, _), _)| record_app_id == app_id)
+            .flat_map(|(_, records)| records.values())
+            .map(|record| record.len() as u64)
+            .sum()
+    }
 }
 
 struct MemoryDatabase {

--- a/wie_backend/src/database.rs
+++ b/wie_backend/src/database.rs
@@ -18,4 +18,6 @@ pub trait DatabaseRepository {
     async fn open(&self, name: &str, app_id: &str) -> Box<dyn Database>;
     async fn exists(&self, name: &str, app_id: &str) -> bool;
     async fn delete(&self, name: &str, app_id: &str) -> bool;
+    /// Returns the bytes occupied by all databases owned by `app_id`.
+    async fn usage(&self, app_id: &str) -> u64;
 }

--- a/wie_backend/src/system/audio.rs
+++ b/wie_backend/src/system/audio.rs
@@ -225,6 +225,10 @@ mod tests {
         async fn delete(&self, _name: &str, _app_id: &str) -> bool {
             false
         }
+
+        async fn usage(&self, _app_id: &str) -> u64 {
+            0
+        }
     }
 
     struct NullFilesystem;

--- a/wie_cli/src/database.rs
+++ b/wie_cli/src/database.rs
@@ -40,6 +40,32 @@ impl DatabaseRepository {
 
         self.base_path.join(app_id).join("db").join(normalized_name)
     }
+
+    fn get_path_for_app_databases(&self, app_id: &str) -> PathBuf {
+        self.get_path_for_database("_", app_id).parent().unwrap().to_owned()
+    }
+
+    fn directory_usage(path: &std::path::Path) -> u64 {
+        let Ok(entries) = fs::read_dir(path) else {
+            return 0;
+        };
+
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                let Ok(file_type) = entry.file_type() else {
+                    return 0;
+                };
+                if file_type.is_file() {
+                    entry.metadata().map(|metadata| metadata.len()).unwrap_or(0)
+                } else if file_type.is_dir() {
+                    Self::directory_usage(&entry.path())
+                } else {
+                    0
+                }
+            })
+            .sum()
+    }
 }
 
 #[async_trait::async_trait]
@@ -69,6 +95,10 @@ impl wie_backend::DatabaseRepository for DatabaseRepository {
                 false
             }
         }
+    }
+
+    async fn usage(&self, app_id: &str) -> u64 {
+        Self::directory_usage(&self.get_path_for_app_databases(app_id))
     }
 }
 

--- a/wie_ktf/src/runtime/wipi_c/method_table.rs
+++ b/wie_ktf/src/runtime/wipi_c/method_table.rs
@@ -520,7 +520,7 @@ pub fn get_method_body(table_id: WIPICTableId, function_id: u16) -> Option<WIPIC
             WIPICDatabaseMethodId::GetAccessMode => Some(gen_stub(9, "MC_dbGetAccessMode")),
             WIPICDatabaseMethodId::GetNumberOfRecords => Some(gen_stub(10, "MC_dbGetNumberOfRecords")),
             WIPICDatabaseMethodId::GetRecordSize => Some(gen_stub(11, "MC_dbGetRecordSize")),
-            WIPICDatabaseMethodId::ListDatabases => Some(gen_stub(12, "MC_dbListDataBase")),
+            WIPICDatabaseMethodId::ListDatabases => Some(database::list_databases.into_body()),
             WIPICDatabaseMethodId::Unk13 => Some(gen_stub(13, "MC_dbUnk13")),
             WIPICDatabaseMethodId::Unk14 => Some(gen_stub(14, "MC_dbUnk14")),
             WIPICDatabaseMethodId::Unk15 => Some(gen_stub(15, "MC_dbUnk15")),

--- a/wie_wipi_c/src/api/database.rs
+++ b/wie_wipi_c/src/api/database.rs
@@ -42,6 +42,7 @@ struct DatabaseHandle {
 }
 
 const MIN_BUFFER_CAPACITY: u32 = 64;
+const KTF_DATABASE_STORAGE_LIMIT: u64 = 1024 * 1024;
 // "MCDB" — sentinel at the start of the handle struct so we can distinguish
 // a real DB handle pointer from an unrelated guest pointer (e.g. a C-string
 // name pointer that KTF's slot 6 passes through the same SVC argument slot).
@@ -168,6 +169,21 @@ pub async fn list_record(context: &mut dyn WIPICContext, db_id: i32, buf_ptr: WI
     }
 
     Ok(ids.len() as _)
+}
+
+/// Returns the database storage available to a KTF application.
+///
+/// Although the standard interface names function ID 12 `MC_dbListDataBase`,
+/// KTF titles use its no-argument return value as an available-storage byte count.
+/// Known callers reject values below 0x100 and 0x1200 respectively.
+pub async fn list_databases(context: &mut dyn WIPICContext) -> Result<i32> {
+    let system = context.system();
+    let pid = system.pid().to_owned();
+    let usage = system.platform().database_repository().usage(&pid).await;
+    let available = KTF_DATABASE_STORAGE_LIMIT.saturating_sub(usage).min(i32::MAX as u64) as i32;
+
+    tracing::debug!("MC_dbListDataBase() = {available} (used={usage}, limit={KTF_DATABASE_STORAGE_LIMIT})");
+    Ok(available)
 }
 
 pub async fn seek_record_single(context: &mut dyn WIPICContext, db_id: i32, offset: i32, origin: i32) -> Result<i32> {
@@ -622,7 +638,22 @@ mod tests {
 
     use crate::context::test::TestContext;
 
-    use super::{delete_database, exists_database, list_record_info, open_database, select_record, stream_read, stream_write, update_record};
+    use super::{
+        KTF_DATABASE_STORAGE_LIMIT, delete_database, exists_database, list_databases, list_record_info, open_database, select_record, stream_read,
+        stream_write, update_record,
+    };
+
+    #[futures_test::test]
+    async fn ktf_available_database_storage_tracks_app_usage() {
+        let mut context = database_test_context();
+        assert_eq!(list_databases(&mut context).await.unwrap(), KTF_DATABASE_STORAGE_LIMIT as i32);
+
+        let db_id = open_test_database(&mut context).await;
+        context.write_bytes(0x2000, &[1, 2, 3, 4]).unwrap();
+        assert_eq!(stream_write(&mut context, db_id, 0x2000, 4).await.unwrap(), 4);
+
+        assert_eq!(list_databases(&mut context).await.unwrap(), KTF_DATABASE_STORAGE_LIMIT as i32 - 4);
+    }
 
     #[futures_test::test]
     async fn lgt_exists_database_reports_missing_and_existing_database() {


### PR DESCRIPTION
## 문제

`에픽크로니클PE`를 구동하기 위해 작업하던 중 몇 가지 문제를 발견했습니다.

현재 KTF WIPI-C 데이터베이스 함수 ID 12는 구현되지 않은 `MC_dbListDataBase` 에 매핑되어 있습니다.

일부 KTF 애플리케이션은 이 함수를 인자 없이 호출하고, 반환값을 사용 가능한 데이터베이스 저장 공간의 바이트 수로 사용하는 것으로 보입니다.
잘못된 값이 반환되면 애플리케이션이 저장 공간 최적화 절차를 반복적으로 실행할 수 있습니다.

## 해결

- `DatabaseRepository`에 애플리케이션별 데이터베이스 사용량 조회 기능을 추가
- 애플리케이션이 저장한 레코드 크기를 기준으로 CLI 데이터베이스 사용량을 계산
- KTF 데이터베이스의 사용 가능한 저장 공간을 애플리케이션별 1 MiB 한도에서 현재 데이터베이스 사용량을 뺀 값으로 보고
- 사용량이 한도에 도달하거나 초과한 경우 결과를 0으로 제한
- KTF 데이터베이스 함수 ID 12를 실제 구현에 연결

## 근거

고정된 사용 가능 공간 값(1 MiB)을 항상 반환하는 방식만으로도 호환성 문제를 확인하기에는 충분했지만 애플리케이션이 실제로 사용한 저장 공간을 반영하지 못합니다.

호스트 파일 시스템의 사용 가능 공간을 직접 반환하는 방식 역시 에뮬레이션 환경에는 적합하지 않을 수 있습니다.
호스트엔 수백 기가바이트의 여유 공간이 있을 수 있지만 에뮬레이션되는 애플리케이션은 제한된 모바일 기기의 저장 환경을 기대하며 디스크 상태에 따라 게스트 애플리케이션의 동작이 달라질 수 있습니다.

따라서 이번 구현에서는 가용 공간 계산을 위한 애플리케이션별 데이터베이스 저장 예산을 1 MiB로 설정하고 여기에서 해당 애플리케이션의 현재 데이터베이스 레코드 사용량을 차감합니다.
이를 통해 다음과 같은 동작을 제공합니다.

- 호스트 파일 시스템의 여유 공간과 무관하게 일관된 값 제공
- 애플리케이션별 데이터베이스 사용량 격리
- 데이터가 저장될수록 보고되는 사용 가능 공간 감소
- 사용량이 저장 예산을 초과하면 음수 대신 0 반환

1 MiB는 실제 KTF 단말 사양에서 확인한 값이 아니라 현재 확인한 게임의 동작을 검증하기 위해 선택한 호환성 기준값입니다.
이후 더 많은 게임의 구동 결과가 쌓이면 2 MiB 등 다른 값으로 조정할 필요가 생길 수 있습니다. (1024 * 1024 → 2 * 1024 * 1024)

DB 사용량 계산은 이 저장 예산과 분리해 구현하였으며 이후 더 적절한 값이 확인되면 사용량 계산 코드는 유지한 채 예산만 변경하거나, 플랫폼별 설정값을 사용하도록 확장할 수 있습니다.

이번 변경은 현재 DB 사용량을 반영해 남은 공간을 보고하는 데 범위를 한정하며 저장 예산을 초과하는 쓰기 작업을 차단하지는 않습니다.
예를 들어 다음과 같은 상황이 발생할 수 있습니다.

```text
DB 저장 예산: 1 MiB
현재 사용량: 900 KiB
보고되는 가용 공간: 124 KiB
새 쓰기 요청: 200 KiB
```

이 경우 가용 공간은 124 KiB로 보고되지만 현재 구현은 200 KiB 쓰기를 반드시 거절하지 않으므로 실제 사용량이 1 MiB를 초과할 수 있습니다.
초과 후 가용 공간을 다시 조회하면 0을 반환합니다.

저장 예산을 초과하는 쓰기를 정확히 차단하려면 기존 Database 인터페이스의 오류 반환 방식과 모든 쓰기 경로를 함께 변경해야 합니다.
이는 이번 PR의 목적보다 변경 범위가 크므로 제외하였습니다.

## 테스트

* 4바이트를 기록하면 보고되는 사용 가능 저장 공간이 4바이트 감소하는지 검증하는 회귀 테스트를 추가했습니다.
* `cargo fmt`
* `cargo clippy --workspace`
* `cargo test --workspace`