### PR TITLE
(CLI) Fix MIDI playback stutter with a dedicated scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,6 +3465,7 @@ dependencies = [
  "wie_lgt",
  "wie_skt",
  "wie_util",
+ "windows-sys 0.61.2",
  "winit",
 ]
 

--- a/wie_backend/src/audio_sink.rs
+++ b/wie_backend/src/audio_sink.rs
@@ -1,3 +1,21 @@
+use alloc::vec::Vec;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MidiEvent {
+    NoteOn { channel: u8, note: u8, velocity: u8 },
+    NoteOff { channel: u8, note: u8, velocity: u8 },
+    ProgramChange { channel: u8, program: u8 },
+    ControlChange { channel: u8, control: u8, value: u8 },
+    PitchBend { channel: u8, value: u16 },
+    SysEx(Vec<u8>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScheduledMidiEvent {
+    pub at_ms: u64,
+    pub event: MidiEvent,
+}
+
 pub trait AudioSink: Sync + Send {
     fn play_wave(&self, channel: u8, sampling_rate: u32, wave_data: &[i16]);
     fn midi_note_on(&self, channel_id: u8, note: u8, velocity: u8);
@@ -6,4 +24,10 @@ pub trait AudioSink: Sync + Send {
     fn midi_control_change(&self, channel_id: u8, control: u8, value: u8);
     fn midi_pitch_bend(&self, channel_id: u8, value: u16);
     fn midi_sysex(&self, data: &[u8]);
+
+    fn schedule_midi(&self, _playback_id: u64, _events: &[ScheduledMidiEvent], _duration_ms: u64, _repeat: bool) -> bool {
+        false
+    }
+
+    fn stop_scheduled_midi(&self, _playback_id: u64) {}
 }

--- a/wie_backend/src/lib.rs
+++ b/wie_backend/src/lib.rs
@@ -13,7 +13,7 @@ mod task_runner;
 mod time;
 
 pub use self::{
-    audio_sink::AudioSink,
+    audio_sink::{AudioSink, MidiEvent, ScheduledMidiEvent},
     database::{Database, DatabaseRepository, RecordId},
     executor::{AsyncCallable, AsyncCallableResult},
     platform::{Filesystem, Platform},

--- a/wie_backend/src/system/audio.rs
+++ b/wie_backend/src/system/audio.rs
@@ -8,7 +8,10 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use smaf_player::{SmafEvent, parse_smaf};
 
-use crate::{System, audio_sink::AudioSink};
+use crate::{
+    System,
+    audio_sink::{AudioSink, MidiEvent, ScheduledMidiEvent},
+};
 
 pub type AudioHandle = u32;
 #[derive(Debug)]
@@ -24,8 +27,14 @@ enum AudioFile {
 pub struct Audio {
     sink: Arc<Box<dyn AudioSink>>,
     files: BTreeMap<AudioHandle, AudioFile>,
-    playing: BTreeMap<AudioHandle, Arc<AtomicBool>>,
+    playing: BTreeMap<AudioHandle, Playback>,
     last_audio_handle: AudioHandle,
+    last_playback_id: u64,
+}
+
+enum Playback {
+    Executor(Arc<AtomicBool>),
+    Scheduled(u64),
 }
 
 impl Audio {
@@ -35,6 +44,7 @@ impl Audio {
             files: BTreeMap::new(),
             playing: BTreeMap::new(),
             last_audio_handle: 0,
+            last_playback_id: 0,
         }
     }
 
@@ -55,12 +65,21 @@ impl Audio {
 
         self.stop(audio_handle);
 
+        if let Some((events, duration_ms)) = player.midi_sequence() {
+            self.last_playback_id += 1;
+            let playback_id = self.last_playback_id;
+            if self.sink.schedule_midi(playback_id, &events, duration_ms, repeat) {
+                self.playing.insert(audio_handle, Playback::Scheduled(playback_id));
+                return Ok(());
+            }
+        }
+
         let mut system_clone = system.clone();
         let sink_clone = self.sink.clone();
 
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stop_flag_clone = stop_flag.clone();
-        self.playing.insert(audio_handle, stop_flag);
+        self.playing.insert(audio_handle, Playback::Executor(stop_flag));
 
         // TODO use dedicated audio player task
         system.spawn(async move || {
@@ -73,8 +92,11 @@ impl Audio {
     }
 
     pub fn stop(&mut self, audio_handle: AudioHandle) {
-        if let Some(stop_flag) = self.playing.remove(&audio_handle) {
-            stop_flag.store(true, Ordering::Relaxed);
+        if let Some(playback) = self.playing.remove(&audio_handle) {
+            match playback {
+                Playback::Executor(stop_flag) => stop_flag.store(true, Ordering::Relaxed),
+                Playback::Scheduled(playback_id) => self.sink.stop_scheduled_midi(playback_id),
+            }
         }
     }
 
@@ -96,6 +118,46 @@ pub struct SmafPlayer {
 impl SmafPlayer {
     pub fn new(data: &[u8]) -> Self {
         Self { events: parse_smaf(data) }
+    }
+
+    fn midi_sequence(&self) -> Option<(Vec<ScheduledMidiEvent>, u64)> {
+        let mut result = Vec::new();
+        let mut duration_ms = 0;
+
+        for (time, event) in &self.events {
+            duration_ms = duration_ms.max(*time as u64);
+            let event = match event {
+                SmafEvent::Wave { .. } => return None,
+                SmafEvent::MidiNoteOn { channel, note, velocity } => MidiEvent::NoteOn {
+                    channel: *channel,
+                    note: *note,
+                    velocity: *velocity,
+                },
+                SmafEvent::MidiNoteOff { channel, note, velocity } => MidiEvent::NoteOff {
+                    channel: *channel,
+                    note: *note,
+                    velocity: *velocity,
+                },
+                SmafEvent::MidiProgramChange { channel, program } => MidiEvent::ProgramChange {
+                    channel: *channel,
+                    program: *program,
+                },
+                SmafEvent::MidiControlChange { channel, control, value } => MidiEvent::ControlChange {
+                    channel: *channel,
+                    control: *control,
+                    value: *value,
+                },
+                SmafEvent::MidiPitchBend { channel, value } => MidiEvent::PitchBend {
+                    channel: *channel,
+                    value: *value,
+                },
+                SmafEvent::MidiSysEx(data) => MidiEvent::SysEx(data.clone()),
+                SmafEvent::End => continue,
+            };
+            result.push(ScheduledMidiEvent { at_ms: *time as u64, event });
+        }
+
+        Some((result, duration_ms))
     }
 
     pub async fn play(&self, system: &mut System, sink: &dyn AudioSink, stop_flag: &AtomicBool, repeat: bool) {
@@ -179,7 +241,10 @@ mod tests {
     use smaf_player::SmafEvent;
 
     use super::SmafPlayer;
-    use crate::{AudioSink, Database, DatabaseRepository, DefaultTaskRunner, Filesystem, Instant, Platform, Screen, System, canvas::Image};
+    use crate::{
+        AudioSink, Database, DatabaseRepository, DefaultTaskRunner, Filesystem, Instant, MidiEvent, Platform, ScheduledMidiEvent, Screen, System,
+        canvas::Image,
+    };
 
     struct NullDatabase;
 
@@ -409,5 +474,60 @@ mod tests {
         player.play(&mut system, &sink, &stop_flag, true).await;
 
         assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn converts_pure_midi_to_an_absolute_sequence() {
+        let player = SmafPlayer {
+            events: vec![
+                (5, SmafEvent::MidiProgramChange { channel: 1, program: 4 }),
+                (
+                    10,
+                    SmafEvent::MidiNoteOn {
+                        channel: 1,
+                        note: 60,
+                        velocity: 100,
+                    },
+                ),
+                (30, SmafEvent::End),
+            ],
+        };
+
+        assert_eq!(
+            player.midi_sequence(),
+            Some((
+                vec![
+                    ScheduledMidiEvent {
+                        at_ms: 5,
+                        event: MidiEvent::ProgramChange { channel: 1, program: 4 },
+                    },
+                    ScheduledMidiEvent {
+                        at_ms: 10,
+                        event: MidiEvent::NoteOn {
+                            channel: 1,
+                            note: 60,
+                            velocity: 100,
+                        },
+                    },
+                ],
+                30,
+            ))
+        );
+    }
+
+    #[test]
+    fn keeps_mixed_wave_sequences_on_the_executor_fallback() {
+        let player = SmafPlayer {
+            events: vec![(
+                0,
+                SmafEvent::Wave {
+                    channel: 1,
+                    sampling_rate: 8000,
+                    data: vec![0],
+                },
+            )],
+        };
+
+        assert_eq!(player.midi_sequence(), None);
     }
 }

--- a/wie_cli/Cargo.toml
+++ b/wie_cli/Cargo.toml
@@ -30,3 +30,6 @@ wie_skt = { path = "../wie_skt" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "=0.3.85" }                        # We need 0.3.85 to not break midir wasm build
 getrandom = { version = "^0.4", features = ["wasm_js"] } # not direct dependency, but broken without it in wasm build
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Media"] }

--- a/wie_cli/src/audio_sink.rs
+++ b/wie_cli/src/audio_sink.rs
@@ -1,15 +1,26 @@
-use std::sync::{Mutex, mpsc::Sender};
+#[cfg(target_arch = "wasm32")]
+use std::sync::Mutex;
+use std::sync::mpsc::Sender;
 
-use midir::MidiOutputConnection;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::midi_worker::MidiWorker;
 
 pub struct AudioSink {
-    midi_out: Option<Mutex<MidiOutputConnection>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    midi_worker: Option<MidiWorker>,
+    #[cfg(target_arch = "wasm32")]
+    midi_out: Option<Mutex<midir::MidiOutputConnection>>,
     audio_tx: Sender<(u8, u32, Vec<i16>)>,
 }
 
 impl AudioSink {
-    pub fn new(midi_out: Option<MidiOutputConnection>, audio_tx: Sender<(u8, u32, Vec<i16>)>) -> Self {
+    pub fn new(midi_out: Option<midir::MidiOutputConnection>, audio_tx: Sender<(u8, u32, Vec<i16>)>) -> Self {
         Self {
+            // Desktop targets share the same scheduler. The browser keeps its
+            // existing Web MIDI path, whose timing is managed by the web host.
+            #[cfg(not(target_arch = "wasm32"))]
+            midi_worker: midi_out.and_then(MidiWorker::new),
+            #[cfg(target_arch = "wasm32")]
             midi_out: midi_out.map(Mutex::new),
             audio_tx,
         }
@@ -28,41 +39,100 @@ impl wie_backend::AudioSink for AudioSink {
     }
 
     fn midi_note_on(&self, channel_id: u8, note: u8, velocity: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0x90 | channel_id, note, velocity]).unwrap();
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.send(wie_backend::MidiEvent::NoteOn {
+                channel: channel_id,
+                note,
+                velocity,
+            });
+        }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(connection) = self.midi_out.as_ref() {
+            let _ = connection.lock().unwrap().send(&[0x90 | channel_id, note, velocity]);
         }
     }
 
     fn midi_note_off(&self, channel_id: u8, note: u8, velocity: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0x80 | channel_id, note, velocity]).unwrap();
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.send(wie_backend::MidiEvent::NoteOff {
+                channel: channel_id,
+                note,
+                velocity,
+            });
+        }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(connection) = self.midi_out.as_ref() {
+            let _ = connection.lock().unwrap().send(&[0x80 | channel_id, note, velocity]);
         }
     }
 
     fn midi_control_change(&self, channel_id: u8, control: u8, value: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0xB0 | channel_id, control, value]).unwrap()
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.send(wie_backend::MidiEvent::ControlChange {
+                channel: channel_id,
+                control,
+                value,
+            });
+        }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(connection) = self.midi_out.as_ref() {
+            let _ = connection.lock().unwrap().send(&[0xb0 | channel_id, control, value]);
         }
     }
 
     fn midi_program_change(&self, channel_id: u8, program: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0xC0 | channel_id, program]).unwrap()
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.send(wie_backend::MidiEvent::ProgramChange {
+                channel: channel_id,
+                program,
+            });
+        }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(connection) = self.midi_out.as_ref() {
+            let _ = connection.lock().unwrap().send(&[0xc0 | channel_id, program]);
         }
     }
 
     fn midi_pitch_bend(&self, channel_id: u8, value: u16) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock()
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.send(wie_backend::MidiEvent::PitchBend { channel: channel_id, value });
+        }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(connection) = self.midi_out.as_ref() {
+            let _ = connection
+                .lock()
                 .unwrap()
-                .send(&[0xE0 | channel_id, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8])
-                .unwrap();
+                .send(&[0xe0 | channel_id, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8]);
         }
     }
 
     fn midi_sysex(&self, data: &[u8]) {
-        if let Some(x) = self.midi_out.as_ref() {
-            let _ = x.lock().unwrap().send(data);
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.send(wie_backend::MidiEvent::SysEx(data.to_vec()));
+        }
+        #[cfg(target_arch = "wasm32")]
+        if let Some(connection) = self.midi_out.as_ref() {
+            let _ = connection.lock().unwrap().send(data);
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn schedule_midi(&self, playback_id: u64, events: &[wie_backend::ScheduledMidiEvent], duration_ms: u64, repeat: bool) -> bool {
+        self.midi_worker
+            .as_ref()
+            .is_some_and(|worker| worker.schedule(playback_id, events, duration_ms, repeat))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn stop_scheduled_midi(&self, playback_id: u64) {
+        if let Some(worker) = self.midi_worker.as_ref() {
+            worker.stop(playback_id);
         }
     }
 }

--- a/wie_cli/src/audio_sink.rs
+++ b/wie_cli/src/audio_sink.rs
@@ -1,13 +1,16 @@
-#[cfg(target_arch = "wasm32")]
-use std::sync::Mutex;
-use std::sync::mpsc::Sender;
+use std::sync::{Mutex, mpsc::Sender};
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::midi_worker::MidiWorker;
+use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::midi_worker::{MidiConnection, MidiWorker, send_event};
 
 pub struct AudioSink {
     #[cfg(not(target_arch = "wasm32"))]
     midi_worker: Option<MidiWorker>,
+    #[cfg(not(target_arch = "wasm32"))]
+    midi_out: Option<MidiConnection>,
     #[cfg(target_arch = "wasm32")]
     midi_out: Option<Mutex<midir::MidiOutputConnection>>,
     audio_tx: Sender<(u8, u32, Vec<i16>)>,
@@ -15,14 +18,33 @@ pub struct AudioSink {
 
 impl AudioSink {
     pub fn new(midi_out: Option<midir::MidiOutputConnection>, audio_tx: Sender<(u8, u32, Vec<i16>)>) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let midi_out = midi_out.map(|connection| Arc::new(Mutex::new(connection)));
+        #[cfg(not(target_arch = "wasm32"))]
+        let midi_worker = midi_out.as_ref().and_then(|connection| MidiWorker::new(connection.clone()));
+
         Self {
-            // Desktop targets share the same scheduler. The browser keeps its
-            // existing Web MIDI path, whose timing is managed by the web host.
+            // Desktop targets share the same scheduler and retain the
+            // connection for direct fallback. The browser keeps its existing
+            // Web MIDI path, whose timing is managed by the web host.
             #[cfg(not(target_arch = "wasm32"))]
-            midi_worker: midi_out.and_then(MidiWorker::new),
+            midi_worker,
+            #[cfg(not(target_arch = "wasm32"))]
+            midi_out,
             #[cfg(target_arch = "wasm32")]
             midi_out: midi_out.map(Mutex::new),
             audio_tx,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn send_midi(&self, event: wie_backend::MidiEvent) {
+        if self.midi_worker.as_ref().is_some_and(|worker| worker.send(event.clone())) {
+            return;
+        }
+
+        if let Some(connection) = self.midi_out.as_ref() {
+            send_event(connection, &event);
         }
     }
 }
@@ -40,82 +62,71 @@ impl wie_backend::AudioSink for AudioSink {
 
     fn midi_note_on(&self, channel_id: u8, note: u8, velocity: u8) {
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(worker) = self.midi_worker.as_ref() {
-            worker.send(wie_backend::MidiEvent::NoteOn {
-                channel: channel_id,
-                note,
-                velocity,
-            });
-        }
+        self.send_midi(wie_backend::MidiEvent::NoteOn {
+            channel: channel_id,
+            note,
+            velocity,
+        });
         #[cfg(target_arch = "wasm32")]
         if let Some(connection) = self.midi_out.as_ref() {
-            let _ = connection.lock().unwrap().send(&[0x90 | channel_id, note, velocity]);
+            connection.lock().unwrap().send(&[0x90 | channel_id, note, velocity]).unwrap();
         }
     }
 
     fn midi_note_off(&self, channel_id: u8, note: u8, velocity: u8) {
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(worker) = self.midi_worker.as_ref() {
-            worker.send(wie_backend::MidiEvent::NoteOff {
-                channel: channel_id,
-                note,
-                velocity,
-            });
-        }
+        self.send_midi(wie_backend::MidiEvent::NoteOff {
+            channel: channel_id,
+            note,
+            velocity,
+        });
         #[cfg(target_arch = "wasm32")]
         if let Some(connection) = self.midi_out.as_ref() {
-            let _ = connection.lock().unwrap().send(&[0x80 | channel_id, note, velocity]);
+            connection.lock().unwrap().send(&[0x80 | channel_id, note, velocity]).unwrap();
         }
     }
 
     fn midi_control_change(&self, channel_id: u8, control: u8, value: u8) {
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(worker) = self.midi_worker.as_ref() {
-            worker.send(wie_backend::MidiEvent::ControlChange {
-                channel: channel_id,
-                control,
-                value,
-            });
-        }
+        self.send_midi(wie_backend::MidiEvent::ControlChange {
+            channel: channel_id,
+            control,
+            value,
+        });
         #[cfg(target_arch = "wasm32")]
         if let Some(connection) = self.midi_out.as_ref() {
-            let _ = connection.lock().unwrap().send(&[0xb0 | channel_id, control, value]);
+            connection.lock().unwrap().send(&[0xB0 | channel_id, control, value]).unwrap()
         }
     }
 
     fn midi_program_change(&self, channel_id: u8, program: u8) {
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(worker) = self.midi_worker.as_ref() {
-            worker.send(wie_backend::MidiEvent::ProgramChange {
-                channel: channel_id,
-                program,
-            });
-        }
+        self.send_midi(wie_backend::MidiEvent::ProgramChange {
+            channel: channel_id,
+            program,
+        });
         #[cfg(target_arch = "wasm32")]
         if let Some(connection) = self.midi_out.as_ref() {
-            let _ = connection.lock().unwrap().send(&[0xc0 | channel_id, program]);
+            connection.lock().unwrap().send(&[0xC0 | channel_id, program]).unwrap()
         }
     }
 
     fn midi_pitch_bend(&self, channel_id: u8, value: u16) {
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(worker) = self.midi_worker.as_ref() {
-            worker.send(wie_backend::MidiEvent::PitchBend { channel: channel_id, value });
-        }
+        self.send_midi(wie_backend::MidiEvent::PitchBend { channel: channel_id, value });
         #[cfg(target_arch = "wasm32")]
         if let Some(connection) = self.midi_out.as_ref() {
-            let _ = connection
+            connection
                 .lock()
                 .unwrap()
-                .send(&[0xe0 | channel_id, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8]);
+                .send(&[0xE0 | channel_id, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8])
+                .unwrap();
         }
     }
 
     fn midi_sysex(&self, data: &[u8]) {
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(worker) = self.midi_worker.as_ref() {
-            worker.send(wie_backend::MidiEvent::SysEx(data.to_vec()));
-        }
+        self.send_midi(wie_backend::MidiEvent::SysEx(data.to_vec()));
         #[cfg(target_arch = "wasm32")]
         if let Some(connection) = self.midi_out.as_ref() {
             let _ = connection.lock().unwrap().send(data);

--- a/wie_cli/src/main.rs
+++ b/wie_cli/src/main.rs
@@ -3,6 +3,8 @@ extern crate alloc;
 mod audio_sink;
 mod database;
 mod filesystem;
+#[cfg(not(target_arch = "wasm32"))]
+mod midi_worker;
 mod window;
 
 use core::str;

--- a/wie_cli/src/midi_worker.rs
+++ b/wie_cli/src/midi_worker.rs
@@ -1,0 +1,533 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError},
+    thread,
+    time::{Duration, Instant},
+};
+
+use midir::MidiOutputConnection;
+use wie_backend::{MidiEvent, ScheduledMidiEvent};
+
+const MAX_CATCH_UP_LATENESS: Duration = Duration::from_millis(50);
+const DEADLINE_YIELD_WINDOW: Duration = Duration::from_millis(1);
+
+pub struct MidiWorker {
+    tx: Sender<MidiCommand>,
+}
+
+impl MidiWorker {
+    pub fn new(connection: MidiOutputConnection) -> Option<Self> {
+        let (tx, rx) = mpsc::channel();
+        if let Err(error) = thread::Builder::new()
+            .name("wie-midi".to_string())
+            .spawn(move || run_worker(connection, rx))
+        {
+            tracing::warn!(%error, "Failed to start MIDI worker");
+            return None;
+        }
+
+        Some(Self { tx })
+    }
+
+    pub fn schedule(&self, playback_id: u64, events: &[ScheduledMidiEvent], duration_ms: u64, repeat: bool) -> bool {
+        self.tx
+            .send(MidiCommand::Play {
+                playback_id,
+                events: events.to_vec(),
+                duration: Duration::from_millis(duration_ms),
+                repeat,
+            })
+            .is_ok()
+    }
+
+    pub fn stop(&self, playback_id: u64) {
+        let _ = self.tx.send(MidiCommand::Stop { playback_id });
+    }
+
+    pub fn send(&self, event: MidiEvent) {
+        let _ = self.tx.send(MidiCommand::Send(event));
+    }
+}
+
+enum MidiCommand {
+    Play {
+        playback_id: u64,
+        events: Vec<ScheduledMidiEvent>,
+        duration: Duration,
+        repeat: bool,
+    },
+    Stop {
+        playback_id: u64,
+    },
+    Send(MidiEvent),
+}
+
+struct Playback {
+    events: Vec<ScheduledMidiEvent>,
+    duration: Duration,
+    repeat: bool,
+    cycle_start: Instant,
+    next_event: usize,
+    active_notes: BTreeSet<(u8, u8)>,
+    used_channels: BTreeSet<u8>,
+    late_event_count: u64,
+    max_lateness: Duration,
+}
+
+impl Playback {
+    fn new(events: Vec<ScheduledMidiEvent>, duration: Duration, repeat: bool, now: Instant) -> Self {
+        Self {
+            events,
+            duration,
+            repeat,
+            cycle_start: now,
+            next_event: 0,
+            active_notes: BTreeSet::new(),
+            used_channels: BTreeSet::new(),
+            late_event_count: 0,
+            max_lateness: Duration::ZERO,
+        }
+    }
+
+    fn next_deadline(&self) -> Instant {
+        if let Some(event) = self.events.get(self.next_event) {
+            self.cycle_start + Duration::from_millis(event.at_ms)
+        } else {
+            self.cycle_start + self.duration
+        }
+    }
+
+    fn take_due_event(&mut self, now: Instant) -> Option<(Instant, MidiEvent)> {
+        let event = self.events.get(self.next_event)?;
+        let deadline = self.cycle_start + Duration::from_millis(event.at_ms);
+        if deadline > now {
+            return None;
+        }
+
+        self.next_event += 1;
+        let lateness = now.saturating_duration_since(deadline);
+        if lateness > Duration::from_millis(10) {
+            self.late_event_count += 1;
+            self.max_lateness = self.max_lateness.max(lateness);
+        }
+
+        Some((deadline, event.event.clone()))
+    }
+
+    fn finish_cycle(&mut self, now: Instant) -> bool {
+        if self.next_event < self.events.len() || self.next_deadline() > now {
+            return false;
+        }
+
+        if !self.repeat || self.duration.is_zero() {
+            return true;
+        }
+
+        let elapsed = now.saturating_duration_since(self.cycle_start);
+        let completed_cycles = (elapsed.as_nanos() / self.duration.as_nanos()).max(1);
+        let advance = self.duration.saturating_mul(completed_cycles.min(u32::MAX as u128) as u32);
+        self.cycle_start += advance;
+        self.next_event = 0;
+        self.active_notes.clear();
+        self.used_channels.clear();
+        self.late_event_count = 0;
+        self.max_lateness = Duration::ZERO;
+
+        false
+    }
+
+    fn skip_missed_cycles(&mut self, now: Instant) -> bool {
+        if !self.repeat || self.duration.is_zero() || now <= self.cycle_start + self.duration + MAX_CATCH_UP_LATENESS {
+            return false;
+        }
+
+        let elapsed = now.saturating_duration_since(self.cycle_start);
+        let completed_cycles = elapsed.as_nanos() / self.duration.as_nanos();
+        let advance = self.duration.saturating_mul(completed_cycles.min(u32::MAX as u128) as u32);
+        self.cycle_start += advance;
+        self.next_event = 0;
+
+        true
+    }
+
+    fn track(&mut self, event: &MidiEvent) {
+        match event {
+            MidiEvent::NoteOn { channel, note, velocity } => {
+                self.used_channels.insert(*channel);
+                if *velocity == 0 {
+                    self.active_notes.remove(&(*channel, *note));
+                } else {
+                    self.active_notes.insert((*channel, *note));
+                }
+            }
+            MidiEvent::NoteOff { channel, note, .. } => {
+                self.used_channels.insert(*channel);
+                self.active_notes.remove(&(*channel, *note));
+            }
+            MidiEvent::ProgramChange { channel, .. } | MidiEvent::ControlChange { channel, .. } | MidiEvent::PitchBend { channel, .. } => {
+                self.used_channels.insert(*channel);
+            }
+            MidiEvent::SysEx(_) => {}
+        }
+    }
+}
+
+fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
+    // Scheduling and deadline handling are shared by every native target. Some
+    // platforms need a process-level hint to make timed waits precise enough;
+    // that optional hint must not affect playback semantics.
+    let _timer_precision = platform_timer::TimerPrecision::acquire();
+    let mut playbacks = BTreeMap::new();
+
+    loop {
+        let now = Instant::now();
+        dispatch_due_events(&mut connection, &mut playbacks, now);
+
+        let command = match next_deadline(&playbacks) {
+            Some(deadline) => match receive_until(&rx, deadline) {
+                WorkerWake::Command(command) => Some(command),
+                WorkerWake::Deadline => continue,
+                WorkerWake::Disconnected => None,
+            },
+            None => rx.recv().ok(),
+        };
+
+        let Some(command) = command else {
+            for (_, playback) in playbacks {
+                cleanup_playback(&mut connection, &playback, true);
+            }
+            break;
+        };
+
+        match command {
+            MidiCommand::Play {
+                playback_id,
+                events,
+                duration,
+                repeat,
+            } => {
+                if let Some(previous) = playbacks.remove(&playback_id) {
+                    cleanup_playback(&mut connection, &previous, true);
+                }
+                tracing::debug!(
+                    playback_id,
+                    event_count = events.len(),
+                    duration_ms = duration.as_millis(),
+                    repeat,
+                    "Scheduled MIDI playback"
+                );
+                playbacks.insert(playback_id, Playback::new(events, duration, repeat, Instant::now()));
+            }
+            MidiCommand::Stop { playback_id } => {
+                if let Some(playback) = playbacks.remove(&playback_id) {
+                    cleanup_playback(&mut connection, &playback, true);
+                }
+            }
+            MidiCommand::Send(event) => send_event(&mut connection, &event),
+        }
+    }
+}
+
+enum WorkerWake {
+    Command(MidiCommand),
+    Deadline,
+    Disconnected,
+}
+
+fn receive_until(rx: &Receiver<MidiCommand>, deadline: Instant) -> WorkerWake {
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return WorkerWake::Deadline;
+        }
+
+        let remaining = deadline - now;
+        if remaining > DEADLINE_YIELD_WINDOW {
+            match rx.recv_timeout(remaining - DEADLINE_YIELD_WINDOW) {
+                Ok(command) => return WorkerWake::Command(command),
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => return WorkerWake::Disconnected,
+            }
+        } else {
+            match rx.try_recv() {
+                Ok(command) => return WorkerWake::Command(command),
+                Err(TryRecvError::Empty) => thread::yield_now(),
+                Err(TryRecvError::Disconnected) => return WorkerWake::Disconnected,
+            }
+        }
+    }
+}
+
+fn next_deadline(playbacks: &BTreeMap<u64, Playback>) -> Option<Instant> {
+    playbacks.values().map(Playback::next_deadline).min()
+}
+
+fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BTreeMap<u64, Playback>, now: Instant) {
+    loop {
+        let next_playback_id = playbacks
+            .iter()
+            .filter(|(_, playback)| playback.next_deadline() <= now)
+            .min_by_key(|(playback_id, playback)| (playback.next_deadline(), **playback_id))
+            .map(|(playback_id, _)| *playback_id);
+        let Some(playback_id) = next_playback_id else {
+            break;
+        };
+
+        let playback = playbacks.get_mut(&playback_id).unwrap();
+        if playback.skip_missed_cycles(now) {
+            cleanup_playback(connection, playback, false);
+            tracing::debug!(
+                playback_id,
+                late_event_count = playback.late_event_count,
+                max_lateness_ms = playback.max_lateness.as_millis(),
+                "Skipped missed MIDI playback cycles"
+            );
+            playback.active_notes.clear();
+            playback.used_channels.clear();
+            playback.late_event_count = 0;
+            playback.max_lateness = Duration::ZERO;
+            continue;
+        }
+        if let Some((_deadline, event)) = playback.take_due_event(now) {
+            send_event(connection, &event);
+            playback.track(&event);
+            continue;
+        }
+
+        cleanup_playback(connection, playback, !playback.repeat);
+        tracing::debug!(
+            playback_id,
+            late_event_count = playback.late_event_count,
+            max_lateness_ms = playback.max_lateness.as_millis(),
+            "MIDI playback timing"
+        );
+        if playback.finish_cycle(now) {
+            playbacks.remove(&playback_id);
+        }
+    }
+}
+
+fn cleanup_playback(connection: &mut MidiOutputConnection, playback: &Playback, full: bool) {
+    for event in cleanup_events(playback, full) {
+        send_event(connection, &event);
+    }
+}
+
+fn cleanup_events(playback: &Playback, full: bool) -> Vec<MidiEvent> {
+    let mut result = Vec::new();
+    for (channel, note) in &playback.active_notes {
+        result.push(MidiEvent::NoteOff {
+            channel: *channel,
+            note: *note,
+            velocity: 0,
+        });
+    }
+
+    for channel in &playback.used_channels {
+        result.push(MidiEvent::ControlChange {
+            channel: *channel,
+            control: 64,
+            value: 0,
+        });
+        if full {
+            result.push(MidiEvent::ControlChange {
+                channel: *channel,
+                control: 120,
+                value: 0,
+            });
+            result.push(MidiEvent::ControlChange {
+                channel: *channel,
+                control: 123,
+                value: 0,
+            });
+        }
+    }
+
+    result
+}
+
+fn send_event(connection: &mut MidiOutputConnection, event: &MidiEvent) {
+    match event {
+        MidiEvent::NoteOn { channel, note, velocity } => send_bytes(connection, &[0x90 | channel, *note, *velocity]),
+        MidiEvent::NoteOff { channel, note, velocity } => send_bytes(connection, &[0x80 | channel, *note, *velocity]),
+        MidiEvent::ProgramChange { channel, program } => send_bytes(connection, &[0xc0 | channel, *program]),
+        MidiEvent::ControlChange { channel, control, value } => send_bytes(connection, &[0xb0 | channel, *control, *value]),
+        MidiEvent::PitchBend { channel, value } => send_bytes(connection, &[0xe0 | channel, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8]),
+        MidiEvent::SysEx(data) => send_bytes(connection, data),
+    }
+}
+
+fn send_bytes(connection: &mut MidiOutputConnection, data: &[u8]) {
+    if let Err(error) = connection.send(data) {
+        tracing::warn!(%error, "Failed to send MIDI message");
+    }
+}
+
+mod platform_timer {
+    #[cfg(windows)]
+    mod implementation {
+        use windows_sys::Win32::Media::{TIMERR_NOERROR, timeBeginPeriod, timeEndPeriod};
+
+        pub struct TimerPrecision {
+            enabled: bool,
+        }
+
+        impl TimerPrecision {
+            pub fn acquire() -> Self {
+                let enabled = unsafe { timeBeginPeriod(1) } == TIMERR_NOERROR;
+                if !enabled {
+                    tracing::warn!("Failed to request 1 ms Windows timer resolution");
+                }
+
+                Self { enabled }
+            }
+        }
+
+        impl Drop for TimerPrecision {
+            fn drop(&mut self) {
+                if self.enabled {
+                    unsafe {
+                        timeEndPeriod(1);
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    mod implementation {
+        pub struct TimerPrecision;
+
+        impl TimerPrecision {
+            pub fn acquire() -> Self {
+                Self
+            }
+        }
+    }
+
+    pub use implementation::TimerPrecision;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn note_on(at_ms: u64, note: u8) -> ScheduledMidiEvent {
+        ScheduledMidiEvent {
+            at_ms,
+            event: MidiEvent::NoteOn {
+                channel: 0,
+                note,
+                velocity: 100,
+            },
+        }
+    }
+
+    #[test]
+    fn uses_absolute_event_deadlines() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(10, 60), note_on(20, 62)], Duration::from_millis(30), false, start);
+
+        assert!(playback.take_due_event(start + Duration::from_millis(9)).is_none());
+        assert_eq!(
+            playback.take_due_event(start + Duration::from_millis(10)),
+            Some((start + Duration::from_millis(10), note_on(10, 60).event))
+        );
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(20));
+        assert_eq!(
+            playback.take_due_event(start + Duration::from_millis(25)),
+            Some((start + Duration::from_millis(20), note_on(20, 62).event))
+        );
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(30));
+    }
+
+    #[test]
+    fn repeating_playback_skips_missed_cycles_without_drift() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(30), true, start);
+
+        assert!(playback.skip_missed_cycles(start + Duration::from_millis(95)));
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(90));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(95));
+        assert_eq!(
+            playback.take_due_event(start + Duration::from_millis(95)),
+            Some((start + Duration::from_millis(95), note_on(5, 60).event))
+        );
+    }
+
+    #[test]
+    fn repeating_playback_catches_up_small_lateness() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(30), true, start);
+
+        assert!(!playback.skip_missed_cycles(start + Duration::from_millis(80)));
+        assert_eq!(playback.cycle_start, start);
+    }
+
+    #[test]
+    fn tracks_active_notes_and_used_channels() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![], Duration::from_millis(30), false, start);
+
+        playback.track(&note_on(0, 60).event);
+        playback.track(&MidiEvent::ProgramChange { channel: 1, program: 4 });
+        assert!(playback.active_notes.contains(&(0, 60)));
+        assert_eq!(playback.used_channels, BTreeSet::from([0, 1]));
+
+        playback.track(&MidiEvent::NoteOff {
+            channel: 0,
+            note: 60,
+            velocity: 0,
+        });
+        assert!(playback.active_notes.is_empty());
+    }
+
+    #[test]
+    fn full_cleanup_stops_notes_and_resets_used_channels() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![], Duration::from_millis(30), false, start);
+        playback.track(&note_on(0, 60).event);
+        playback.track(&MidiEvent::ProgramChange { channel: 1, program: 4 });
+
+        assert_eq!(
+            cleanup_events(&playback, true),
+            vec![
+                MidiEvent::NoteOff {
+                    channel: 0,
+                    note: 60,
+                    velocity: 0,
+                },
+                MidiEvent::ControlChange {
+                    channel: 0,
+                    control: 64,
+                    value: 0,
+                },
+                MidiEvent::ControlChange {
+                    channel: 0,
+                    control: 120,
+                    value: 0,
+                },
+                MidiEvent::ControlChange {
+                    channel: 0,
+                    control: 123,
+                    value: 0,
+                },
+                MidiEvent::ControlChange {
+                    channel: 1,
+                    control: 64,
+                    value: 0,
+                },
+                MidiEvent::ControlChange {
+                    channel: 1,
+                    control: 120,
+                    value: 0,
+                },
+                MidiEvent::ControlChange {
+                    channel: 1,
+                    control: 123,
+                    value: 0,
+                },
+            ]
+        );
+    }
+}

