### PR TITLE
Move audio playback to platform workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6294,7 +6294,6 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "js-sys",
- "rodio",
  "time",
  "tracing",
  "tracing-subscriber",

--- a/test_utils/src/platform.rs
+++ b/test_utils/src/platform.rs
@@ -182,33 +182,7 @@ impl Database for MemoryDatabase {
 pub struct TestAudioSink;
 
 impl AudioSink for TestAudioSink {
-    fn play_wave(&self, _channel: u8, _sampling_rate: u32, _wave_data: &[i16]) {
-        todo!()
-    }
-
-    fn midi_note_on(&self, _channel_id: u8, _note: u8, _velocity: u8) {
-        todo!()
-    }
-
-    fn midi_note_off(&self, _channel_id: u8, _note: u8, _velocity: u8) {
-        todo!()
-    }
-
-    fn midi_program_change(&self, _channel_id: u8, _program: u8) {
-        todo!()
-    }
-
-    fn midi_control_change(&self, _channel_id: u8, _control: u8, _value: u8) {
-        todo!()
-    }
-
-    fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {
-        todo!()
-    }
-
-    fn midi_sysex(&self, _data: &[u8]) {
-        todo!()
-    }
+    fn send(&self, _command: wie_backend::AudioCommand) {}
 }
 
 pub struct TestScreen {

--- a/wie_backend/src/audio_sink.rs
+++ b/wie_backend/src/audio_sink.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 
 pub type AudioHandle = u32;
 
@@ -6,7 +6,7 @@ pub type AudioHandle = u32;
 pub enum AudioCommand {
     Play {
         handle: AudioHandle,
-        sequence: AudioSequence,
+        sequence: Arc<AudioSequence>,
         repeat: bool,
     },
     Stop {

--- a/wie_backend/src/audio_sink.rs
+++ b/wie_backend/src/audio_sink.rs
@@ -1,9 +1,37 @@
+use alloc::vec::Vec;
+
+pub type AudioHandle = u32;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum AudioCommand {
+    Play {
+        handle: AudioHandle,
+        sequence: AudioSequence,
+        repeat: bool,
+    },
+    Stop {
+        handle: AudioHandle,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AudioSequence {
+    pub duration: u64,
+    pub events: Vec<TimedAudioEvent>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TimedAudioEvent {
+    pub time: u64,
+    pub data: AudioEventData,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum AudioEventData {
+    Midi(Vec<u8>),
+    Wave { channels: u8, sampling_rate: u32, samples: Vec<i16> },
+}
+
 pub trait AudioSink: Sync + Send {
-    fn play_wave(&self, channel: u8, sampling_rate: u32, wave_data: &[i16]);
-    fn midi_note_on(&self, channel_id: u8, note: u8, velocity: u8);
-    fn midi_note_off(&self, channel_id: u8, note: u8, velocity: u8);
-    fn midi_program_change(&self, channel_id: u8, program: u8);
-    fn midi_control_change(&self, channel_id: u8, control: u8, value: u8);
-    fn midi_pitch_bend(&self, channel_id: u8, value: u16);
-    fn midi_sysex(&self, data: &[u8]);
+    fn send(&self, command: AudioCommand);
 }

--- a/wie_backend/src/lib.rs
+++ b/wie_backend/src/lib.rs
@@ -13,7 +13,7 @@ mod task_runner;
 mod time;
 
 pub use self::{
-    audio_sink::AudioSink,
+    audio_sink::{AudioCommand, AudioEventData, AudioHandle, AudioSequence, AudioSink, TimedAudioEvent},
     database::{Database, DatabaseRepository, RecordId},
     executor::{AsyncCallable, AsyncCallableResult},
     platform::{Filesystem, Platform},

--- a/wie_backend/src/system/audio.rs
+++ b/wie_backend/src/system/audio.rs
@@ -1,80 +1,58 @@
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-    vec::Vec,
-};
-use core::sync::atomic::{AtomicBool, Ordering};
+use alloc::{boxed::Box, collections::BTreeMap, collections::BTreeSet, vec, vec::Vec};
 
 use smaf_player::{SmafEvent, parse_smaf};
 
-use crate::{System, audio_sink::AudioSink};
+use crate::{AudioCommand, AudioEventData, AudioHandle, AudioSequence, AudioSink, TimedAudioEvent};
 
-pub type AudioHandle = u32;
 #[derive(Debug)]
 pub enum AudioError {
     InvalidHandle,
-    InvalidAudio,
-}
-
-enum AudioFile {
-    Smaf(Vec<u8>),
 }
 
 pub struct Audio {
-    sink: Arc<Box<dyn AudioSink>>,
-    files: BTreeMap<AudioHandle, AudioFile>,
-    playing: BTreeMap<AudioHandle, Arc<AtomicBool>>,
+    sink: Box<dyn AudioSink>,
+    files: BTreeMap<AudioHandle, AudioSequence>,
+    playing: BTreeSet<AudioHandle>,
     last_audio_handle: AudioHandle,
 }
 
 impl Audio {
     pub fn new(sink: Box<dyn AudioSink>) -> Self {
         Self {
-            sink: Arc::new(sink),
+            sink,
             files: BTreeMap::new(),
-            playing: BTreeMap::new(),
+            playing: BTreeSet::new(),
             last_audio_handle: 0,
         }
     }
 
     pub fn load_smaf(&mut self, data: &[u8]) -> Result<AudioHandle, AudioError> {
         let audio_handle = self.last_audio_handle;
+        let sequence = convert_smaf_events(parse_smaf(data));
 
         self.last_audio_handle += 1;
-        self.files.insert(audio_handle, AudioFile::Smaf(data.to_vec()));
+        self.files.insert(audio_handle, sequence);
 
         Ok(audio_handle)
     }
 
-    pub fn play(&mut self, system: &System, audio_handle: AudioHandle, repeat: bool) -> Result<(), AudioError> {
-        let player = match self.files.get(&audio_handle) {
-            Some(AudioFile::Smaf(data)) => SmafPlayer::new(data),
-            None => return Err(AudioError::InvalidHandle),
-        };
+    pub fn play(&mut self, audio_handle: AudioHandle, repeat: bool) -> Result<(), AudioError> {
+        let sequence = self.files.get(&audio_handle).cloned().ok_or(AudioError::InvalidHandle)?;
 
         self.stop(audio_handle);
-
-        let mut system_clone = system.clone();
-        let sink_clone = self.sink.clone();
-
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let stop_flag_clone = stop_flag.clone();
-        self.playing.insert(audio_handle, stop_flag);
-
-        // TODO use dedicated audio player task
-        system.spawn(async move || {
-            player.play(&mut system_clone, &**sink_clone, &stop_flag_clone, repeat).await;
-
-            Ok(())
+        self.playing.insert(audio_handle);
+        self.sink.send(AudioCommand::Play {
+            handle: audio_handle,
+            sequence,
+            repeat,
         });
 
         Ok(())
     }
 
     pub fn stop(&mut self, audio_handle: AudioHandle) {
-        if let Some(stop_flag) = self.playing.remove(&audio_handle) {
-            stop_flag.store(true, Ordering::Relaxed);
+        if self.playing.remove(&audio_handle) {
+            self.sink.send(AudioCommand::Stop { handle: audio_handle });
         }
     }
 
@@ -89,325 +67,110 @@ impl Audio {
     }
 }
 
-pub struct SmafPlayer {
-    events: Vec<(usize, SmafEvent)>,
-}
-
-impl SmafPlayer {
-    pub fn new(data: &[u8]) -> Self {
-        Self { events: parse_smaf(data) }
-    }
-
-    pub async fn play(&self, system: &mut System, sink: &dyn AudioSink, stop_flag: &AtomicBool, repeat: bool) {
-        loop {
-            let mut active_notes: Vec<(u8, u8)> = Vec::new();
-            let mut used_channels: BTreeSet<u8> = BTreeSet::new();
-
-            let start_time = system.platform().now();
-            for (time, event) in &self.events {
-                if stop_flag.load(Ordering::Relaxed) {
-                    break;
+fn convert_smaf_events(events: Vec<(usize, SmafEvent)>) -> AudioSequence {
+    let duration = events.iter().map(|(time, _)| *time as u64).max().unwrap_or(0);
+    let events = events
+        .into_iter()
+        .filter_map(|(time, event)| {
+            let data = match event {
+                SmafEvent::Wave {
+                    channel,
+                    sampling_rate,
+                    data,
+                } => AudioEventData::Wave {
+                    channels: channel,
+                    sampling_rate,
+                    samples: data,
+                },
+                SmafEvent::MidiNoteOn { channel, note, velocity } => AudioEventData::Midi(vec![0x90 | channel, note, velocity]),
+                SmafEvent::MidiNoteOff { channel, note, velocity } => AudioEventData::Midi(vec![0x80 | channel, note, velocity]),
+                SmafEvent::MidiProgramChange { channel, program } => AudioEventData::Midi(vec![0xc0 | channel, program]),
+                SmafEvent::MidiControlChange { channel, control, value } => AudioEventData::Midi(vec![0xb0 | channel, control, value]),
+                SmafEvent::MidiPitchBend { channel, value } => {
+                    AudioEventData::Midi(vec![0xe0 | channel, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8])
                 }
+                SmafEvent::MidiSysEx(data) => AudioEventData::Midi(data),
+                SmafEvent::End => return None,
+            };
 
-                let now = system.platform().now();
-                if (*time as u64) > now - start_time {
-                    system.sleep(((*time as u64) - (now - start_time)) as _).await;
+            Some(TimedAudioEvent { time: time as u64, data })
+        })
+        .collect();
 
-                    if stop_flag.load(Ordering::Relaxed) {
-                        break;
-                    }
-                }
-
-                match event {
-                    SmafEvent::Wave {
-                        channel,
-                        sampling_rate,
-                        data,
-                    } => {
-                        sink.play_wave(*channel, *sampling_rate, data);
-                    }
-                    SmafEvent::MidiNoteOn { channel, note, velocity } => {
-                        sink.midi_note_on(*channel, *note, *velocity);
-                        active_notes.push((*channel, *note));
-                        used_channels.insert(*channel);
-                    }
-                    SmafEvent::MidiNoteOff { channel, note, velocity } => {
-                        sink.midi_note_off(*channel, *note, *velocity);
-                        active_notes.retain(|(c, n)| !(*c == *channel && *n == *note));
-                    }
-                    SmafEvent::MidiProgramChange { channel, program } => {
-                        sink.midi_program_change(*channel, *program);
-                        used_channels.insert(*channel);
-                    }
-                    SmafEvent::MidiControlChange { channel, control, value } => {
-                        sink.midi_control_change(*channel, *control, *value);
-                        used_channels.insert(*channel);
-                    }
-                    SmafEvent::MidiPitchBend { channel, value } => {
-                        sink.midi_pitch_bend(*channel, *value);
-                        used_channels.insert(*channel);
-                    }
-                    SmafEvent::MidiSysEx(data) => {
-                        sink.midi_sysex(data);
-                    }
-                    SmafEvent::End => {}
-                }
-            }
-
-            for (channel, note) in &active_notes {
-                sink.midi_note_off(*channel, *note, 0);
-            }
-
-            for channel in &used_channels {
-                sink.midi_control_change(*channel, 64, 0);
-                sink.midi_control_change(*channel, 120, 0);
-                sink.midi_control_change(*channel, 123, 0);
-            }
-
-            if !repeat || stop_flag.load(Ordering::Relaxed) {
-                break;
-            }
-        }
-    }
+    AudioSequence { duration, events }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::{boxed::Box, sync::Arc, vec};
-    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    extern crate std;
+
+    use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+    use std::sync::Mutex;
 
     use smaf_player::SmafEvent;
 
-    use super::SmafPlayer;
-    use crate::{AudioSink, Database, DatabaseRepository, DefaultTaskRunner, Filesystem, Instant, Platform, Screen, System, canvas::Image};
+    use super::{Audio, convert_smaf_events};
+    use crate::{AudioCommand, AudioEventData, AudioSequence, AudioSink, TimedAudioEvent};
 
-    struct NullDatabase;
+    struct RecordingSink(Arc<Mutex<Vec<AudioCommand>>>);
 
-    #[async_trait::async_trait]
-    impl Database for NullDatabase {
-        async fn next_id(&self) -> u32 {
-            1
-        }
-
-        async fn add(&mut self, _data: &[u8]) -> u32 {
-            1
-        }
-
-        async fn get(&self, _id: u32) -> Option<alloc::vec::Vec<u8>> {
-            None
-        }
-
-        async fn set(&mut self, _id: u32, _data: &[u8]) -> bool {
-            true
-        }
-
-        async fn delete(&mut self, _id: u32) -> bool {
-            true
-        }
-
-        async fn get_record_ids(&self) -> alloc::vec::Vec<u32> {
-            vec![]
+    impl AudioSink for RecordingSink {
+        fn send(&self, command: AudioCommand) {
+            self.0.lock().unwrap().push(command);
         }
     }
 
-    struct NullDatabaseRepository;
+    #[test]
+    fn converts_smaf_events_to_timed_transport() {
+        let sequence = convert_smaf_events(vec![
+            (5, SmafEvent::MidiProgramChange { channel: 2, program: 7 }),
+            (10, SmafEvent::MidiPitchBend { channel: 3, value: 0x1234 }),
+            (15, SmafEvent::End),
+        ]);
 
-    #[async_trait::async_trait]
-    impl DatabaseRepository for NullDatabaseRepository {
-        async fn open(&self, _name: &str, _app_id: &str) -> Box<dyn Database> {
-            Box::new(NullDatabase)
-        }
-
-        async fn exists(&self, _name: &str, _app_id: &str) -> bool {
-            false
-        }
-
-        async fn delete(&self, _name: &str, _app_id: &str) -> bool {
-            false
-        }
-
-        async fn usage(&self, _app_id: &str) -> u64 {
-            0
-        }
-    }
-
-    struct NullFilesystem;
-
-    #[async_trait::async_trait]
-    impl Filesystem for NullFilesystem {
-        async fn exists(&self, _aid: &str, _path: &str) -> bool {
-            false
-        }
-
-        async fn size(&self, _aid: &str, _path: &str) -> Option<usize> {
-            None
-        }
-
-        async fn read(&self, _aid: &str, _path: &str, _offset: usize, _count: usize, _buf: &mut [u8]) -> Option<usize> {
-            None
-        }
-
-        async fn write(&self, _aid: &str, _path: &str, _offset: usize, data: &[u8]) -> usize {
-            data.len()
-        }
-
-        async fn truncate(&self, _aid: &str, _path: &str, _len: usize) {}
-    }
-
-    struct NullScreen;
-
-    impl Screen for NullScreen {
-        fn resize(&self, _width: u32, _height: u32) -> wie_util::Result<()> {
-            Ok(())
-        }
-
-        fn request_redraw(&self) -> wie_util::Result<()> {
-            Ok(())
-        }
-
-        fn paint(&self, _image: &dyn Image) {}
-
-        fn width(&self) -> u32 {
-            240
-        }
-
-        fn height(&self) -> u32 {
-            320
-        }
-    }
-
-    struct NullPlatform {
-        screen: NullScreen,
-        database_repository: NullDatabaseRepository,
-        filesystem: NullFilesystem,
-        now: AtomicUsize,
-    }
-
-    impl NullPlatform {
-        fn new() -> Self {
-            Self {
-                screen: NullScreen,
-                database_repository: NullDatabaseRepository,
-                filesystem: NullFilesystem,
-                now: AtomicUsize::new(0),
+        assert_eq!(
+            sequence,
+            AudioSequence {
+                duration: 15,
+                events: vec![
+                    TimedAudioEvent {
+                        time: 5,
+                        data: AudioEventData::Midi(vec![0xc2, 7]),
+                    },
+                    TimedAudioEvent {
+                        time: 10,
+                        data: AudioEventData::Midi(vec![0xe3, 0x34, 0x24]),
+                    },
+                ],
             }
-        }
+        );
     }
 
-    impl Platform for NullPlatform {
-        fn screen(&self) -> &dyn Screen {
-            &self.screen
-        }
+    #[test]
+    fn replay_stops_previous_playback_before_starting_again() {
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let mut audio = Audio::new(Box::new(RecordingSink(commands.clone())));
+        let handle = audio.load_smaf(&[]).unwrap();
 
-        fn now(&self) -> Instant {
-            Instant::from_epoch_millis(self.now.fetch_add(8, Ordering::SeqCst) as u64)
-        }
+        audio.play(handle, false).unwrap();
+        audio.play(handle, true).unwrap();
 
-        fn database_repository(&self) -> &dyn DatabaseRepository {
-            &self.database_repository
-        }
-
-        fn filesystem(&self) -> &dyn Filesystem {
-            &self.filesystem
-        }
-
-        fn audio_sink(&self) -> Box<dyn AudioSink> {
-            Box::new(NoopAudioSink)
-        }
-
-        fn write_stdout(&self, _buf: &[u8]) {}
-
-        fn write_stderr(&self, _buf: &[u8]) {}
-
-        fn exit(&self) {}
-
-        fn vibrate(&self, _duration_ms: u64, _intensity: u8) {}
+        let commands = commands.lock().unwrap();
+        assert!(matches!(commands[0], AudioCommand::Play { repeat: false, .. }));
+        assert_eq!(commands[1], AudioCommand::Stop { handle });
+        assert!(matches!(commands[2], AudioCommand::Play { repeat: true, .. }));
     }
 
-    struct NoopAudioSink;
+    #[test]
+    fn close_stops_playback_and_removes_the_handle() {
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let mut audio = Audio::new(Box::new(RecordingSink(commands.clone())));
+        let handle = audio.load_smaf(&[]).unwrap();
 
-    impl AudioSink for NoopAudioSink {
-        fn play_wave(&self, _channel: u8, _sampling_rate: u32, _wave_data: &[i16]) {}
+        audio.play(handle, false).unwrap();
+        audio.close(handle).unwrap();
 
-        fn midi_note_on(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
-
-        fn midi_note_off(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
-
-        fn midi_program_change(&self, _channel_id: u8, _program: u8) {}
-
-        fn midi_control_change(&self, _channel_id: u8, _control: u8, _value: u8) {}
-
-        fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {}
-
-        fn midi_sysex(&self, _data: &[u8]) {}
-    }
-
-    struct CountingSink {
-        program_change_count: Arc<AtomicUsize>,
-        stop_after: usize,
-        stop_flag: Arc<AtomicBool>,
-    }
-
-    impl AudioSink for CountingSink {
-        fn play_wave(&self, _channel: u8, _sampling_rate: u32, _wave_data: &[i16]) {}
-
-        fn midi_note_on(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
-
-        fn midi_note_off(&self, _channel_id: u8, _note: u8, _velocity: u8) {}
-
-        fn midi_program_change(&self, _channel_id: u8, _program: u8) {
-            let count = self.program_change_count.fetch_add(1, Ordering::SeqCst) + 1;
-            if count >= self.stop_after {
-                self.stop_flag.store(true, Ordering::SeqCst);
-            }
-        }
-
-        fn midi_control_change(&self, _channel_id: u8, _control: u8, _value: u8) {}
-
-        fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {}
-
-        fn midi_sysex(&self, _data: &[u8]) {}
-    }
-
-    fn new_system() -> System {
-        System::new(Box::new(NullPlatform::new()), "test-pid", "test-aid", DefaultTaskRunner)
-    }
-
-    #[futures_test::test]
-    async fn plays_once_when_repeat_is_false() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let sink = CountingSink {
-            program_change_count: counter.clone(),
-            stop_after: usize::MAX,
-            stop_flag: stop_flag.clone(),
-        };
-        let player = SmafPlayer {
-            events: vec![(0, SmafEvent::MidiProgramChange { channel: 0, program: 1 })],
-        };
-        let mut system = new_system();
-
-        player.play(&mut system, &sink, &stop_flag, false).await;
-
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
-    }
-
-    #[futures_test::test]
-    async fn repeats_until_stop_flag_is_set() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let sink = CountingSink {
-            program_change_count: counter.clone(),
-            stop_after: 2,
-            stop_flag: stop_flag.clone(),
-        };
-        let player = SmafPlayer {
-            events: vec![(0, SmafEvent::MidiProgramChange { channel: 0, program: 1 })],
-        };
-        let mut system = new_system();
-
-        player.play(&mut system, &sink, &stop_flag, true).await;
-
-        assert_eq!(counter.load(Ordering::SeqCst), 2);
+        assert_eq!(commands.lock().unwrap()[1], AudioCommand::Stop { handle });
+        assert!(audio.play(handle, false).is_err());
     }
 }

--- a/wie_backend/src/system/audio.rs
+++ b/wie_backend/src/system/audio.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, collections::BTreeMap, collections::BTreeSet, vec, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap, collections::BTreeSet, sync::Arc, vec, vec::Vec};
 
 use smaf_player::{SmafEvent, parse_smaf};
 
@@ -11,7 +11,7 @@ pub enum AudioError {
 
 pub struct Audio {
     sink: Box<dyn AudioSink>,
-    files: BTreeMap<AudioHandle, AudioSequence>,
+    files: BTreeMap<AudioHandle, Arc<AudioSequence>>,
     playing: BTreeSet<AudioHandle>,
     last_audio_handle: AudioHandle,
 }
@@ -28,7 +28,7 @@ impl Audio {
 
     pub fn load_smaf(&mut self, data: &[u8]) -> Result<AudioHandle, AudioError> {
         let audio_handle = self.last_audio_handle;
-        let sequence = convert_smaf_events(parse_smaf(data));
+        let sequence = Arc::new(convert_smaf_events(parse_smaf(data)));
 
         self.last_audio_handle += 1;
         self.files.insert(audio_handle, sequence);
@@ -156,9 +156,24 @@ mod tests {
         audio.play(handle, true).unwrap();
 
         let commands = commands.lock().unwrap();
-        assert!(matches!(commands[0], AudioCommand::Play { repeat: false, .. }));
+        let AudioCommand::Play {
+            sequence: first_sequence,
+            repeat: false,
+            ..
+        } = &commands[0]
+        else {
+            panic!("expected initial play command");
+        };
         assert_eq!(commands[1], AudioCommand::Stop { handle });
-        assert!(matches!(commands[2], AudioCommand::Play { repeat: true, .. }));
+        let AudioCommand::Play {
+            sequence: second_sequence,
+            repeat: true,
+            ..
+        } = &commands[2]
+        else {
+            panic!("expected replay command");
+        };
+        assert!(Arc::ptr_eq(first_sequence, second_sequence));
     }
 
     #[test]

--- a/wie_cli/src/audio_sink.rs
+++ b/wie_cli/src/audio_sink.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     error::Error,
     num::NonZero,
-    sync::mpsc::{Receiver, RecvTimeoutError, Sender},
+    sync::{Arc, mpsc::Receiver, mpsc::RecvTimeoutError, mpsc::Sender},
     time::{Duration, Instant},
 };
 
@@ -31,7 +31,7 @@ impl wie_backend::AudioSink for AudioSink {
 }
 
 struct Playback {
-    sequence: AudioSequence,
+    sequence: Arc<AudioSequence>,
     repeat: bool,
     started_at: Instant,
     next_event: usize,
@@ -40,7 +40,7 @@ struct Playback {
 }
 
 impl Playback {
-    fn new(sequence: AudioSequence, repeat: bool) -> Self {
+    fn new(sequence: Arc<AudioSequence>, repeat: bool) -> Self {
         Self {
             sequence,
             repeat,

--- a/wie_cli/src/audio_sink.rs
+++ b/wie_cli/src/audio_sink.rs
@@ -1,68 +1,246 @@
-use std::sync::{Mutex, mpsc::Sender};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    num::NonZero,
+    sync::mpsc::{Receiver, RecvTimeoutError, Sender},
+    time::{Duration, Instant},
+};
 
-use midir::MidiOutputConnection;
+use midir::{MidiOutput, MidiOutputConnection};
+use rodio::{DeviceSinkBuilder, Player, buffer::SamplesBuffer, conversions::SampleTypeConverter};
+use wie_backend::{AudioCommand, AudioEventData, AudioHandle, AudioSequence, TimedAudioEvent};
+
+use crate::select_midi_output_index;
 
 pub struct AudioSink {
-    midi_out: Option<Mutex<MidiOutputConnection>>,
-    audio_tx: Sender<(u8, u32, Vec<i16>)>,
+    tx: Sender<AudioCommand>,
 }
 
 impl AudioSink {
-    pub fn new(midi_out: Option<MidiOutputConnection>, audio_tx: Sender<(u8, u32, Vec<i16>)>) -> Self {
-        Self {
-            midi_out: midi_out.map(Mutex::new),
-            audio_tx,
+    pub fn new(tx: Sender<AudioCommand>) -> Self {
+        Self { tx }
+    }
+}
+
+impl wie_backend::AudioSink for AudioSink {
+    fn send(&self, command: AudioCommand) {
+        if self.tx.send(command).is_err() {
+            tracing::warn!("Audio worker is unavailable");
         }
     }
 }
 
-// XXX wasm32 is single-threaded anyway
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for AudioSink {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for AudioSink {}
+struct Playback {
+    sequence: AudioSequence,
+    repeat: bool,
+    started_at: Instant,
+    next_event: usize,
+    active_notes: BTreeSet<(u8, u8)>,
+    used_channels: BTreeSet<u8>,
+}
 
-impl wie_backend::AudioSink for AudioSink {
-    fn play_wave(&self, channel: u8, sampling_rate: u32, wave_data: &[i16]) {
-        self.audio_tx.send((channel, sampling_rate, wave_data.to_vec())).unwrap();
-    }
-
-    fn midi_note_on(&self, channel_id: u8, note: u8, velocity: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0x90 | channel_id, note, velocity]).unwrap();
+impl Playback {
+    fn new(sequence: AudioSequence, repeat: bool) -> Self {
+        Self {
+            sequence,
+            repeat,
+            started_at: Instant::now(),
+            next_event: 0,
+            active_notes: BTreeSet::new(),
+            used_channels: BTreeSet::new(),
         }
     }
 
-    fn midi_note_off(&self, channel_id: u8, note: u8, velocity: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0x80 | channel_id, note, velocity]).unwrap();
+    fn next_deadline(&self) -> Instant {
+        let time = self
+            .sequence
+            .events
+            .get(self.next_event)
+            .map_or(self.sequence.duration, |event| event.time);
+        self.started_at + Duration::from_millis(time)
+    }
+}
+
+pub fn run(rx: Receiver<AudioCommand>, midi_device: Option<usize>) {
+    let mut midi_out = match (|| {
+        let midi_out = MidiOutput::new("wie_cli")?;
+        let midi_ports = midi_out.ports();
+        let port_index = select_midi_output_index(midi_ports.len(), midi_device).ok_or_else(|| anyhow::anyhow!("No MIDI output port"))?;
+        let out_port = &midi_ports[port_index];
+        let port_name = midi_out.port_name(out_port).unwrap_or_else(|_| "<unknown>".to_string());
+
+        if let Some(requested) = midi_device
+            && requested != port_index
+        {
+            tracing::warn!(requested, fallback = %port_name, "Requested MIDI output index is out of range; using default");
+        }
+
+        let connection = midi_out.connect(out_port, "wie_cli")?;
+        tracing::info!(port = %port_name, "Using MIDI output");
+        Ok::<_, Box<dyn Error>>(connection)
+    })() {
+        Ok(connection) => Some(connection),
+        Err(error) => {
+            tracing::warn!(%error, "MIDI output is unavailable");
+            None
+        }
+    };
+
+    let output_sink = match DeviceSinkBuilder::open_default_sink() {
+        Ok(output_sink) => Some(output_sink),
+        Err(error) => {
+            tracing::warn!(%error, "PCM output is unavailable");
+            None
+        }
+    };
+    let player = output_sink.as_ref().map(|output_sink| Player::connect_new(output_sink.mixer()));
+    let mut playbacks = BTreeMap::new();
+
+    loop {
+        let command = if let Some(deadline) = playbacks.values().map(Playback::next_deadline).min() {
+            match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+                Ok(command) => Some(command),
+                Err(RecvTimeoutError::Timeout) => None,
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+        } else {
+            match rx.recv() {
+                Ok(command) => Some(command),
+                Err(_) => break,
+            }
+        };
+
+        if let Some(command) = command {
+            match command {
+                AudioCommand::Play { handle, sequence, repeat } => {
+                    if let Some(mut playback) = playbacks.remove(&handle) {
+                        cleanup(&mut midi_out, &mut playback);
+                    }
+                    playbacks.insert(handle, Playback::new(sequence, repeat));
+                }
+                AudioCommand::Stop { handle } => {
+                    if let Some(mut playback) = playbacks.remove(&handle) {
+                        cleanup(&mut midi_out, &mut playback);
+                    }
+                }
+            }
+            continue;
+        }
+
+        let now = Instant::now();
+        let handles: Vec<AudioHandle> = playbacks.keys().copied().collect();
+        for handle in handles {
+            let playback = playbacks.get_mut(&handle).unwrap();
+
+            while let Some(event) = playback.sequence.events.get(playback.next_event) {
+                if playback.started_at + Duration::from_millis(event.time) > now {
+                    break;
+                }
+
+                play_event(
+                    &mut midi_out,
+                    player.as_ref(),
+                    event,
+                    &mut playback.active_notes,
+                    &mut playback.used_channels,
+                );
+                playback.next_event += 1;
+            }
+
+            if playback.next_event == playback.sequence.events.len() && playback.started_at + Duration::from_millis(playback.sequence.duration) <= now
+            {
+                cleanup(&mut midi_out, playback);
+
+                if playback.repeat && playback.sequence.duration != 0 {
+                    playback.started_at = now;
+                    playback.next_event = 0;
+                } else {
+                    playbacks.remove(&handle);
+                }
+            }
         }
     }
 
-    fn midi_control_change(&self, channel_id: u8, control: u8, value: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0xB0 | channel_id, control, value]).unwrap()
+    for playback in playbacks.values_mut() {
+        cleanup(&mut midi_out, playback);
+    }
+}
+
+fn play_event(
+    midi_out: &mut Option<MidiOutputConnection>,
+    player: Option<&Player>,
+    event: &TimedAudioEvent,
+    active_notes: &mut BTreeSet<(u8, u8)>,
+    used_channels: &mut BTreeSet<u8>,
+) {
+    match &event.data {
+        AudioEventData::Midi(data) => {
+            if let Some(status) = data.first().copied()
+                && (0x80..0xf0).contains(&status)
+            {
+                let channel = status & 0x0f;
+                used_channels.insert(channel);
+
+                if let Some(note) = data.get(1).copied() {
+                    match status & 0xf0 {
+                        0x80 => {
+                            active_notes.remove(&(channel, note));
+                        }
+                        0x90 if data.get(2).copied().unwrap_or(0) == 0 => {
+                            active_notes.remove(&(channel, note));
+                        }
+                        0x90 => {
+                            active_notes.insert((channel, note));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if let Some(midi_out) = midi_out
+                && let Err(error) = midi_out.send(data)
+            {
+                tracing::warn!(%error, "Failed to send MIDI event");
+            }
+        }
+        AudioEventData::Wave {
+            channels,
+            sampling_rate,
+            samples,
+        } => {
+            let (Some(player), Some(channels), Some(sampling_rate)) = (player, NonZero::new((*channels).into()), NonZero::new(*sampling_rate)) else {
+                return;
+            };
+
+            player.append(SamplesBuffer::new(
+                channels,
+                sampling_rate,
+                SampleTypeConverter::new(samples.iter().copied()).collect::<Vec<_>>(),
+            ));
+        }
+    }
+}
+
+fn cleanup(midi_out: &mut Option<MidiOutputConnection>, playback: &mut Playback) {
+    let Some(midi_out) = midi_out else {
+        playback.active_notes.clear();
+        playback.used_channels.clear();
+        return;
+    };
+
+    for (channel, note) in &playback.active_notes {
+        if let Err(error) = midi_out.send(&[0x80 | channel, *note, 0]) {
+            tracing::warn!(%error, "Failed to stop MIDI note");
+        }
+    }
+    for channel in &playback.used_channels {
+        for control in [64, 120, 123] {
+            if let Err(error) = midi_out.send(&[0xb0 | channel, control, 0]) {
+                tracing::warn!(%error, "Failed to reset MIDI channel");
+            }
         }
     }
 
-    fn midi_program_change(&self, channel_id: u8, program: u8) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock().unwrap().send(&[0xC0 | channel_id, program]).unwrap()
-        }
-    }
-
-    fn midi_pitch_bend(&self, channel_id: u8, value: u16) {
-        if let Some(x) = self.midi_out.as_ref() {
-            x.lock()
-                .unwrap()
-                .send(&[0xE0 | channel_id, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8])
-                .unwrap();
-        }
-    }
-
-    fn midi_sysex(&self, data: &[u8]) {
-        if let Some(x) = self.midi_out.as_ref() {
-            let _ = x.lock().unwrap().send(data);
-        }
-    }
+    playback.active_notes.clear();
+    playback.used_channels.clear();
 }

--- a/wie_cli/src/main.rs
+++ b/wie_cli/src/main.rs
@@ -8,25 +8,19 @@ mod window;
 use core::str;
 use std::{
     collections::{HashMap, hash_map::Entry},
-    error::Error,
     fs::{self, File},
     io::{LineWriter, Write, stderr},
-    num::NonZero,
     path::PathBuf,
-    sync::{
-        Mutex,
-        mpsc::{Receiver, Sender, channel},
-    },
+    sync::{Mutex, mpsc::Sender, mpsc::channel},
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use clap::Parser;
 use midir::MidiOutput;
-use rodio::{DeviceSinkBuilder, Player, buffer::SamplesBuffer, conversions::SampleTypeConverter};
 use winit::keyboard::{KeyCode as WinitKeyCode, PhysicalKey};
 
-use wie_backend::{Emulator, Event, Filesystem, Instant, KeyCode, Options, Platform, ProfileSample, Screen, extract_zip};
+use wie_backend::{AudioCommand, Emulator, Event, Filesystem, Instant, KeyCode, Options, Platform, ProfileSample, Screen, extract_zip};
 use wie_j2me::J2MEEmulator;
 use wie_ktf::KtfEmulator;
 use wie_lgt::LgtEmulator;
@@ -40,61 +34,22 @@ use self::{
 };
 
 struct WieCliPlatform {
-    audio_thread_tx: Sender<(u8, u32, Vec<i16>)>,
+    audio_tx: Sender<AudioCommand>,
     database_repository: DatabaseRepository,
     filesystem: CliFilesystem,
-    midi_device: Option<usize>,
     window: WindowHandle,
 }
 
 impl WieCliPlatform {
     fn new(window: WindowHandle, midi_device: Option<usize>) -> Self {
         let (tx, rx) = channel();
-        thread::spawn(|| Self::audio_thread(rx));
+        thread::spawn(move || audio_sink::run(rx, midi_device));
 
         Self {
-            audio_thread_tx: tx,
+            audio_tx: tx,
             database_repository: DatabaseRepository::new(),
             filesystem: CliFilesystem::new(),
-            midi_device,
             window,
-        }
-    }
-
-    fn audio_thread(rx: Receiver<(u8, u32, Vec<i16>)>) {
-        let default_output = DeviceSinkBuilder::open_default_sink();
-        if default_output.is_err() {
-            // do nothing if we can't open output
-            loop {
-                rx.recv().unwrap();
-            }
-        }
-
-        let output_sink = default_output.unwrap();
-        let player = Player::connect_new(output_sink.mixer());
-
-        loop {
-            let result = rx.recv();
-            if result.is_err() {
-                break;
-            }
-            let (channel, sampling_rate, wave_data) = result.unwrap();
-
-            let Some(channel_count) = NonZero::new(channel.into()) else {
-                continue;
-            };
-            let Some(sample_rate) = NonZero::new(sampling_rate) else {
-                continue;
-            };
-
-            let buffer = SamplesBuffer::new(
-                channel_count,
-                sample_rate,
-                SampleTypeConverter::new(wave_data.into_iter()).collect::<Vec<_>>(),
-            );
-
-            // TODO we should be able to play multiple audio at once
-            player.append(buffer);
         }
     }
 }
@@ -120,36 +75,7 @@ impl Platform for WieCliPlatform {
     }
 
     fn audio_sink(&self) -> Box<dyn wie_backend::AudioSink> {
-        let midi_out = (|| {
-            let midi_out = MidiOutput::new("wie_cli")?;
-            let midi_ports = midi_out.ports();
-            let port_index = select_midi_output_index(midi_ports.len(), self.midi_device).ok_or_else(|| anyhow::anyhow!("No MIDI output port"))?;
-            let out_port = &midi_ports[port_index];
-            let port_name = midi_out.port_name(out_port).unwrap_or_else(|_| "<unknown>".to_string());
-
-            if let Some(requested) = self.midi_device
-                && requested != port_index
-            {
-                tracing::warn!(
-                    requested,
-                    fallback = %port_name,
-                    "Requested MIDI output index is out of range; using default"
-                );
-            }
-
-            let connection = midi_out.connect(out_port, "wie_cli")?;
-            tracing::info!(port = %port_name, "Using MIDI output");
-            Ok::<_, Box<dyn Error>>(connection)
-        })();
-        let midi_out = match midi_out {
-            Ok(connection) => Some(connection),
-            Err(error) => {
-                tracing::warn!(%error, "MIDI output is unavailable");
-                None
-            }
-        };
-
-        Box::new(AudioSink::new(midi_out, self.audio_thread_tx.clone()))
+        Box::new(AudioSink::new(self.audio_tx.clone()))
     }
 
     fn write_stdout(&self, buf: &[u8]) {

--- a/wie_midp/src/classes/net/wie/smaf_player.rs
+++ b/wie_midp/src/classes/net/wie/smaf_player.rs
@@ -49,9 +49,7 @@ impl SmafPlayer {
 
         let audio_handle: i32 = jvm.get_field(&this, "audioHandle", "I").await?;
 
-        let system = context.system();
-
-        system.audio().play(system, audio_handle as u32, repeat).unwrap();
+        context.system().audio().play(audio_handle as u32, repeat).unwrap();
 
         Ok(())
     }

--- a/wie_web/Cargo.toml
+++ b/wie_web/Cargo.toml
@@ -21,7 +21,6 @@ console_error_panic_hook = { version = "^0.1" }
 futures = { version = "^0.3", default-features = false, features = ["alloc"] }
 hashbrown = { version = "^0.17" }
 js-sys = { version = "^0.3" }
-rodio = { version = "^0.22", features = ["playback", "wasm-bindgen"], default-features = false }
 time = { version = "^0.3", features = ["wasm-bindgen"] }
 tracing = { version = "^0.1", features = ["release_max_level_info"] }
 tracing-subscriber = { version = "^0.3", features = ["time"] }

--- a/wie_web/src/rust/audio_sink.rs
+++ b/wie_web/src/rust/audio_sink.rs
@@ -39,11 +39,11 @@ impl wie_backend::AudioSink for AudioSink {
         match command {
             AudioCommand::Play { handle, sequence, repeat } => {
                 let events = Array::new();
-                for event in sequence.events {
+                for event in &sequence.events {
                     let value = Array::new();
                     value.push(&JsValue::from_f64(event.time as f64));
 
-                    match event.data {
+                    match &event.data {
                         AudioEventData::Midi(data) => {
                             value.push(&JsValue::from_str("midi"));
                             value.push(Uint8Array::from(data.as_slice()).as_ref());
@@ -54,8 +54,8 @@ impl wie_backend::AudioSink for AudioSink {
                             samples,
                         } => {
                             value.push(&JsValue::from_str("wave"));
-                            value.push(&JsValue::from(channels));
-                            value.push(&JsValue::from(sampling_rate));
+                            value.push(&JsValue::from(*channels));
+                            value.push(&JsValue::from(*sampling_rate));
                             value.push(Int16Array::from(samples.as_slice()).as_ref());
                         }
                     }

--- a/wie_web/src/rust/audio_sink.rs
+++ b/wie_web/src/rust/audio_sink.rs
@@ -1,83 +1,71 @@
-use alloc::{sync::Arc, vec::Vec};
-use core::num::NonZero;
-
-use rodio::{Player, buffer::SamplesBuffer, conversions::SampleTypeConverter};
+use js_sys::{Array, Int16Array, Uint8Array};
 use wasm_bindgen::prelude::*;
+
+use wie_backend::{AudioCommand, AudioEventData};
 
 #[wasm_bindgen(module = "midi.ts")]
 extern "C" {
-    type MidiPlayer;
+    type AudioPlayer;
 
     #[wasm_bindgen(constructor)]
-    fn new() -> MidiPlayer;
+    fn new() -> AudioPlayer;
 
     #[wasm_bindgen(method)]
-    fn note_on(this: &MidiPlayer, channel_id: u8, note: u8, velocity: u8);
+    fn play(this: &AudioPlayer, handle: u32, duration: f64, events: Array, repeat: bool);
+
     #[wasm_bindgen(method)]
-    fn note_off(this: &MidiPlayer, channel_id: u8, note: u8, velocity: u8);
-    #[wasm_bindgen(method)]
-    fn control_change(this: &MidiPlayer, channel_id: u8, control: u8, value: u8);
-    #[wasm_bindgen(method)]
-    fn program_change(this: &MidiPlayer, channel_id: u8, program: u8);
+    fn stop(this: &AudioPlayer, handle: u32);
+
+    #[wasm_bindgen(js_name = setPcmVolume)]
+    pub fn set_pcm_volume(value: f32);
 }
 
 pub struct AudioSink {
-    midi_player: MidiPlayer,
-    sink: Arc<Player>,
+    player: AudioPlayer,
 }
 
-// XXX we're on single thread
+// The wasm frontend and its JavaScript audio bridge run on one thread.
 unsafe impl Sync for AudioSink {}
 unsafe impl Send for AudioSink {}
 
 impl AudioSink {
-    pub fn new(sink: Arc<Player>) -> Self {
-        Self {
-            midi_player: MidiPlayer::new(),
-            sink,
-        }
+    pub fn new() -> Self {
+        Self { player: AudioPlayer::new() }
     }
 }
 
 impl wie_backend::AudioSink for AudioSink {
-    fn play_wave(&self, channel: u8, sampling_rate: u32, wave_data: &[i16]) {
-        let Some(channel) = NonZero::new(channel as u16) else {
-            return;
-        };
-        let Some(sampling_rate) = NonZero::new(sampling_rate) else {
-            return;
-        };
+    fn send(&self, command: AudioCommand) {
+        match command {
+            AudioCommand::Play { handle, sequence, repeat } => {
+                let events = Array::new();
+                for event in sequence.events {
+                    let value = Array::new();
+                    value.push(&JsValue::from_f64(event.time as f64));
 
-        let buffer = SamplesBuffer::new(
-            channel,
-            sampling_rate,
-            SampleTypeConverter::new(wave_data.iter().copied()).collect::<Vec<_>>(),
-        );
+                    match event.data {
+                        AudioEventData::Midi(data) => {
+                            value.push(&JsValue::from_str("midi"));
+                            value.push(Uint8Array::from(data.as_slice()).as_ref());
+                        }
+                        AudioEventData::Wave {
+                            channels,
+                            sampling_rate,
+                            samples,
+                        } => {
+                            value.push(&JsValue::from_str("wave"));
+                            value.push(&JsValue::from(channels));
+                            value.push(&JsValue::from(sampling_rate));
+                            value.push(Int16Array::from(samples.as_slice()).as_ref());
+                        }
+                    }
 
-        self.sink.append(buffer);
-    }
+                    events.push(value.as_ref());
+                }
 
-    fn midi_note_on(&self, channel_id: u8, note: u8, velocity: u8) {
-        self.midi_player.note_on(channel_id, note, velocity);
-    }
-
-    fn midi_note_off(&self, channel_id: u8, note: u8, velocity: u8) {
-        self.midi_player.note_off(channel_id, note, velocity);
-    }
-
-    fn midi_control_change(&self, channel_id: u8, control: u8, value: u8) {
-        self.midi_player.control_change(channel_id, control, value);
-    }
-
-    fn midi_program_change(&self, channel_id: u8, program: u8) {
-        self.midi_player.program_change(channel_id, program);
-    }
-
-    fn midi_pitch_bend(&self, _channel_id: u8, _value: u16) {
-        // TODO
-    }
-
-    fn midi_sysex(&self, _data: &[u8]) {
-        // TODO
+                self.player.play(handle, sequence.duration as f64, events, repeat);
+            }
+            AudioCommand::Stop { handle } => self.player.stop(handle),
+        }
     }
 }

--- a/wie_web/src/rust/lib.rs
+++ b/wie_web/src/rust/lib.rs
@@ -20,7 +20,6 @@ use core::{
 };
 
 use hashbrown::HashMap;
-use rodio::{DeviceSinkBuilder, Player};
 use tracing_subscriber::{Layer, filter::LevelFilter, fmt::time::UtcTime, layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_web::MakeConsoleWriter;
 use wasm_bindgen::{JsError, prelude::*};
@@ -38,7 +37,6 @@ struct WieWebPlatform {
     database_repository: DatabaseRepository,
     filesystem: WebFilesystem,
     window: WindowImpl,
-    player: Arc<Player>,
 }
 
 // XXX we're on single thread
@@ -46,12 +44,11 @@ unsafe impl Sync for WieWebPlatform {}
 unsafe impl Send for WieWebPlatform {}
 
 impl WieWebPlatform {
-    fn new(window: WindowImpl, player: Arc<Player>) -> Self {
+    fn new(window: WindowImpl) -> Self {
         Self {
             database_repository: DatabaseRepository::new(),
             filesystem: WebFilesystem::new(),
             window,
-            player,
         }
     }
 }
@@ -77,7 +74,7 @@ impl Platform for WieWebPlatform {
     }
 
     fn audio_sink(&self) -> Box<dyn wie_backend::AudioSink> {
-        Box::new(AudioSink::new(self.player.clone()))
+        Box::new(AudioSink::new())
     }
 
     fn write_stdout(&self, data: &[u8]) {
@@ -112,7 +109,6 @@ pub struct WieWeb {
     emulator: Box<dyn Emulator>,
     should_redraw: Arc<AtomicBool>,
     key_events: HashMap<KeyCode, f64>,
-    player: Arc<Player>,
 }
 
 #[wasm_bindgen]
@@ -122,9 +118,7 @@ impl WieWeb {
         (move || {
             let should_redraw = Arc::new(AtomicBool::new(true));
             let window = WindowImpl::new(canvas, should_redraw.clone());
-            let output_stream = DeviceSinkBuilder::open_default_sink().unwrap();
-            let player = Arc::new(Player::connect_new(output_stream.mixer()));
-            let platform = Box::new(WieWebPlatform::new(window, player.clone()));
+            let platform = Box::new(WieWebPlatform::new(window));
             let options = Options {
                 enable_gdbserver: false,
                 profile: None,
@@ -185,7 +179,6 @@ impl WieWeb {
                 emulator,
                 should_redraw,
                 key_events: HashMap::new(),
-                player,
             })
         })()
         .map_err(|e| JsError::new(&e.to_string()))
@@ -231,7 +224,7 @@ impl WieWeb {
     }
 
     pub fn set_pcm_volume(&self, volume: f32) {
-        self.player.set_volume(volume);
+        audio_sink::set_pcm_volume(volume);
     }
 }
 

--- a/wie_web/src/ts/audio-worker.ts
+++ b/wie_web/src/ts/audio-worker.ts
@@ -17,6 +17,7 @@ type Playback = {
   startedAt: number;
   nextEvent: number;
   lastScheduledAt: number;
+  cleanupAt: number | null;
   activeNotes: Set<number>;
   usedChannels: Set<number>;
 };
@@ -35,7 +36,7 @@ scope.onmessage = message => {
   const command = message.data;
   if (command.type === "play") {
     const oldPlayback = playbacks.get(command.handle);
-    if (oldPlayback) stopPlayback(command.handle, oldPlayback, true);
+    if (oldPlayback) stopPlayback(command.handle, oldPlayback);
 
     const now = performance.now();
     const startedAt = Math.max(now, blockedUntil.get(command.handle) ?? now);
@@ -47,12 +48,13 @@ scope.onmessage = message => {
       startedAt,
       nextEvent: 0,
       lastScheduledAt: startedAt,
+      cleanupAt: null,
       activeNotes: new Set(),
       usedChannels: new Set(),
     });
   } else {
     const playback = playbacks.get(command.handle);
-    if (playback) stopPlayback(command.handle, playback, true);
+    if (playback) stopPlayback(command.handle, playback);
   }
 
   schedule();
@@ -67,7 +69,16 @@ function schedule(): void {
   const now = performance.now();
   const horizon = now + LOOKAHEAD_MS;
 
+  for (const [handle, deadline] of blockedUntil) {
+    if (deadline <= now) blockedUntil.delete(handle);
+  }
+
   for (const [handle, playback] of playbacks) {
+    if (playback.cleanupAt !== null) {
+      if (playback.cleanupAt <= now) playbacks.delete(handle);
+      continue;
+    }
+
     while (true) {
       const event = playback.events[playback.nextEvent];
       if (event) {
@@ -84,33 +95,48 @@ function schedule(): void {
       const end = playback.startedAt + playback.duration;
       if (end > horizon) break;
 
+      playback.lastScheduledAt = Math.max(playback.lastScheduledAt, end);
       postCleanup(handle, playback, end, false);
       if (!playback.repeat || playback.duration === 0) {
-        playbacks.delete(handle);
+        if (end <= now) {
+          playbacks.delete(handle);
+        } else {
+          playback.cleanupAt = end;
+        }
         break;
       }
 
+      playback.activeNotes.clear();
+      playback.usedChannels.clear();
       playback.startedAt = Math.max(end, now);
       playback.nextEvent = 0;
       playback.lastScheduledAt = playback.startedAt;
     }
   }
 
-  let nextDeadline = Number.POSITIVE_INFINITY;
+  let nextDelay = Number.POSITIVE_INFINITY;
   for (const playback of playbacks.values()) {
-    const event = playback.events[playback.nextEvent];
-    nextDeadline = Math.min(nextDeadline, event ? playback.startedAt + event[0] : playback.startedAt + playback.duration);
+    if (playback.cleanupAt !== null) {
+      nextDelay = Math.min(nextDelay, playback.cleanupAt - now);
+    } else {
+      const event = playback.events[playback.nextEvent];
+      const deadline = event ? playback.startedAt + event[0] : playback.startedAt + playback.duration;
+      nextDelay = Math.min(nextDelay, deadline - now - LOOKAHEAD_MS);
+    }
   }
-  if (nextDeadline !== Number.POSITIVE_INFINITY) {
-    timer = setTimeout(schedule, Math.max(0, nextDeadline - performance.now() - LOOKAHEAD_MS));
+  for (const deadline of blockedUntil.values()) {
+    nextDelay = Math.min(nextDelay, deadline - now);
+  }
+  if (nextDelay !== Number.POSITIVE_INFINITY) {
+    timer = setTimeout(schedule, Math.max(0, nextDelay));
   }
 }
 
-function stopPlayback(handle: number, playback: Playback, immediate: boolean): void {
+function stopPlayback(handle: number, playback: Playback): void {
   playbacks.delete(handle);
   const deadline = Math.max(performance.now(), playback.lastScheduledAt) + 1;
   blockedUntil.set(handle, deadline);
-  postCleanup(handle, playback, deadline, immediate);
+  postCleanup(handle, playback, deadline, true);
 }
 
 function trackMidi(playback: Playback, event: TransportEvent): void {
@@ -141,6 +167,4 @@ function postCleanup(handle: number, playback: Playback, deadline: number, immed
     notes,
     immediate,
   });
-  playback.activeNotes.clear();
-  playback.usedChannels.clear();
 }

--- a/wie_web/src/ts/audio-worker.ts
+++ b/wie_web/src/ts/audio-worker.ts
@@ -1,0 +1,146 @@
+type MidiEvent = [time: number, kind: "midi", data: Uint8Array];
+type WaveEvent = [time: number, kind: "wave", channels: number, samplingRate: number, samples: Int16Array];
+type TransportEvent = MidiEvent | WaveEvent;
+
+type WorkerCommand =
+  | { type: "play"; handle: number; duration: number; events: TransportEvent[]; repeat: boolean }
+  | { type: "stop"; handle: number };
+
+type WorkerOutput =
+  | { type: "event"; handle: number; deadline: number; event: TransportEvent }
+  | { type: "cleanup"; handle: number; deadline: number; channels: number[]; notes: [number, number][]; immediate: boolean };
+
+type Playback = {
+  duration: number;
+  events: TransportEvent[];
+  repeat: boolean;
+  startedAt: number;
+  nextEvent: number;
+  lastScheduledAt: number;
+  activeNotes: Set<number>;
+  usedChannels: Set<number>;
+};
+
+const LOOKAHEAD_MS = 50;
+const playbacks = new Map<number, Playback>();
+const blockedUntil = new Map<number, number>();
+let timer: ReturnType<typeof setTimeout> | undefined;
+
+const scope = self as unknown as {
+  onmessage: ((message: MessageEvent<WorkerCommand>) => void) | null;
+  postMessage(message: WorkerOutput): void;
+};
+
+scope.onmessage = message => {
+  const command = message.data;
+  if (command.type === "play") {
+    const oldPlayback = playbacks.get(command.handle);
+    if (oldPlayback) stopPlayback(command.handle, oldPlayback, true);
+
+    const now = performance.now();
+    const startedAt = Math.max(now, blockedUntil.get(command.handle) ?? now);
+    blockedUntil.delete(command.handle);
+    playbacks.set(command.handle, {
+      duration: command.duration,
+      events: command.events,
+      repeat: command.repeat,
+      startedAt,
+      nextEvent: 0,
+      lastScheduledAt: startedAt,
+      activeNotes: new Set(),
+      usedChannels: new Set(),
+    });
+  } else {
+    const playback = playbacks.get(command.handle);
+    if (playback) stopPlayback(command.handle, playback, true);
+  }
+
+  schedule();
+};
+
+function schedule(): void {
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timer = undefined;
+  }
+
+  const now = performance.now();
+  const horizon = now + LOOKAHEAD_MS;
+
+  for (const [handle, playback] of playbacks) {
+    while (true) {
+      const event = playback.events[playback.nextEvent];
+      if (event) {
+        const deadline = playback.startedAt + event[0];
+        if (deadline > horizon) break;
+
+        trackMidi(playback, event);
+        playback.lastScheduledAt = Math.max(playback.lastScheduledAt, deadline);
+        playback.nextEvent++;
+        scope.postMessage({ type: "event", handle, deadline: performance.timeOrigin + deadline, event });
+        continue;
+      }
+
+      const end = playback.startedAt + playback.duration;
+      if (end > horizon) break;
+
+      postCleanup(handle, playback, end, false);
+      if (!playback.repeat || playback.duration === 0) {
+        playbacks.delete(handle);
+        break;
+      }
+
+      playback.startedAt = Math.max(end, now);
+      playback.nextEvent = 0;
+      playback.lastScheduledAt = playback.startedAt;
+    }
+  }
+
+  let nextDeadline = Number.POSITIVE_INFINITY;
+  for (const playback of playbacks.values()) {
+    const event = playback.events[playback.nextEvent];
+    nextDeadline = Math.min(nextDeadline, event ? playback.startedAt + event[0] : playback.startedAt + playback.duration);
+  }
+  if (nextDeadline !== Number.POSITIVE_INFINITY) {
+    timer = setTimeout(schedule, Math.max(0, nextDeadline - performance.now() - LOOKAHEAD_MS));
+  }
+}
+
+function stopPlayback(handle: number, playback: Playback, immediate: boolean): void {
+  playbacks.delete(handle);
+  const deadline = Math.max(performance.now(), playback.lastScheduledAt) + 1;
+  blockedUntil.set(handle, deadline);
+  postCleanup(handle, playback, deadline, immediate);
+}
+
+function trackMidi(playback: Playback, event: TransportEvent): void {
+  if (event[1] !== "midi" || event[2].length === 0) return;
+
+  const status = event[2][0];
+  if (status < 0x80 || status >= 0xf0) return;
+
+  const channel = status & 0x0f;
+  playback.usedChannels.add(channel);
+  if (event[2].length < 2) return;
+
+  const noteKey = (channel << 8) | event[2][1];
+  if ((status & 0xf0) === 0x80 || ((status & 0xf0) === 0x90 && (event[2][2] ?? 0) === 0)) {
+    playback.activeNotes.delete(noteKey);
+  } else if ((status & 0xf0) === 0x90) {
+    playback.activeNotes.add(noteKey);
+  }
+}
+
+function postCleanup(handle: number, playback: Playback, deadline: number, immediate: boolean): void {
+  const notes = [...playback.activeNotes].map(note => [note >> 8, note & 0xff] as [number, number]);
+  scope.postMessage({
+    type: "cleanup",
+    handle,
+    deadline: performance.timeOrigin + deadline,
+    channels: [...playback.usedChannels],
+    notes,
+    immediate,
+  });
+  playback.activeNotes.clear();
+  playback.usedChannels.clear();
+}

--- a/wie_web/src/ts/midi.ts
+++ b/wie_web/src/ts/midi.ts
@@ -1,66 +1,154 @@
-import { WorkletSynthesizer } from 'spessasynth_lib';
+import { WorkletSynthesizer } from "spessasynth_lib";
 
-type AudioState = { synth: WorkletSynthesizer; ctx: AudioContext; gain: GainNode };
+type MidiEvent = [time: number, kind: "midi", data: Uint8Array];
+type WaveEvent = [time: number, kind: "wave", channels: number, samplingRate: number, samples: Int16Array];
+type TransportEvent = MidiEvent | WaveEvent;
 
-let masterVolume = 0.5;
+type WorkerOutput =
+  | { type: "event"; handle: number; deadline: number; event: TransportEvent }
+  | { type: "cleanup"; handle: number; deadline: number; channels: number[]; notes: [number, number][]; immediate: boolean };
+
+type AudioState = {
+  synth: WorkletSynthesizer | null;
+  ctx: AudioContext;
+  midiGain: GainNode;
+  pcmGain: GainNode;
+  pcmSources: Map<number, Set<AudioBufferSourceNode>>;
+};
+
+let midiVolume = 0.5;
+let pcmVolume = 0.5;
 
 async function initAudio(): Promise<AudioState> {
   const ctx = new AudioContext();
-  await ctx.audioWorklet.addModule('/spessasynth_processor.min.js');
-  const synth = new WorkletSynthesizer(ctx);
-  const buffer = await fetch('GeneralUser.sf3').then(r => r.arrayBuffer());
-  await synth.soundBankManager.addSoundBank(buffer, 'main');
-  await synth.isReady;
-  const gain = ctx.createGain();
-  gain.gain.value = masterVolume;
-  synth.connect(gain);
-  gain.connect(ctx.destination);
-  return { synth, ctx, gain };
+  const midiGain = ctx.createGain();
+  midiGain.gain.value = midiVolume;
+  midiGain.connect(ctx.destination);
+
+  const pcmGain = ctx.createGain();
+  pcmGain.gain.value = pcmVolume;
+  pcmGain.connect(ctx.destination);
+
+  let synth: WorkletSynthesizer | null = null;
+  try {
+    await ctx.audioWorklet.addModule("/spessasynth_processor.min.js");
+    synth = new WorkletSynthesizer(ctx);
+    const buffer = await fetch("GeneralUser.sf3").then(response => response.arrayBuffer());
+    await synth.soundBankManager.addSoundBank(buffer, "main");
+    await synth.isReady;
+    synth.connect(midiGain);
+  } catch (error) {
+    console.warn("MIDI output is unavailable:", error);
+  }
+
+  return { synth, ctx, midiGain, pcmGain, pcmSources: new Map() };
 }
 
-// Starts loading immediately on DOMContentLoaded.
-// ctx.resume() is called lazily on first note_on (requires user gesture).
 const audioReady: Promise<AudioState | null> = new Promise(resolve => {
-  const start = () => initAudio().then(resolve, err => {
-    console.warn('MidiPlayer init failed, audio will be silent:', err);
+  const start = () => initAudio().then(resolve, error => {
+    console.warn("AudioPlayer init failed, audio will be silent:", error);
     resolve(null);
   });
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', start, { once: true });
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
   } else {
     start();
   }
 });
 
 export function setMasterVolume(value: number): void {
-  masterVolume = value;
-  audioReady.then(s => {
-    if (s) s.gain.gain.value = value;
+  midiVolume = value;
+  audioReady.then(state => {
+    if (state) state.midiGain.gain.value = value;
   });
 }
 
-export class MidiPlayer {
-  constructor() {}
+export function setPcmVolume(value: number): void {
+  pcmVolume = value;
+  audioReady.then(state => {
+    if (state) state.pcmGain.gain.value = value;
+  });
+}
 
-  public note_on(channel_id: number, note: number, velocity: number): void {
-    if (velocity === 0) { this.note_off(channel_id, note, 0); return; }
-    audioReady.then(async s => {
-      if (!s) return;
-      if (s.ctx.state === 'suspended') await s.ctx.resume();
-      s.synth.noteOn(channel_id, note, velocity);
-    });
+export class AudioPlayer {
+  private readonly worker = new Worker(new URL("./audio-worker.ts", import.meta.url), { type: "module" });
+  private commands: Promise<void> = Promise.resolve();
+
+  constructor() {
+    this.worker.onmessage = (message: MessageEvent<WorkerOutput>) => {
+      void audioReady.then(state => {
+        if (!state) return;
+
+        const output = message.data;
+        const time = state.ctx.currentTime + Math.max(0, output.deadline - performance.timeOrigin - performance.now()) / 1000;
+
+        if (output.type === "event") {
+          if (output.event[1] === "midi") {
+            state.synth?.sendMessage(output.event[2], 0, { time });
+            return;
+          }
+
+          const [, , channels, samplingRate, samples] = output.event;
+          if (channels === 0 || samplingRate === 0) return;
+
+          const frameCount = Math.floor(samples.length / channels);
+          const buffer = state.ctx.createBuffer(channels, frameCount, samplingRate);
+          for (let channel = 0; channel < channels; channel++) {
+            const data = buffer.getChannelData(channel);
+            for (let frame = 0; frame < frameCount; frame++) {
+              data[frame] = samples[frame * channels + channel] / 32768;
+            }
+          }
+
+          const source = state.ctx.createBufferSource();
+          source.buffer = buffer;
+          source.connect(state.pcmGain);
+          const sources = state.pcmSources.get(output.handle) ?? new Set<AudioBufferSourceNode>();
+          sources.add(source);
+          state.pcmSources.set(output.handle, sources);
+          source.onended = () => {
+            sources.delete(source);
+            if (sources.size === 0) state.pcmSources.delete(output.handle);
+          };
+          source.start(time);
+          return;
+        }
+
+        for (const [channel, note] of output.notes) {
+          state.synth?.sendMessage([0x80 | channel, note, 0], 0, { time });
+        }
+        for (const channel of output.channels) {
+          state.synth?.sendMessage([0xb0 | channel, 64, 0], 0, { time });
+          state.synth?.sendMessage([0xb0 | channel, 120, 0], 0, { time });
+          state.synth?.sendMessage([0xb0 | channel, 123, 0], 0, { time });
+        }
+
+        if (output.immediate) {
+          for (const source of state.pcmSources.get(output.handle) ?? []) {
+            source.stop(state.ctx.currentTime);
+          }
+        }
+      });
+    };
   }
 
-  public note_off(channel_id: number, note: number, _velocity: number): void {
-    audioReady.then(s => s?.synth.noteOff(channel_id, note));
+  public play(handle: number, duration: number, events: TransportEvent[], repeat: boolean): void {
+    const buffers = events.map(event => (event[1] === "midi" ? event[2].buffer : event[4].buffer));
+    this.commands = this.commands
+      .then(async () => {
+        const state = await audioReady;
+        if (state?.ctx.state === "suspended") await state.ctx.resume();
+        this.worker.postMessage({ type: "play", handle, duration, events, repeat }, buffers);
+      })
+      .catch(error => console.warn("Failed to start audio playback:", error));
   }
 
-  public control_change(channel_id: number, control: number, value: number): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    audioReady.then(s => s?.synth.controllerChange(channel_id, control as any, value));
-  }
-
-  public program_change(channel_id: number, program: number): void {
-    audioReady.then(s => s?.synth.programChange(channel_id, program));
+  public stop(handle: number): void {
+    this.commands = this.commands
+      .then(async () => {
+        await audioReady;
+        this.worker.postMessage({ type: "stop", handle });
+      })
+      .catch(error => console.warn("Failed to stop audio playback:", error));
   }
 }

--- a/wie_web/src/ts/midi.ts
+++ b/wie_web/src/ts/midi.ts
@@ -114,13 +114,16 @@ export class AudioPlayer {
           return;
         }
 
-        for (const [channel, note] of output.notes) {
-          state.synth?.sendMessage([0x80 | channel, note, 0], 0, { time });
-        }
-        for (const channel of output.channels) {
-          state.synth?.sendMessage([0xb0 | channel, 64, 0], 0, { time });
-          state.synth?.sendMessage([0xb0 | channel, 120, 0], 0, { time });
-          state.synth?.sendMessage([0xb0 | channel, 123, 0], 0, { time });
+        const cleanupTimes = output.immediate && time > state.ctx.currentTime ? [state.ctx.currentTime, time] : [time];
+        for (const cleanupTime of cleanupTimes) {
+          for (const [channel, note] of output.notes) {
+            state.synth?.sendMessage([0x80 | channel, note, 0], 0, { time: cleanupTime });
+          }
+          for (const channel of output.channels) {
+            state.synth?.sendMessage([0xb0 | channel, 64, 0], 0, { time: cleanupTime });
+            state.synth?.sendMessage([0xb0 | channel, 120, 0], 0, { time: cleanupTime });
+            state.synth?.sendMessage([0xb0 | channel, 123, 0], 0, { time: cleanupTime });
+          }
         }
 
         if (output.immediate) {

--- a/wie_wipi_c/src/api/media.rs
+++ b/wie_wipi_c/src/api/media.rs
@@ -186,9 +186,7 @@ pub async fn play(context: &mut dyn WIPICContext, ptr_clip: WIPICWord, repeat: W
 
     let clip: MdaClip = read_generic(context, ptr_clip)?;
 
-    let system = context.system();
-
-    let result = system.audio().play(system, clip.handle, repeat != 0);
+    let result = context.system().audio().play(clip.handle, repeat != 0);
 
     if let Err(x) = result {
         tracing::error!("Failed to load audio: {x:?}");


### PR DESCRIPTION
## Summary
- replace backend event-by-event playback with owned Play and Stop commands
- run CLI MIDI and PCM scheduling on a dedicated channel-driven worker thread
- schedule Web audio from a Dedicated Worker using AudioContext timestamps
- preserve repeat, cleanup, PCM volume, pitch bend, and SysEx behavior

## Testing
- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test --workspace`
- `cargo check -p wie_web --target wasm32-unknown-unknown`
- `npm run build:dev`