### PR TITLE
Add Tauri release workflows

### DIFF
--- a/.github/scripts/release-tauri/publish.sh
+++ b/.github/scripts/release-tauri/publish.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo="repos/$GITHUB_REPOSITORY"
+
+warning_body() {
+  cat <<EOF
+## Unsigned artifacts
+
+- The Windows, Linux, macOS, Android, and iOS artifacts are unsigned.
+- The macOS artifacts are not notarized.
+- Android AAB files cannot be installed directly on a device.
+- The iOS \`.xcarchive.zip\` is not an IPA for device installation, TestFlight, or App Store submission.
+EOF
+}
+
+if [[ "$CHANNEL" == stable ]]; then
+  tag=${GITHUB_REF#refs/tags/}
+  if release=$(gh api "$repo/releases/tags/$tag" 2>/dev/null); then
+    release_id=$(jq -r '.id' <<< "$release")
+  else
+    initial_body=$(warning_body)
+    release=$(gh api --method POST "$repo/releases" -f tag_name="$tag" -f target_commitish="$TARGET_SHA" -f name="$tag" -f body="$initial_body" -F draft=true -F prerelease=false)
+    release_id=$(jq -r '.id' <<< "$release")
+  fi
+
+  gh release upload "$tag" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+
+  notes=$(gh api --method POST "$repo/releases/generate-notes" -f tag_name="$tag" -f target_commitish="$TARGET_SHA" --jq '.body')
+  body="$(warning_body)
+
+## Changes
+
+$notes"
+  gh api --method PATCH "$repo/releases/$release_id" -f name="$tag" -f body="$body" -F draft=false -F prerelease=false >/dev/null
+else
+  if [[ $(gh api "$repo/git/ref/heads/main" --jq '.object.sha') != "$TARGET_SHA" ]]; then
+    echo "Skipping stale nightly before any release mutation"
+    exit 0
+  fi
+
+  if release=$(gh api "$repo/releases/tags/nightly" 2>/dev/null); then
+    release_id=$(jq -r '.id' <<< "$release")
+  else
+    initial_body=$(warning_body)
+    release=$(gh api --method POST "$repo/releases" -f tag_name=nightly -f target_commitish="$TARGET_SHA" -f name=nightly -f body="$initial_body" -F draft=true -F prerelease=true)
+    release_id=$(jq -r '.id' <<< "$release")
+  fi
+
+  gh release upload nightly release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+
+  if gh api "$repo/git/ref/tags/nightly" >/dev/null 2>&1; then
+    gh api --method PATCH "$repo/git/refs/tags/nightly" -f sha="$TARGET_SHA" -F force=true >/dev/null
+  else
+    gh api --method POST "$repo/git/refs" -f ref=refs/tags/nightly -f sha="$TARGET_SHA" >/dev/null
+  fi
+  body="$(warning_body)
+
+## Nightly
+
+- Target SHA: \`$TARGET_SHA\`
+- Workflow run: \`$RUN_NUMBER\`"
+  gh api --method PATCH "$repo/releases/$release_id" -f name=nightly -f body="$body" -F draft=false -F prerelease=true >/dev/null
+fi

--- a/.github/scripts/release-tauri/resolve-context.sh
+++ b/.github/scripts/release-tauri/resolve-context.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+target_sha=$(git rev-parse 'HEAD^{commit}')
+
+if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+  channel=nightly
+  base_version=$(jq -r '.version' wie_app/tauri.conf.json)
+  app_version="${base_version}-nightly-${target_sha:0:12}"
+  asset_identity=nightly
+elif [[ "$GITHUB_REF" =~ ^refs/tags/(v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$ ]]; then
+  channel=stable
+  tag=${BASH_REMATCH[1]}
+  app_version=${tag#v}
+  asset_identity=$tag
+else
+  echo "Unsupported release ref: $GITHUB_REF" >&2
+  exit 1
+fi
+
+{
+  echo "asset_identity=$asset_identity"
+  echo "channel=$channel"
+  echo "run_number=$GITHUB_RUN_NUMBER"
+  echo "target_sha=$target_sha"
+  echo "app_version=$app_version"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -3,14 +3,13 @@ on:
   push:
     branches:
       - main
-      - release
+    tags:
+      - 'v*'
 
 name: Deploy Web
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +17,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.repository == 'dlunch/wie'
+    if: github.repository == 'dlunch/wie' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,11 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           submodules: "recursive"
-
-      - name: Install packages
-        run: |
-          sudo apt-get update;sudo apt-get install -y --no-install-recommends build-essential zstd
 
       - name: Restore cache cargo
         uses: actions/cache/restore@v6
@@ -70,20 +66,29 @@ jobs:
       - name: npm install
         run: npm ci
 
-      - name: Build
-        if: github.ref == 'refs/heads/release'
-        run: npm run build:prod
-
-      - name: Build
+      - name: Build development site
         if: github.ref == 'refs/heads/main'
         run: npm run build:dev
 
-      - name: Publish to Cloudflare Pages
+      - name: Build production site
+        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+        run: npm run build:prod
+
+      - name: Publish development site to Cloudflare Pages
+        if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./wie_web/dist --project-name=${{ fromJSON('["wie-dev", "wie"]')[ github.ref != 'refs/heads/main' ] }} --branch=main
+          command: pages deploy ./wie_web/dist --project-name=wie-dev --branch=main
+
+      - name: Publish production site to Cloudflare Pages
+        if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./wie_web/dist --project-name=wie --branch=main
 
       - name: Save cache cargo
         uses: actions/cache/save@v6

--- a/.github/workflows/release-tauri.yaml
+++ b/.github/workflows/release-tauri.yaml
@@ -1,0 +1,384 @@
+name: Release Tauri
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
+
+permissions:
+  contents: read
+
+jobs:
+  context:
+    name: Resolve release context
+    runs-on: ubuntu-latest
+    outputs:
+      asset_identity: ${{ steps.context.outputs.asset_identity }}
+      channel: ${{ steps.context.outputs.channel }}
+      run_number: ${{ steps.context.outputs.run_number }}
+      target_sha: ${{ steps.context.outputs.target_sha }}
+      app_version: ${{ steps.context.outputs.app_version }}
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Resolve channel and version
+        id: context
+        run: bash .github/scripts/release-tauri/resolve-context.sh
+
+  web:
+    name: Web frontend
+    needs: context
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          cache: npm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build production frontend
+        run: |
+          npm ci
+          npm run build:prod
+
+      - name: Upload web frontend
+        uses: actions/upload-artifact@v6
+        with:
+          name: tauri-web
+          path: wie_web/dist
+          if-no-files-found: error
+
+  windows:
+    name: Windows x64
+    needs:
+      - context
+      - web
+    runs-on: windows-latest
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Download web frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: tauri-web
+          path: wie_web/dist
+
+      - name: Build unsigned installers
+        uses: tauri-apps/tauri-action@v1
+        with:
+          projectPath: wie_app
+          args: >-
+            --config '{"version":"${{ needs.context.outputs.app_version }}","build":{"beforeBuildCommand":""}}'
+            --ci --target x86_64-pc-windows-msvc --bundles msi,nsis --no-sign
+
+      - name: Package installers
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force dist | Out-Null
+          Copy-Item (Get-ChildItem target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi | Select-Object -First 1) "dist/wie-${{ needs.context.outputs.asset_identity }}-windows-x86_64-unsigned.msi"
+          Copy-Item (Get-ChildItem target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe | Select-Object -First 1) "dist/wie-${{ needs.context.outputs.asset_identity }}-windows-x86_64-unsigned-setup.exe"
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-windows
+          path: dist/*
+          if-no-files-found: error
+
+  linux:
+    name: Linux x64
+    needs:
+      - context
+      - web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libasound2-dev libayatana-appindicator3-dev librsvg2-dev libwebkit2gtk-4.1-dev patchelf
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Download web frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: tauri-web
+          path: wie_web/dist
+
+      - name: Build unsigned packages
+        uses: tauri-apps/tauri-action@v1
+        with:
+          projectPath: wie_app
+          args: >-
+            --config '{"version":"${{ needs.context.outputs.app_version }}","build":{"beforeBuildCommand":""}}'
+            --ci --target x86_64-unknown-linux-gnu --bundles appimage,deb --no-sign
+
+      - name: Package bundles
+        run: |
+          mkdir -p dist
+          cp target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage "dist/wie-${{ needs.context.outputs.asset_identity }}-linux-x86_64-unsigned.AppImage"
+          cp target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb "dist/wie-${{ needs.context.outputs.asset_identity }}-linux-x86_64-unsigned.deb"
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-linux
+          path: dist/*
+          if-no-files-found: error
+
+  macos:
+    name: macOS universal
+    needs:
+      - context
+      - web
+    runs-on: macos-latest
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Download web frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: tauri-web
+          path: wie_web/dist
+
+      - name: Build unsigned universal bundles
+        uses: tauri-apps/tauri-action@v1
+        with:
+          projectPath: wie_app
+          args: >-
+            --config '{"version":"${{ needs.context.outputs.app_version }}","build":{"beforeBuildCommand":""}}'
+            --ci --target universal-apple-darwin --bundles app,dmg --no-sign
+
+      - name: Package bundles
+        run: |
+          mkdir -p dist
+          ditto -c -k --keepParent target/universal-apple-darwin/release/bundle/macos/*.app "dist/wie-${{ needs.context.outputs.asset_identity }}-macos-universal-unsigned.app.zip"
+          cp target/universal-apple-darwin/release/bundle/dmg/*.dmg "dist/wie-${{ needs.context.outputs.asset_identity }}-macos-universal-unsigned.dmg"
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-macos
+          path: dist/*
+          if-no-files-found: error
+
+  android:
+    name: Android aarch64
+    needs:
+      - context
+      - web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Select preinstalled Android NDK
+        shell: bash
+        run: |
+          ndk_home=${ANDROID_NDK_LATEST_HOME:-$(find "$ANDROID_HOME/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)}
+          echo "ANDROID_NDK_HOME=$ndk_home" >> "$GITHUB_ENV"
+          echo "NDK_HOME=$ndk_home" >> "$GITHUB_ENV"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - name: Download web frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: tauri-web
+          path: wie_web/dist
+
+      - name: Install Tauri CLI
+        uses: taiki-e/install-action@v2
+        with:
+          tool: tauri-cli
+
+      - name: Initialize Android project
+        working-directory: wie_app
+        run: cargo tauri android init --config '{"version":"${{ needs.context.outputs.app_version }}"}' --ci
+
+      - name: Build unsigned Android packages
+        uses: tauri-apps/tauri-action@v1
+        with:
+          tauriScript: cargo tauri
+          projectPath: wie_app
+          mobile: android
+          args: >-
+            --config '{"version":"${{ needs.context.outputs.app_version }}","build":{"beforeBuildCommand":""}}'
+            --target aarch64 --apk --aab --ci
+
+      - name: Package Android bundles
+        run: |
+          mkdir -p dist
+          cp "$(find wie_app/gen/android/app/build/outputs/apk -type f -name '*-release-unsigned.apk' -print -quit)" "dist/wie-${{ needs.context.outputs.asset_identity }}-android-aarch64-unsigned.apk"
+          cp "$(find wie_app/gen/android/app/build/outputs/bundle -type f -name '*-release.aab' -print -quit)" "dist/wie-${{ needs.context.outputs.asset_identity }}-android-aarch64-unsigned.aab"
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-android
+          path: dist/*
+          if-no-files-found: error
+
+  ios:
+    name: iOS aarch64
+    needs:
+      - context
+      - web
+    runs-on: macos-latest
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios
+
+      - name: Download web frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: tauri-web
+          path: wie_web/dist
+
+      - name: Install iOS build dependencies
+        run: arch -arm64 brew reinstall xcodegen libimobiledevice
+
+      - name: Install Tauri CLI
+        uses: taiki-e/install-action@v2
+        with:
+          tool: tauri-cli
+
+      - name: Initialize iOS project
+        working-directory: wie_app
+        run: cargo tauri ios init --config '{"version":"${{ needs.context.outputs.app_version }}"}' --ci
+
+      - name: Build unsigned iOS archive
+        uses: tauri-apps/tauri-action@v1
+        with:
+          tauriScript: cargo tauri
+          projectPath: wie_app
+          mobile: ios
+          args: >-
+            --config '{"version":"${{ needs.context.outputs.app_version }}","build":{"beforeBuildCommand":""}}'
+            --target aarch64 --no-sign --archive-only
+            --build-number ${{ needs.context.outputs.run_number }} --ci
+
+      - name: Package iOS archive
+        run: |
+          mkdir -p dist
+          archive=$(find target wie_app/gen -type d -name '*.xcarchive' -print -quit)
+          ditto -c -k --keepParent "$archive" "dist/wie-${{ needs.context.outputs.asset_identity }}-ios-aarch64-unsigned.xcarchive.zip"
+
+      - name: Upload iOS artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-ios
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs:
+      - context
+      - windows
+      - linux
+      - macos
+      - android
+      - ios
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: tauri-release-publisher-${{ github.repository }}
+      cancel-in-progress: false
+    env:
+      CHANNEL: ${{ needs.context.outputs.channel }}
+      GH_TOKEN: ${{ github.token }}
+      RUN_NUMBER: ${{ needs.context.outputs.run_number }}
+      TARGET_SHA: ${{ needs.context.outputs.target_sha }}
+    steps:
+      - name: Checkout release scripts
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.context.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: release-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish release
+        run: bash .github/scripts/release-tauri/publish.sh


### PR DESCRIPTION
## Summary
- build unsigned Tauri artifacts for Windows, Linux, macOS, Android, and iOS
- update the fixed nightly prerelease on main pushes and create stable releases from `vMAJOR.MINOR.PATCH` tags
- generate stable release notes automatically
- deploy Cloudflare production from version tags instead of the release branch

## Implementation
- build the optimized production WASM frontend once and share it with every platform job
- use `tauri-apps/tauri-action@v1` on the latest GitHub runner images
- use Java 21 for Android and the runner-provided Node.js versions
- derive stable app versions from tags and nightly versions as `<base>-nightly-<short-sha>`
- merge Actions artifacts directly before publishing, with fixed asset names replaced via `--clobber`
- keep release context resolution and GitHub release publication in two focused scripts

## Validation
- `actionlint 1.7.12`
- shell syntax and release context checks for main, stable, and rejected refs
- `cargo fmt`
- `cargo clippy --workspace`

The platform artifacts are intentionally unsigned. macOS artifacts are not notarized, and iOS publishes an xcarchive zip rather than an IPA.