--- a/wie_cli/src/midi_worker.rs
+++ b/wie_cli/src/midi_worker.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError},
+    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender},
     thread,
     time::{Duration, Instant},
 };
@@ -8,8 +8,7 @@ use std::{
 use midir::MidiOutputConnection;
 use wie_backend::{MidiEvent, ScheduledMidiEvent};
 
-const MAX_CATCH_UP_LATENESS: Duration = Duration::from_millis(50);
-const DEADLINE_YIELD_WINDOW: Duration = Duration::from_millis(1);
+const MAX_EVENT_LATENESS: Duration = Duration::from_millis(50);
 
 pub struct MidiWorker {
     tx: Sender<MidiCommand>,
@@ -136,18 +135,39 @@ impl Playback {
         false
     }
 
-    fn skip_missed_cycles(&mut self, now: Instant) -> bool {
-        if !self.repeat || self.duration.is_zero() || now <= self.cycle_start + self.duration + MAX_CATCH_UP_LATENESS {
-            return false;
+    fn recover_from_late_wakeup(&mut self, now: Instant) -> LateRecovery {
+        if !self.repeat || self.duration.is_zero() {
+            return LateRecovery::None;
         }
 
         let elapsed = now.saturating_duration_since(self.cycle_start);
         let completed_cycles = elapsed.as_nanos() / self.duration.as_nanos();
-        let advance = self.duration.saturating_mul(completed_cycles.min(u32::MAX as u128) as u32);
+        let cycle_remainder = elapsed.as_nanos() % self.duration.as_nanos();
+        if completed_cycles == 0 && now.saturating_duration_since(self.next_deadline()) <= MAX_EVENT_LATENESS {
+            return LateRecovery::None;
+        }
+
+        if completed_cycles > 0 && cycle_remainder == 0 {
+            let first_boundary_event = self.events[self.next_event..]
+                .iter()
+                .position(|event| Duration::from_millis(event.at_ms) == self.duration)
+                .map(|index| self.next_event + index);
+            if let Some(first_boundary_event) = first_boundary_event {
+                let previous_cycles = completed_cycles - 1;
+                let advance = self.duration.saturating_mul(previous_cycles.min(u32::MAX as u128) as u32);
+                self.cycle_start += advance;
+                self.next_event = first_boundary_event;
+                return LateRecovery::CycleBoundary;
+            }
+        }
+
+        let cycles_to_next = completed_cycles + u128::from(cycle_remainder > 0);
+        let cycles_to_next = cycles_to_next.max(1);
+        let advance = self.duration.saturating_mul(cycles_to_next.min(u32::MAX as u128) as u32);
         self.cycle_start += advance;
         self.next_event = 0;
 
-        true
+        LateRecovery::NextCycle
     }
 
     fn track(&mut self, event: &MidiEvent) {
@@ -172,6 +192,13 @@ impl Playback {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LateRecovery {
+    None,
+    CycleBoundary,
+    NextCycle,
+}
+
 fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
     // Scheduling and deadline handling are shared by every native target. Some
     // platforms need a process-level hint to make timed waits precise enough;
@@ -194,7 +221,7 @@ fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
 
         let Some(command) = command else {
             for (_, playback) in playbacks {
-                cleanup_playback(&mut connection, &playback, true);
+                cleanup_playback(&mut connection, &playback);
             }
             break;
         };
@@ -207,7 +234,7 @@ fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
                 repeat,
             } => {
                 if let Some(previous) = playbacks.remove(&playback_id) {
-                    cleanup_playback(&mut connection, &previous, true);
+                    cleanup_playback(&mut connection, &previous);
                 }
                 tracing::debug!(
                     playback_id,
@@ -220,7 +247,7 @@ fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
             }
             MidiCommand::Stop { playback_id } => {
                 if let Some(playback) = playbacks.remove(&playback_id) {
-                    cleanup_playback(&mut connection, &playback, true);
+                    cleanup_playback(&mut connection, &playback);
                 }
             }
             MidiCommand::Send(event) => send_event(&mut connection, &event),
@@ -241,19 +268,10 @@ fn receive_until(rx: &Receiver<MidiCommand>, deadline: Instant) -> WorkerWake {
             return WorkerWake::Deadline;
         }
 
-        let remaining = deadline - now;
-        if remaining > DEADLINE_YIELD_WINDOW {
-            match rx.recv_timeout(remaining - DEADLINE_YIELD_WINDOW) {
-                Ok(command) => return WorkerWake::Command(command),
-                Err(RecvTimeoutError::Timeout) => continue,
-                Err(RecvTimeoutError::Disconnected) => return WorkerWake::Disconnected,
-            }
-        } else {
-            match rx.try_recv() {
-                Ok(command) => return WorkerWake::Command(command),
-                Err(TryRecvError::Empty) => thread::yield_now(),
-                Err(TryRecvError::Disconnected) => return WorkerWake::Disconnected,
-            }
+        match rx.recv_timeout(deadline - now) {
+            Ok(command) => return WorkerWake::Command(command),
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => return WorkerWake::Disconnected,
         }
     }
 }
@@ -274,19 +292,22 @@ fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BT
         };
 
         let playback = playbacks.get_mut(&playback_id).unwrap();
-        if playback.skip_missed_cycles(now) {
-            cleanup_playback(connection, playback, false);
-            tracing::debug!(
-                playback_id,
-                late_event_count = playback.late_event_count,
-                max_lateness_ms = playback.max_lateness.as_millis(),
-                "Skipped missed MIDI playback cycles"
-            );
-            playback.active_notes.clear();
-            playback.used_channels.clear();
-            playback.late_event_count = 0;
-            playback.max_lateness = Duration::ZERO;
-            continue;
+        match playback.recover_from_late_wakeup(now) {
+            LateRecovery::None | LateRecovery::CycleBoundary => {}
+            LateRecovery::NextCycle => {
+                cleanup_playback(connection, playback);
+                tracing::debug!(
+                    playback_id,
+                    late_event_count = playback.late_event_count,
+                    max_lateness_ms = playback.max_lateness.as_millis(),
+                    "Skipped to the next complete MIDI playback cycle"
+                );
+                playback.active_notes.clear();
+                playback.used_channels.clear();
+                playback.late_event_count = 0;
+                playback.max_lateness = Duration::ZERO;
+                continue;
+            }
         }
         if let Some((_deadline, event)) = playback.take_due_event(now) {
             send_event(connection, &event);
@@ -294,7 +315,7 @@ fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BT
             continue;
         }
 
-        cleanup_playback(connection, playback, !playback.repeat);
+        cleanup_playback(connection, playback);
         tracing::debug!(
             playback_id,
             late_event_count = playback.late_event_count,
@@ -307,13 +328,13 @@ fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BT
     }
 }
 
-fn cleanup_playback(connection: &mut MidiOutputConnection, playback: &Playback, full: bool) {
-    for event in cleanup_events(playback, full) {
+fn cleanup_playback(connection: &mut MidiOutputConnection, playback: &Playback) {
+    for event in cleanup_events(playback) {
         send_event(connection, &event);
     }
 }
 
-fn cleanup_events(playback: &Playback, full: bool) -> Vec<MidiEvent> {
+fn cleanup_events(playback: &Playback) -> Vec<MidiEvent> {
     let mut result = Vec::new();
     for (channel, note) in &playback.active_notes {
         result.push(MidiEvent::NoteOff {
@@ -329,18 +350,16 @@ fn cleanup_events(playback: &Playback, full: bool) -> Vec<MidiEvent> {
             control: 64,
             value: 0,
         });
-        if full {
-            result.push(MidiEvent::ControlChange {
-                channel: *channel,
-                control: 120,
-                value: 0,
-            });
-            result.push(MidiEvent::ControlChange {
-                channel: *channel,
-                control: 123,
-                value: 0,
-            });
-        }
+        result.push(MidiEvent::ControlChange {
+            channel: *channel,
+            control: 120,
+            value: 0,
+        });
+        result.push(MidiEvent::ControlChange {
+            channel: *channel,
+            control: 123,
+            value: 0,
+        });
     }
 
     result
@@ -423,6 +442,13 @@ mod tests {
         }
     }
 
+    fn program_change(at_ms: u64, program: u8) -> ScheduledMidiEvent {
+        ScheduledMidiEvent {
+            at_ms,
+            event: MidiEvent::ProgramChange { channel: 0, program },
+        }
+    }
+
     #[test]
     fn uses_absolute_event_deadlines() {
         let start = Instant::now();
@@ -442,26 +468,105 @@ mod tests {
     }
 
     #[test]
-    fn repeating_playback_skips_missed_cycles_without_drift() {
+    fn repeating_playback_waits_for_the_next_complete_cycle_without_drift() {
         let start = Instant::now();
         let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(30), true, start);
 
-        assert!(playback.skip_missed_cycles(start + Duration::from_millis(95)));
+        assert_eq!(
+            playback.recover_from_late_wakeup(start + Duration::from_millis(95)),
+            LateRecovery::NextCycle
+        );
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(120));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(125));
+    }
+
+    #[test]
+    fn repeating_playback_keeps_events_within_the_lateness_limit() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(1000), true, start);
+
+        assert_eq!(playback.recover_from_late_wakeup(start + Duration::from_millis(55)), LateRecovery::None);
+        assert_eq!(playback.cycle_start, start);
+    }
+
+    #[test]
+    fn repeating_playback_does_not_catch_up_previous_cycles() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(30), true, start);
+
+        assert_eq!(
+            playback.recover_from_late_wakeup(start + Duration::from_millis(80)),
+            LateRecovery::NextCycle
+        );
         assert_eq!(playback.cycle_start, start + Duration::from_millis(90));
         assert_eq!(playback.next_deadline(), start + Duration::from_millis(95));
+    }
+
+    #[test]
+    fn repeating_playback_keeps_an_event_at_the_cycle_boundary() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(30, 60)], Duration::from_millis(30), true, start);
+
         assert_eq!(
-            playback.take_due_event(start + Duration::from_millis(95)),
-            Some((start + Duration::from_millis(95), note_on(5, 60).event))
+            playback.recover_from_late_wakeup(start + Duration::from_millis(30)),
+            LateRecovery::CycleBoundary
+        );
+        assert_eq!(
+            playback.take_due_event(start + Duration::from_millis(30)),
+            Some((start + Duration::from_millis(30), note_on(30, 60).event))
         );
     }
 
     #[test]
