### PR TITLE
Preserve LGT AOT static references during GC

### DIFF
--- a/wie_core_arm/src/allocator.rs
+++ b/wie_core_arm/src/allocator.rs
@@ -40,4 +40,38 @@ impl Allocator {
             BucketAllocator::free(core, HEAP_BASE + HEAP_SIZE / 2, address, size)
         }
     }
+
+    pub fn is_allocated(core: &ArmCore, address: u32, size: u32) -> Result<bool> {
+        if size > BUCKET_MAX as _ {
+            ListAllocator::is_allocated(core, HEAP_BASE, HEAP_SIZE / 2, address, size)
+        } else {
+            BucketAllocator::is_allocated(core, HEAP_BASE + HEAP_SIZE / 2, address, size)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wie_util::Result;
+
+    use crate::{Allocator, ArmCore};
+
+    #[test]
+    fn allocation_status_tracks_bucket_and_list_allocations() -> Result<()> {
+        let mut core = ArmCore::new(false, None)?;
+        Allocator::init(&mut core)?;
+
+        let bucket = Allocator::alloc(&mut core, 12)?;
+        let list = Allocator::alloc(&mut core, 1024)?;
+        assert!(Allocator::is_allocated(&core, bucket, 12)?);
+        assert!(Allocator::is_allocated(&core, list, 1024)?);
+        assert!(!Allocator::is_allocated(&core, bucket + 4, 12)?);
+
+        Allocator::free(&mut core, bucket, 12)?;
+        Allocator::free(&mut core, list, 1024)?;
+        assert!(!Allocator::is_allocated(&core, bucket, 12)?);
+        assert!(!Allocator::is_allocated(&core, list, 1024)?);
+
+        Ok(())
+    }
 }

--- a/wie_core_arm/src/allocator/bucket.rs
+++ b/wie_core_arm/src/allocator/bucket.rs
@@ -116,6 +116,28 @@ impl BucketAllocator {
         Ok(())
     }
 
+    pub fn is_allocated(core: &ArmCore, base_address: u32, address: u32, size: u32) -> Result<bool> {
+        let bucket_index = Self::find_bucket_index(size);
+        let (slot_size, slot_count) = BUCKETS[bucket_index];
+        let header_address = base_address + region_offset(bucket_index) as u32;
+        let header_len = header_length(bucket_index) as u32;
+        let Some(offset) = address.checked_sub(header_address + header_len) else {
+            return Ok(false);
+        };
+        if offset % slot_size as u32 != 0 {
+            return Ok(false);
+        }
+
+        let slot = offset / slot_size as u32;
+        if slot >= slot_count as u32 {
+            return Ok(false);
+        }
+
+        let mut header = [0u8; 1];
+        core.read_bytes(header_address + slot / 8, &mut header)?;
+        Ok(header[0] & (1 << (slot % 8)) == 0)
+    }
+
     fn find_bucket_index(size: u32) -> usize {
         BUCKETS.iter().position(|&(s, _)| size as usize <= s).unwrap_or(BUCKETS.len() - 1)
     }

--- a/wie_core_arm/src/allocator/list.rs
+++ b/wie_core_arm/src/allocator/list.rs
@@ -90,6 +90,19 @@ impl ListAllocator {
         Ok(())
     }
 
+    pub fn is_allocated(core: &ArmCore, base_address: u32, base_size: u32, address: u32, size: u32) -> Result<bool> {
+        let Some(header_address) = address.checked_sub(size_of::<ListAllocationHeader>() as u32) else {
+            return Ok(false);
+        };
+        if header_address < base_address || header_address >= base_address + base_size {
+            return Ok(false);
+        }
+
+        let header: ListAllocationHeader = read_generic(core, header_address)?;
+        let allocation_size = (size as usize + size_of::<ListAllocationHeader>()).next_multiple_of(4) as u32 + CANARY_SIZE;
+        Ok(header.in_use() && header.size() == allocation_size)
+    }
+
     fn find_address(core: &mut ArmCore, base_address: u32, base_size: u32, size: u32) -> Result<u32> {
         let end = base_address + base_size;
         let mut cursor = base_address;

--- a/wie_lgt/src/runtime/java/jvm_support.rs
+++ b/wie_lgt/src/runtime/java/jvm_support.rs
@@ -28,7 +28,7 @@ use self::{
     array_class_instance::JavaArrayClassInstance,
     class_definition::JavaClassDefinition,
     class_instance::JavaClassInstance,
-    field::{JavaField, JavaReferenceField},
+    field::{JavaField, JavaReferenceField, JavaStaticReferenceField},
     method::JavaMethod,
     value::JavaValueCodec,
     vtable::JavaVtableEntry,

--- a/wie_lgt/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/class_definition.rs
@@ -26,7 +26,7 @@ use crate::runtime::{
 };
 
 use super::{
-    JavaClassInstance, JavaField, JavaMethod, JavaReferenceField, LgtJvmWord,
+    JavaClassInstance, JavaField, JavaMethod, JavaReferenceField, JavaStaticReferenceField, LgtJvmWord,
     value::JavaValueCodec,
     vtable::{JavaVtable, JavaVtableEntry},
 };
@@ -861,15 +861,50 @@ impl ClassDefinition for JavaClassDefinition {
                 }
             }
         }
+
+        // AOT descriptors have no static reference bitmap. Expose words that
+        // resolve through an intact instance, dispatch table, and class chain.
+        for word_index in 0..descriptor.static_field_word_count {
+            let ptr_instance: u32 = read_generic(
+                &self.core,
+                self.ptr_static_fields().unwrap() + word_index * size_of::<LgtJvmWord>() as u32,
+            )
+            .unwrap();
+            if ptr_instance == 0 {
+                continue;
+            }
+
+            let Ok(instance): Result<RawJavaClassInstance> = read_generic(&self.core, ptr_instance) else {
+                continue;
+            };
+            let Ok(ptr_class): Result<u32> = read_generic(&self.core, instance.ptr_dispatch_table) else {
+                continue;
+            };
+            let Ok(class): Result<RawJavaClass> = read_generic(&self.core, ptr_class) else {
+                continue;
+            };
+            if class.unk1 == instance.ptr_dispatch_table {
+                fields.push(Box::new(JavaStaticReferenceField { word_index }));
+            }
+        }
         fields
     }
 
     fn get_static_field(&self, field: &dyn Field) -> JvmResult<JavaValue> {
-        let field = field.as_any().downcast_ref::<JavaField>().unwrap();
-        let field_type = JavaType::parse(&field.descriptor());
-        let raw_field = field.raw().unwrap();
-        let declaring_class = Self::from_raw(raw_field.ptr_class, &self.core);
-        let address = declaring_class.ptr_static_fields().unwrap() + raw_field.word_index * size_of::<LgtJvmWord>() as u32;
+        let (address, field_type) = if let Some(field) = field.as_any().downcast_ref::<JavaField>() {
+            let raw_field = field.raw().unwrap();
+            let declaring_class = Self::from_raw(raw_field.ptr_class, &self.core);
+            (
+                declaring_class.ptr_static_fields().unwrap() + raw_field.word_index * size_of::<LgtJvmWord>() as u32,
+                JavaType::parse(&field.descriptor()),
+            )
+        } else {
+            let field = field.as_any().downcast_ref::<JavaStaticReferenceField>().unwrap();
+            (
+                self.ptr_static_fields().unwrap() + field.word_index * size_of::<LgtJvmWord>() as u32,
+                JavaType::parse(&field.descriptor()),
+            )
+        };
         let low = read_generic(&self.core, address).unwrap();
         let codec = JavaValueCodec::new(&self.core);
         Ok(if matches!(field_type, JavaType::Long | JavaType::Double) {

--- a/wie_lgt/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/class_definition.rs
@@ -862,8 +862,8 @@ impl ClassDefinition for JavaClassDefinition {
             }
         }
 
-        // AOT descriptors have no static reference bitmap. Expose words that
-        // resolve through an intact instance, dispatch table, and class chain.
+        // LGT AOT static storage is untyped, so conservatively retain words that
+        // point to allocated instances with an intact object-header chain.
         for word_index in 0..descriptor.static_field_word_count {
             let ptr_instance: u32 = read_generic(
                 &self.core,
@@ -871,6 +871,9 @@ impl ClassDefinition for JavaClassDefinition {
             )
             .unwrap();
             if ptr_instance == 0 {
+                continue;
+            }
+            if !Allocator::is_allocated(&self.core, ptr_instance, size_of::<RawJavaClassInstance>() as u32).unwrap() {
                 continue;
             }
 

--- a/wie_lgt/src/runtime/java/jvm_support/field.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/field.rs
@@ -97,3 +97,22 @@ impl Field for JavaReferenceField {
         FieldAccessFlags::empty()
     }
 }
+
+#[derive(Debug)]
+pub struct JavaStaticReferenceField {
+    pub word_index: u32,
+}
+
+impl Field for JavaStaticReferenceField {
+    fn name(&self) -> String {
+        format!("<static-reference-word-{}>", self.word_index)
+    }
+
+    fn descriptor(&self) -> String {
+        "Ljava/lang/Object;".into()
+    }
+
+    fn access_flags(&self) -> FieldAccessFlags {
+        FieldAccessFlags::STATIC
+    }
+}


### PR DESCRIPTION
## Summary
- expose live object references held in LGT AOT static storage through the existing JVM field metadata path
- validate candidates using guest-backed instance, dispatch-table, and class records
- preserve existing instance bitmap handling without RustJava hooks or host-side state

## Validation
- `cargo test -p wie_lgt`
- `cargo clippy --workspace`