### PR TITLE
KTF WIPI-C 리소스 캐시 추가

### DIFF
--- a/wie_ktf/src/runtime/wipi_c.rs
+++ b/wie_ktf/src/runtime/wipi_c.rs
@@ -1,7 +1,6 @@
-use alloc::{boxed::Box, sync::Arc, vec};
+use alloc::{boxed::Box, vec};
 
 use jvm::Jvm;
-use spin::Mutex;
 use wie_backend::System;
 use wie_core_arm::{ArmCore, EmulatedFunction, EmulatedFunctionParam, ResultWriter, SvcId};
 use wie_util::{Result, WieError};
@@ -14,7 +13,7 @@ mod context;
 pub mod interface;
 mod method_table;
 
-use context::{KtfWIPICContext, WIPICRuntimeState};
+use context::KtfWIPICContext;
 
 struct WIPICMethodResult {
     result: WIPICResult,
@@ -56,12 +55,12 @@ impl EmulatedFunction<(), WIPICMethodResult, ()> for CMethodProxy {
     }
 }
 
-async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm, state): &mut (System, Jvm, Arc<Mutex<WIPICRuntimeState>>), id: SvcId) -> Result<()> {
+async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm), id: SvcId) -> Result<()> {
     let table_id = WIPICTableId::try_from(id.0 >> 16)?;
     let function_id = id.0 as u16;
     let (_, lr) = core.read_pc_lr()?;
     if table_id == WIPICTableId::Kernel && function_id == WIPICKernelMethodId::Reserved1 as u16 {
-        return interface::get_wipic_interfaces(core, &mut KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone(), state.clone()))
+        return interface::get_wipic_interfaces(core, &mut KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone()))
             .await?
             .write(core, lr);
     }
@@ -71,7 +70,7 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm, state): &mut (System
 
     EmulatedFunction::call(
         &CMethodProxy {
-            context: KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone(), state.clone()),
+            context: KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone()),
             body,
         },
         core,
@@ -82,9 +81,5 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm, state): &mut (System
 }
 
 pub fn register_wipic_svc_handler(core: &mut ArmCore, system: &System, jvm: &Jvm) -> Result<()> {
-    core.register_svc_handler(
-        SVC_CATEGORY_WIPIC,
-        handle_wipic_svc,
-        &(system.clone(), jvm.clone(), Arc::new(Mutex::new(WIPICRuntimeState::default()))),
-    )
+    core.register_svc_handler(SVC_CATEGORY_WIPIC, handle_wipic_svc, &(system.clone(), jvm.clone()))
 }

--- a/wie_ktf/src/runtime/wipi_c.rs
+++ b/wie_ktf/src/runtime/wipi_c.rs
@@ -1,6 +1,7 @@
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, sync::Arc, vec};
 
 use jvm::Jvm;
+use spin::Mutex;
 use wie_backend::System;
 use wie_core_arm::{ArmCore, EmulatedFunction, EmulatedFunctionParam, ResultWriter, SvcId};
 use wie_util::{Result, WieError};
@@ -13,7 +14,7 @@ mod context;
 pub mod interface;
 mod method_table;
 
-use context::KtfWIPICContext;
+use context::{KtfWIPICContext, WIPICRuntimeState};
 
 struct WIPICMethodResult {
     result: WIPICResult,
@@ -55,12 +56,12 @@ impl EmulatedFunction<(), WIPICMethodResult, ()> for CMethodProxy {
     }
 }
 
-async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm), id: SvcId) -> Result<()> {
+async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm, state): &mut (System, Jvm, Arc<Mutex<WIPICRuntimeState>>), id: SvcId) -> Result<()> {
     let table_id = WIPICTableId::try_from(id.0 >> 16)?;
     let function_id = id.0 as u16;
     let (_, lr) = core.read_pc_lr()?;
     if table_id == WIPICTableId::Kernel && function_id == WIPICKernelMethodId::Reserved1 as u16 {
-        return interface::get_wipic_interfaces(core, &mut KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone()))
+        return interface::get_wipic_interfaces(core, &mut KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone(), state.clone()))
             .await?
             .write(core, lr);
     }