-    fn repeating_playback_catches_up_small_lateness() {
+    fn repeating_playback_restarts_state_at_the_next_complete_cycle() {
         let start = Instant::now();
-        let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(30), true, start);
+        let mut playback = Playback::new(vec![program_change(0, 4), note_on(100, 62)], Duration::from_millis(1000), true, start);
 
-        assert!(!playback.skip_missed_cycles(start + Duration::from_millis(80)));
-        assert_eq!(playback.cycle_start, start);
+        assert_eq!(
+            playback.recover_from_late_wakeup(start + Duration::from_millis(80)),
+            LateRecovery::NextCycle
+        );
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(1000));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(1000));
+        assert_eq!(
+            playback.take_due_event(start + Duration::from_millis(1000)),
+            Some((start + Duration::from_millis(1000), program_change(0, 4).event))
+        );
+    }
+
+    #[test]
+    fn repeating_playback_keeps_only_boundary_events_from_the_previous_cycle() {
+        let start = Instant::now();
+        let mut playback = Playback::new(
+            vec![note_on(5, 60), note_on(10, 62), note_on(30, 64)],
+            Duration::from_millis(30),
+            true,
+            start,
+        );
+
+        assert_eq!(
+            playback.recover_from_late_wakeup(start + Duration::from_millis(60)),
+            LateRecovery::CycleBoundary
+        );
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(30));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(60));
+        assert_eq!(
+            playback.take_due_event(start + Duration::from_millis(60)),
+            Some((start + Duration::from_millis(60), note_on(30, 64).event))
+        );
+    }
+
+    #[test]
+    fn repeating_playback_starts_a_new_cycle_at_an_exact_boundary() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(5, 60), note_on(10, 62)], Duration::from_millis(30), true, start);
+
+        assert_eq!(
+            playback.recover_from_late_wakeup(start + Duration::from_millis(60)),
+            LateRecovery::NextCycle
+        );
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(60));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(65));
     }
 
     #[test]
