### PR TITLE
Fix LGT Java runtime ABI dispatch

### DIFF
--- a/data/lgt_java_abi.toml
+++ b/data/lgt_java_abi.toml
@@ -49,6 +49,7 @@ name = "java/lang/String"
 vtable = [
     { name = "length", descriptor = "()I", index = 10 },
     { name = "charAt", descriptor = "(I)C", index = 11 },
+    { name = "getBytes", descriptor = "()[B", index = 14 },
     { name = "substring", descriptor = "(II)Ljava/lang/String;", index = 28 },
     { name = "trim", descriptor = "()Ljava/lang/String;", index = 33 },
     { name = "toCharArray", descriptor = "()[C", index = 34 },
@@ -74,6 +75,15 @@ name = "java/lang/Thread"
 vtable = [
     { name = "start", descriptor = "()V", index = 10 },
     { name = "setPriority", descriptor = "(I)V", index = 14 },
+]
+
+[[class]]
+name = "java/util/Vector"
+vtable = [
+    { name = "size", descriptor = "()I", index = 15 },
+    { name = "elementAt", descriptor = "(I)Ljava/lang/Object;", index = 23 },
+    { name = "removeElementAt", descriptor = "(I)V", index = 27 },
+    { name = "insertElementAt", descriptor = "(Ljava/lang/Object;I)V", index = 28 },
 ]
 
 [[class]]

--- a/wie_lgt/src/runtime/java/jvm_support.rs
+++ b/wie_lgt/src/runtime/java/jvm_support.rs
@@ -457,10 +457,33 @@ mod tests {
             let string_methods = string_definition.vtable_entries(&jvm).await?;
             assert_eq!(string_methods[10].method.as_ref().unwrap().name(), "length");
             assert_eq!(string_methods[11].method.as_ref().unwrap().name(), "charAt");
+            assert_eq!(string_methods[14].method.as_ref().unwrap().name(), "getBytes");
             assert_eq!(string_methods[28].method.as_ref().unwrap().name(), "substring");
-            for index in [10usize, 11, 28] {
+            for index in [10usize, 11, 14, 28] {
                 let target: u32 = read_generic(&core, string_definition.ptr_vtable()? + ((index + 1) * 4) as u32)?;
                 assert_eq!(target, string_methods[index].method.as_ref().unwrap().target()?);
+            }
+
+            let vector_definition = jvm
+                .resolve_class("java/util/Vector")
+                .await
+                .unwrap()
+                .definition
+                .as_any()
+                .downcast_ref::<super::JavaClassDefinition>()
+                .unwrap()
+                .clone();
+            let vector_methods = vector_definition.vtable_entries(&jvm).await?;
+            for (index, name, descriptor) in [
+                (15usize, "size", "()I"),
+                (23, "elementAt", "(I)Ljava/lang/Object;"),
+                (27, "removeElementAt", "(I)V"),
+                (28, "insertElementAt", "(Ljava/lang/Object;I)V"),
+            ] {
+                let method = vector_methods[index].method.as_ref().unwrap();
+                assert_eq!((method.name().as_str(), method.descriptor().as_str()), (name, descriptor));
+                let target: u32 = read_generic(&core, vector_definition.ptr_vtable()? + ((index + 1) * 4) as u32)?;
+                assert_eq!(target, method.target()?);
             }
 
             let reader_definition = jvm
@@ -773,6 +796,22 @@ mod tests {
                 .unwrap();
             let JavaValue::Object(Some(inherited_reference)) = static_child_definition.get_static_field(&*reference_field).unwrap() else {
                 panic!("expected inherited static reference field")
+            };
+            assert_eq!(inherited_reference.identity(), guest_reference.identity());
+
+            write_generic(&mut core, static_fields, guest_reference_raw)?;
+            static_child_definition.put_static_field(&*child_word_field, JavaValue::Int(4)).unwrap();
+            let static_reference_field = ClassDefinition::fields(&static_definition)
+                .into_iter()
+                .find(|field| {
+                    field
+                        .as_any()
+                        .downcast_ref::<super::JavaStaticReferenceField>()
+                        .is_some_and(|field| field.word_index == 0)
+                })
+                .unwrap();
+            let JavaValue::Object(Some(inherited_reference)) = static_child_definition.get_static_field(&*static_reference_field).unwrap() else {
+                panic!("expected inherited untyped static reference")
             };
             assert_eq!(inherited_reference.identity(), guest_reference.identity());
 

--- a/wie_lgt/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/class_definition.rs
@@ -887,7 +887,10 @@ impl ClassDefinition for JavaClassDefinition {
                 continue;
             };
             if class.unk1 == instance.ptr_dispatch_table {
-                fields.push(Box::new(JavaStaticReferenceField { word_index }));
+                fields.push(Box::new(JavaStaticReferenceField {
+                    ptr_class: self.ptr_raw,
+                    word_index,
+                }));
             }
         }
         fields
@@ -903,8 +906,9 @@ impl ClassDefinition for JavaClassDefinition {
             )
         } else {
             let field = field.as_any().downcast_ref::<JavaStaticReferenceField>().unwrap();
+            let declaring_class = Self::from_raw(field.ptr_class, &self.core);
             (
-                self.ptr_static_fields().unwrap() + field.word_index * size_of::<LgtJvmWord>() as u32,
+                declaring_class.ptr_static_fields().unwrap() + field.word_index * size_of::<LgtJvmWord>() as u32,
                 JavaType::parse(&field.descriptor()),
             )
         };

--- a/wie_lgt/src/runtime/java/jvm_support/field.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/field.rs
@@ -100,6 +100,7 @@ impl Field for JavaReferenceField {
 
 #[derive(Debug)]
 pub struct JavaStaticReferenceField {
+    pub ptr_class: u32,
     pub word_index: u32,
 }
 


### PR DESCRIPTION
## Summary

- add confirmed LGT vtable indexes for `String.getBytes()` and the `Vector` methods used by AOT code
- preserve the declaring class for synthesized static reference fields so inherited fields read the correct guest storage
- extend the LGT JVM runtime test coverage for both dispatch tables and inherited static references

## Root cause

LGT AOT code dispatches selected Java methods through fixed ABI indexes that were missing from the runtime data. In addition, inherited synthesized static reference fields were resolved against the child class storage instead of the storage owned by their declaring class, allowing primitive words to be interpreted as object references during GC traversal.

## Impact

LGT applications can proceed through the affected startup and collection paths without missing-method failures or invalid guest object decoding.

## Validation

- `cargo test -p wie_lgt runtime::java::jvm_support::tests::test_native_jvm_runtime`
- `cargo fmt`
- `cargo clippy --workspace`
- 65-second LGT runtime smoke test through the affected startup path