@@ -70,7 +71,7 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm),
 
     EmulatedFunction::call(
         &CMethodProxy {
-            context: KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone()),
+            context: KtfWIPICContext::new(core.clone(), system.clone(), jvm.clone(), state.clone()),
             body,
         },
         core,
@@ -81,5 +82,9 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm),
 }
 
 pub fn register_wipic_svc_handler(core: &mut ArmCore, system: &System, jvm: &Jvm) -> Result<()> {
-    core.register_svc_handler(SVC_CATEGORY_WIPIC, handle_wipic_svc, &(system.clone(), jvm.clone()))
+    core.register_svc_handler(
+        SVC_CATEGORY_WIPIC,
+        handle_wipic_svc,
+        &(system.clone(), jvm.clone(), Arc::new(Mutex::new(WIPICRuntimeState::default()))),
+    )
 }

--- a/wie_ktf/src/runtime/wipi_c/context.rs
+++ b/wie_ktf/src/runtime/wipi_c/context.rs
@@ -1,4 +1,12 @@
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+
+use spin::Mutex;
 
 use jvm::{
     Jvm,
@@ -8,7 +16,8 @@ use wipi_types::wipic::{WIPICIndirectPtr, WIPICWord};
 
 use wie_backend::{AsyncCallable, Event, Instant, System};
 use wie_core_arm::{Allocator, ArmCore};
-use wie_util::{ByteRead, ByteWrite, Result, read_generic, write_generic};
+use wie_jvm_support::JvmSupport;
+use wie_util::{ByteRead, ByteWrite, Result, WieError, read_generic, write_generic};
 use wie_wipi_c::{WIPICContext, WIPICMethodBody};
 
 #[derive(Clone)]
@@ -16,11 +25,17 @@ pub struct KtfWIPICContext {
     core: ArmCore,
     system: System,
     jvm: Jvm, // We need jvm to access resource in jvm. TODO is there better way to do this?
+    state: Arc<Mutex<WIPICRuntimeState>>,
+}
+
+#[derive(Default)]
+pub(super) struct WIPICRuntimeState {
+    resource_cache: BTreeMap<String, Vec<u8>>,
 }
 
 impl KtfWIPICContext {
-    pub fn new(core: ArmCore, system: System, jvm: Jvm) -> Self {
-        Self { core, system, jvm }
+    pub fn new(core: ArmCore, system: System, jvm: Jvm, state: Arc<Mutex<WIPICRuntimeState>>) -> Self {
+        Self { core, system, jvm, state }
     }
 }
 
@@ -90,26 +105,81 @@ impl WIPICContext for KtfWIPICContext {
     }
 
     async fn get_resource_size(&self, name: &str) -> Result<Option<usize>> {
-        let class_loader = self.jvm.current_class_loader().await.unwrap();
-        let stream = JavaLangClassLoader::get_resource_as_stream(&self.jvm, &class_loader, name).await.unwrap();
+        if let Some(size) = self.state.lock().resource_cache.get(name).map(Vec::len) {
+            tracing::debug!("WIPI-C resource cache hit for size: name={name:?}, size={size}");
+            return Ok(Some(size));
+        }
+
+        let class_loader = self
+            .jvm
+            .current_class_loader()
+            .await
+            .map_err(|err| WieError::FatalError(alloc::format!("Failed to get class loader for resource {name:?}: {err:?}")))?;
+        let stream = match JavaLangClassLoader::get_resource_as_stream(&self.jvm, &class_loader, name).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                tracing::error!("Java exception while opening resource for size query: name={name:?}, error={err:?}");
+                return Err(JvmSupport::to_wie_err(&self.jvm, err).await);
+            }
+        };
 
         if stream.is_none() {
             return Ok(None);
         }
 
-        let available: i32 = self.jvm.invoke_virtual(&stream.unwrap(), "available", "()I", ()).await.unwrap();
+        let stream = stream.unwrap();
+        let available: i32 = match self.jvm.invoke_virtual(&stream, "available", "()I", ()).await {
+            Ok(available) => available,
+            Err(err) => {
+                tracing::error!("Java exception while querying resource size: name={name:?}, error={err:?}");
+                return Err(JvmSupport::to_wie_err(&self.jvm, err).await);
+            }
+        };
+        drop(stream);
+        let garbage_count = match self.jvm.collect_garbage() {
+            Ok(count) => count,
+            Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
+        };
+        tracing::debug!("WIPI-C resource size GC: name={name:?}, collected={garbage_count}");
 
         Ok(Some(available as _))
     }
 
     async fn read_resource(&self, name: &str) -> Result<Vec<u8>> {
-        let class_loader = self.jvm.current_class_loader().await.unwrap();
-        let stream = JavaLangClassLoader::get_resource_as_stream(&self.jvm, &class_loader, name)
-            .await
-            .unwrap()
-            .unwrap();
+        if let Some(data) = self.state.lock().resource_cache.get(name).cloned() {
+            tracing::debug!("WIPI-C resource cache hit for read: name={name:?}, size={}", data.len());
+            return Ok(data);
+        }
 
-        Ok(JavaIoInputStream::read_until_end(&self.jvm, &stream).await.unwrap())
+        let class_loader = self
+            .jvm
+            .current_class_loader()
+            .await
+            .map_err(|err| WieError::FatalError(alloc::format!("Failed to get class loader for resource {name:?}: {err:?}")))?;
+        let stream = match JavaLangClassLoader::get_resource_as_stream(&self.jvm, &class_loader, name).await {
+            Ok(Some(stream)) => stream,
+            Ok(None) => return Err(WieError::FatalError(alloc::format!("Resource disappeared before read: {name:?}"))),
+            Err(err) => {
+                tracing::error!("Java exception while opening resource for read: name={name:?}, error={err:?}");
+                return Err(JvmSupport::to_wie_err(&self.jvm, err).await);
+            }
+        };
+
+        let data = match JavaIoInputStream::read_until_end(&self.jvm, &stream).await {
+            Ok(data) => data,
+            Err(err) => {
+                tracing::error!("Java exception while reading resource: name={name:?}, error={err:?}");
+                return Err(JvmSupport::to_wie_err(&self.jvm, err).await);
+            }
+        };
+        drop(stream);
+        self.state.lock().resource_cache.insert(name.to_string(), data.clone());
+        let garbage_count = match self.jvm.collect_garbage() {
+            Ok(count) => count,
+            Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
+        };
+        tracing::info!("WIPI-C resource cached: name={name:?}, size={}, collected={garbage_count}", data.len());
+        Ok(data)
     }
 
     fn set_timer(&mut self, due: Instant, callback: WIPICMethodBody) {

--- a/wie_ktf/src/runtime/wipi_c/context.rs
+++ b/wie_ktf/src/runtime/wipi_c/context.rs
@@ -1,12 +1,4 @@
-use alloc::{
-    boxed::Box,
-    collections::BTreeMap,
-    string::{String, ToString},
-    sync::Arc,
-    vec::Vec,
-};
-
-use spin::Mutex;
+use alloc::{boxed::Box, vec::Vec};
 
 use jvm::{
     Jvm,
@@ -25,17 +17,11 @@ pub struct KtfWIPICContext {
     core: ArmCore,
     system: System,
     jvm: Jvm, // We need jvm to access resource in jvm. TODO is there better way to do this?
-    state: Arc<Mutex<WIPICRuntimeState>>,
-}
-
-#[derive(Default)]
-pub(super) struct WIPICRuntimeState {
-    resource_cache: BTreeMap<String, Vec<u8>>,
 }
 
 impl KtfWIPICContext {
-    pub fn new(core: ArmCore, system: System, jvm: Jvm, state: Arc<Mutex<WIPICRuntimeState>>) -> Self {
-        Self { core, system, jvm, state }
+    pub fn new(core: ArmCore, system: System, jvm: Jvm) -> Self {
+        Self { core, system, jvm }
     }
 }
 
@@ -105,11 +91,6 @@ impl WIPICContext for KtfWIPICContext {
     }
 
     async fn get_resource_size(&self, name: &str) -> Result<Option<usize>> {
-        if let Some(size) = self.state.lock().resource_cache.get(name).map(Vec::len) {
-            tracing::debug!("WIPI-C resource cache hit for size: name={name:?}, size={size}");
-            return Ok(Some(size));
-        }
-
         let class_loader = self
             .jvm
             .current_class_loader()
@@ -123,34 +104,26 @@ impl WIPICContext for KtfWIPICContext {
             }
         };
 
-        if stream.is_none() {
-            return Ok(None);
+        let result = match stream {
+            Some(stream) => {
+                let available: i32 = match self.jvm.invoke_virtual(&stream, "available", "()I", ()).await {
+                    Ok(available) => available,
+                    Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
+                };
+                drop(stream);
+                Some(available as usize)
+            }
+            None => None,
+        };
+        match self.jvm.collect_garbage() {
+            Ok(_) => {}
+            Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
         }
 
-        let stream = stream.unwrap();
-        let available: i32 = match self.jvm.invoke_virtual(&stream, "available", "()I", ()).await {
-            Ok(available) => available,
-            Err(err) => {
-                tracing::error!("Java exception while querying resource size: name={name:?}, error={err:?}");
-                return Err(JvmSupport::to_wie_err(&self.jvm, err).await);
-            }
-        };
-        drop(stream);
-        let garbage_count = match self.jvm.collect_garbage() {
-            Ok(count) => count,
-            Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
-        };
-        tracing::debug!("WIPI-C resource size GC: name={name:?}, collected={garbage_count}");
-
-        Ok(Some(available as _))
+        Ok(result)
     }
 
     async fn read_resource(&self, name: &str) -> Result<Vec<u8>> {
-        if let Some(data) = self.state.lock().resource_cache.get(name).cloned() {
-            tracing::debug!("WIPI-C resource cache hit for read: name={name:?}, size={}", data.len());
-            return Ok(data);
-        }
-
         let class_loader = self
             .jvm
             .current_class_loader()
@@ -173,12 +146,10 @@ impl WIPICContext for KtfWIPICContext {
             }
         };
         drop(stream);
-        self.state.lock().resource_cache.insert(name.to_string(), data.clone());
-        let garbage_count = match self.jvm.collect_garbage() {
-            Ok(count) => count,
+        match self.jvm.collect_garbage() {
+            Ok(_) => {}
             Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
-        };
-        tracing::info!("WIPI-C resource cached: name={name:?}, size={}, collected={garbage_count}", data.len());
+        }
         Ok(data)
     }
 


### PR DESCRIPTION
## 문제

KTF는 각 SVC 호출마다 새로운 WIPI-C 컨텍스트를 생성합니다.
이로 인해 `res.gmf`와 같이 자주 접근하는 리소스가 `URLClassLoader.getResourceAsStream()`을 통해 반복해서 로드되었습니다.

30분 이상 게임 플레이 시 임시 Java 배열이 회수되지 않은 채 누적되었고, 결국 다음 오류와 함께 리소스 로딩에 실패했습니다.

```text
Failed to instantiate array: Allocation failure
```

이때 발생한 Java 예외는 unwrap()에 의해 Rust 패닉으로 이어졌습니다.

## 해결

- KTF SVC 호출 간에 WIPI-C 런타임 상태 공유
- 최초 JAR 읽기 이후 리소스 데이터 캐싱, 이후 크기 조회 및 읽기 요청에서는 캐시된 데이터를 재사용
- 리소스 로딩 후 임시 JVM 객체 정리
- Java 리소스 로딩 오류 발생 시 unwrap()으로 패닉을 일으키는 대신 오류를 상위로 전달

## 테스트

- cargo fmt
- cargo clippy --workspace
- cargo test -p wie_ktf
- res.gmf, map.pmd, script.bin에 반복적으로 접근하는 장시간 게임 플레이 테스트