@@ -490,7 +595,7 @@ mod tests {
         playback.track(&MidiEvent::ProgramChange { channel: 1, program: 4 });
 
         assert_eq!(
-            cleanup_events(&playback, true),
+            cleanup_events(&playback),
             vec![
                 MidiEvent::NoteOff {
                     channel: 0,

--- a/wie_cli/src/midi_worker.rs
+++ b/wie_cli/src/midi_worker.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender},
+    sync::{
+        Arc, Mutex,
+        mpsc::{self, Receiver, RecvTimeoutError, Sender},
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -10,12 +13,14 @@ use wie_backend::{MidiEvent, ScheduledMidiEvent};
 
 const MAX_EVENT_LATENESS: Duration = Duration::from_millis(50);
 
+pub type MidiConnection = Arc<Mutex<MidiOutputConnection>>;
+
 pub struct MidiWorker {
     tx: Sender<MidiCommand>,
 }
 
 impl MidiWorker {
-    pub fn new(connection: MidiOutputConnection) -> Option<Self> {
+    pub fn new(connection: MidiConnection) -> Option<Self> {
         let (tx, rx) = mpsc::channel();
         if let Err(error) = thread::Builder::new()
             .name("wie-midi".to_string())
@@ -39,12 +44,12 @@ impl MidiWorker {
             .is_ok()
     }
 
-    pub fn stop(&self, playback_id: u64) {
-        let _ = self.tx.send(MidiCommand::Stop { playback_id });
+    pub fn stop(&self, playback_id: u64) -> bool {
+        self.tx.send(MidiCommand::Stop { playback_id }).is_ok()
     }
 
-    pub fn send(&self, event: MidiEvent) {
-        let _ = self.tx.send(MidiCommand::Send(event));
+    pub fn send(&self, event: MidiEvent) -> bool {
+        self.tx.send(MidiCommand::Send(event)).is_ok()
     }
 }
 
@@ -161,13 +166,10 @@ impl Playback {
             }
         }
 
-        let cycles_to_next = completed_cycles + u128::from(cycle_remainder > 0);
-        let cycles_to_next = cycles_to_next.max(1);
-        let advance = self.duration.saturating_mul(cycles_to_next.min(u32::MAX as u128) as u32);
-        self.cycle_start += advance;
+        self.cycle_start = now;
         self.next_event = 0;
 
-        LateRecovery::NextCycle
+        LateRecovery::RestartCycle
     }
 
     fn track(&mut self, event: &MidiEvent) {
@@ -196,19 +198,25 @@ impl Playback {
 enum LateRecovery {
     None,
     CycleBoundary,
-    NextCycle,
+    RestartCycle,
 }
 
-fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
+fn run_worker(connection: MidiConnection, rx: Receiver<MidiCommand>) {
     // Scheduling and deadline handling are shared by every native target. Some
     // platforms need a process-level hint to make timed waits precise enough;
     // that optional hint must not affect playback semantics.
-    let _timer_precision = platform_timer::TimerPrecision::acquire();
     let mut playbacks = BTreeMap::new();
+    let mut timer_precision = None;
 
     loop {
         let now = Instant::now();
-        dispatch_due_events(&mut connection, &mut playbacks, now);
+        dispatch_due_events(&connection, &mut playbacks, now);
+
+        if playbacks.is_empty() {
+            timer_precision = None;
+        } else if timer_precision.is_none() {
+            timer_precision = Some(platform_timer::TimerPrecision::acquire());
+        }
 
         let command = match next_deadline(&playbacks) {
             Some(deadline) => match receive_until(&rx, deadline) {
@@ -221,7 +229,7 @@ fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
 
         let Some(command) = command else {
             for (_, playback) in playbacks {
-                cleanup_playback(&mut connection, &playback);
+                cleanup_playback(&connection, &playback);
             }
             break;
         };
@@ -234,7 +242,7 @@ fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
                 repeat,
             } => {
                 if let Some(previous) = playbacks.remove(&playback_id) {
-                    cleanup_playback(&mut connection, &previous);
+                    cleanup_playback(&connection, &previous);
                 }
                 tracing::debug!(
                     playback_id,
@@ -247,10 +255,10 @@ fn run_worker(mut connection: MidiOutputConnection, rx: Receiver<MidiCommand>) {
             }
             MidiCommand::Stop { playback_id } => {
                 if let Some(playback) = playbacks.remove(&playback_id) {
-                    cleanup_playback(&mut connection, &playback);
+                    cleanup_playback(&connection, &playback);
                 }
             }
-            MidiCommand::Send(event) => send_event(&mut connection, &event),
+            MidiCommand::Send(event) => send_event(&connection, &event),
         }
     }
 }
@@ -280,7 +288,7 @@ fn next_deadline(playbacks: &BTreeMap<u64, Playback>) -> Option<Instant> {
     playbacks.values().map(Playback::next_deadline).min()
 }
 
-fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BTreeMap<u64, Playback>, now: Instant) {
+fn dispatch_due_events(connection: &MidiConnection, playbacks: &mut BTreeMap<u64, Playback>, now: Instant) {
     loop {
         let next_playback_id = playbacks
             .iter()
@@ -294,13 +302,13 @@ fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BT
         let playback = playbacks.get_mut(&playback_id).unwrap();
         match playback.recover_from_late_wakeup(now) {
             LateRecovery::None | LateRecovery::CycleBoundary => {}
-            LateRecovery::NextCycle => {
+            LateRecovery::RestartCycle => {
                 cleanup_playback(connection, playback);
                 tracing::debug!(
                     playback_id,
                     late_event_count = playback.late_event_count,
                     max_lateness_ms = playback.max_lateness.as_millis(),
-                    "Skipped to the next complete MIDI playback cycle"
+                    "Restarted a late MIDI playback cycle"
                 );
                 playback.active_notes.clear();
                 playback.used_channels.clear();
@@ -328,7 +336,7 @@ fn dispatch_due_events(connection: &mut MidiOutputConnection, playbacks: &mut BT
     }
 }
 
-fn cleanup_playback(connection: &mut MidiOutputConnection, playback: &Playback) {
+fn cleanup_playback(connection: &MidiConnection, playback: &Playback) {
     for event in cleanup_events(playback) {
         send_event(connection, &event);
     }
@@ -365,19 +373,23 @@ fn cleanup_events(playback: &Playback) -> Vec<MidiEvent> {
     result
 }
 
-fn send_event(connection: &mut MidiOutputConnection, event: &MidiEvent) {
+pub fn send_event(connection: &MidiConnection, event: &MidiEvent) {
     match event {
         MidiEvent::NoteOn { channel, note, velocity } => send_bytes(connection, &[0x90 | channel, *note, *velocity]),
         MidiEvent::NoteOff { channel, note, velocity } => send_bytes(connection, &[0x80 | channel, *note, *velocity]),
-        MidiEvent::ProgramChange { channel, program } => send_bytes(connection, &[0xc0 | channel, *program]),
-        MidiEvent::ControlChange { channel, control, value } => send_bytes(connection, &[0xb0 | channel, *control, *value]),
-        MidiEvent::PitchBend { channel, value } => send_bytes(connection, &[0xe0 | channel, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8]),
+        MidiEvent::ProgramChange { channel, program } => send_bytes(connection, &[0xC0 | channel, *program]),
+        MidiEvent::ControlChange { channel, control, value } => send_bytes(connection, &[0xB0 | channel, *control, *value]),
+        MidiEvent::PitchBend { channel, value } => send_bytes(connection, &[0xE0 | channel, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8]),
         MidiEvent::SysEx(data) => send_bytes(connection, data),
     }
 }
 
-fn send_bytes(connection: &mut MidiOutputConnection, data: &[u8]) {
-    if let Err(error) = connection.send(data) {
+fn send_bytes(connection: &MidiConnection, data: &[u8]) {
+    let result = match connection.lock() {
+        Ok(mut connection) => connection.send(data),
+        Err(poisoned) => poisoned.into_inner().send(data),
+    };
+    if let Err(error) = result {
         tracing::warn!(%error, "Failed to send MIDI message");
     }
 }
@@ -468,16 +480,16 @@ mod tests {
     }
 
     #[test]
-    fn repeating_playback_waits_for_the_next_complete_cycle_without_drift() {
+    fn repeating_playback_restarts_a_late_cycle_without_drift() {
         let start = Instant::now();
         let mut playback = Playback::new(vec![note_on(5, 60)], Duration::from_millis(30), true, start);
 
         assert_eq!(
             playback.recover_from_late_wakeup(start + Duration::from_millis(95)),
-            LateRecovery::NextCycle
+            LateRecovery::RestartCycle
         );
-        assert_eq!(playback.cycle_start, start + Duration::from_millis(120));
-        assert_eq!(playback.next_deadline(), start + Duration::from_millis(125));
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(95));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(100));
     }
 
     #[test]
@@ -496,10 +508,10 @@ mod tests {
 
         assert_eq!(
             playback.recover_from_late_wakeup(start + Duration::from_millis(80)),
-            LateRecovery::NextCycle
+            LateRecovery::RestartCycle
         );
-        assert_eq!(playback.cycle_start, start + Duration::from_millis(90));
-        assert_eq!(playback.next_deadline(), start + Duration::from_millis(95));
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(80));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(85));
     }
 
     #[test]
@@ -518,19 +530,19 @@ mod tests {
     }
 
     #[test]
-    fn repeating_playback_restarts_state_at_the_next_complete_cycle() {
+    fn repeating_playback_restarts_state_immediately_after_a_late_wakeup() {
         let start = Instant::now();
-        let mut playback = Playback::new(vec![program_change(0, 4), note_on(100, 62)], Duration::from_millis(1000), true, start);
+        let mut playback = Playback::new(vec![program_change(0, 4), note_on(100, 62)], Duration::from_secs(180), true, start);
 
         assert_eq!(
-            playback.recover_from_late_wakeup(start + Duration::from_millis(80)),
-            LateRecovery::NextCycle
+            playback.recover_from_late_wakeup(start + Duration::from_millis(51)),
+            LateRecovery::RestartCycle
         );
-        assert_eq!(playback.cycle_start, start + Duration::from_millis(1000));
-        assert_eq!(playback.next_deadline(), start + Duration::from_millis(1000));
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(51));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(51));
         assert_eq!(
-            playback.take_due_event(start + Duration::from_millis(1000)),
-            Some((start + Duration::from_millis(1000), program_change(0, 4).event))
+            playback.take_due_event(start + Duration::from_millis(51)),
+            Some((start + Duration::from_millis(51), program_change(0, 4).event))
         );
     }
 
@@ -563,7 +575,7 @@ mod tests {
 
         assert_eq!(
             playback.recover_from_late_wakeup(start + Duration::from_millis(60)),
-            LateRecovery::NextCycle
+            LateRecovery::RestartCycle
         );
         assert_eq!(playback.cycle_start, start + Duration::from_millis(60));
         assert_eq!(playback.next_deadline(), start + Duration::from_millis(65));
@@ -580,6 +592,17 @@ mod tests {
         assert!(!playback.finish_cycle(late_wakeup));
         assert_eq!(playback.cycle_start, start + Duration::from_millis(30));
         assert_eq!(playback.next_deadline(), start + Duration::from_millis(30));
+    }
+
+    #[test]
+    fn disconnected_worker_reports_fallback_for_all_commands() {
+        let (tx, rx) = mpsc::channel();
+        drop(rx);
+        let worker = MidiWorker { tx };
+
+        assert!(!worker.send(note_on(0, 60).event));
+        assert!(!worker.schedule(1, &[note_on(0, 60)], 30, false));
+        assert!(!worker.stop(1));
     }
 
     #[test]

--- a/wie_cli/src/midi_worker.rs
+++ b/wie_cli/src/midi_worker.rs
@@ -136,7 +136,7 @@ impl Playback {
     }
 
     fn recover_from_late_wakeup(&mut self, now: Instant) -> LateRecovery {
-        if !self.repeat || self.duration.is_zero() {
+        if !self.repeat || self.duration.is_zero() || self.next_event >= self.events.len() {
             return LateRecovery::None;
         }
 
@@ -567,6 +567,19 @@ mod tests {
         );
         assert_eq!(playback.cycle_start, start + Duration::from_millis(60));
         assert_eq!(playback.next_deadline(), start + Duration::from_millis(65));
+    }
+
+    #[test]
+    fn repeating_playback_finishes_normally_after_a_late_cycle_end_wakeup() {
+        let start = Instant::now();
+        let mut playback = Playback::new(vec![note_on(0, 60)], Duration::from_millis(30), true, start);
+
+        assert_eq!(playback.take_due_event(start), Some((start, note_on(0, 60).event)));
+        let late_wakeup = start + Duration::from_millis(31);
+        assert_eq!(playback.recover_from_late_wakeup(late_wakeup), LateRecovery::None);
+        assert!(!playback.finish_cycle(late_wakeup));
+        assert_eq!(playback.cycle_start, start + Duration::from_millis(30));
+        assert_eq!(playback.next_deadline(), start + Duration::from_millis(30));
     }
 
     #[test]

--- a/wie_midp/src/classes/javax/microedition/lcdui/canvas.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/canvas.rs
@@ -83,7 +83,7 @@ impl Canvas {
     }
 
     async fn service_repaints(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
-        tracing::debug!("stub javax.microedition.lcdui.Canvas::serviceRepaints({this:?})");
+        tracing::warn!("stub javax.microedition.lcdui.Canvas::serviceRepaints({this:?})");
 
         jvm.invoke_virtual(&this, "repaint", "(IIII)V", (0, 0, 0, 0)).await
     }

--- a/wie_midp/src/classes/javax/microedition/lcdui/canvas.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/canvas.rs
@@ -83,7 +83,7 @@ impl Canvas {
     }
 
     async fn service_repaints(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Canvas::serviceRepaints({this:?})");
+        tracing::debug!("stub javax.microedition.lcdui.Canvas::serviceRepaints({this:?})");
 
         jvm.invoke_virtual(&this, "repaint", "(IIII)V", (0, 0, 0, 0)).await
     }


### PR DESCRIPTION
## 문제

CLI에서의 MIDI 이벤트가 에뮬레이터의 cooperative tick에서 처리되어, 프레임 처리 상황에 따라 발음 간격이 흔들리고 BGM 반복 사이에 긴 공백이 발생할 수 있었습니다.

## 원인

게임 루프의 실행 주기는 MIDI 이벤트의 짧은 간격을 안정적으로 보장하지 못합니다. 또한 늦게 깨어난 반복 재생을 다음 주기까지 미루면서 긴 곡에서는 불필요하게 오랫동안 재생이 중단될 수 있었습니다.

## 대응

- 네이티브 CLI에서 MIDI 시퀀스를 전용 워커가 절대 시각 기준으로 재생하도록 변경했습니다.
- 반복 경계 이벤트를 보존하고, 정상적으로 완료된 루프가 지연 복구 대상으로 처리되지 않도록 했습니다.
- 허용 범위를 초과해 늦어진 경우 다음 주기를 기다리지 않고 현재 시점부터 시퀀스를 다시 시작합니다.
- 워커 생성 또는 통신 실패 시 기존 MIDI 연결로 직접 전송하는 fallback을 유지합니다.
- Windows의 타이머 정밀도 조정은 예약 재생 중에만 사용하며, 스케줄링 동작 자체는 모든 네이티브 플랫폼에서 공통으로 유지합니다.
- WASM은 기존 Web MIDI 경로를 그대로 사용합니다.

전용 워커를 사용한 이유는 에뮬레이터 tick 주기와 MIDI 타이밍을 분리하기 위해서입니다. 플랫폼별 타이머 API는 선택적인 정밀도 보조 수단으로만 두어 공통 동작이 특정 OS에 의존하지 않도록 했습니다.

## 검증

- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --target wasm32-unknown-unknown -- -D warnings`
- `cargo test --workspace`
- CLI 환경에서 끊김 완화 및 즉시 반복 재생을 청감 확인