### PR TITLE
Fix KTF class interface metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "wipi_types"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/wipi.git#a49599bcf00e4d0cfdebbd849f1c7d2441e8576a"
+source = "git+https://github.com/dlunch/wipi.git#5c744444d139e669e0ddaf5599f441971a71bbc1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/wie_ktf/src/runtime/java/jvm_support.rs
+++ b/wie_ktf/src/runtime/java/jvm_support.rs
@@ -10,7 +10,7 @@ mod name;
 mod value;
 mod vtable;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 use core::mem::size_of;
 use jvm_implementation::KtfJvmImplementation;
 
@@ -22,7 +22,7 @@ use jvm::{ClassDefinition, ClassInstance, ClassInstanceRef, Jvm, runtime::JavaLa
 use wie_backend::System;
 use wie_core_arm::{Allocator, ArmCore};
 use wie_jvm_support::JvmSupport;
-use wie_util::{Result, WieError, read_generic, read_null_terminated_table, write_generic, write_null_terminated_table};
+use wie_util::{Result, WieError, read_generic, read_null_terminated_table, write_generic};
 
 use wipi_types::ktf::InitParam2;
 
@@ -55,16 +55,6 @@ struct KtfJvmExceptionContext {
 struct KtfJvmSupportContext {
     ptr_vtables_base: u32,
     ptr_jvm_exception_context: u32,
-    ptr_class_interfaces: u32,
-}
-
-// AOT descriptors use ptr_interfaces for executable metadata, so Rust class relationships stay in the support context.
-#[repr(C)]
-#[derive(Clone, Copy, Pod, Zeroable)]
-struct KtfJvmClassInterfaceEntry {
-    ptr_class: u32,
-    ptr_interfaces: u32,
-    ptr_next: u32,
 }
 
 const SUPPORT_CONTEXT_BASE: u32 = 0x7fff0000;
@@ -92,7 +82,6 @@ impl KtfJvmSupport {
         let context_data = KtfJvmSupportContext {
             ptr_vtables_base: ptr_jvm_context + 12,
             ptr_jvm_exception_context,
-            ptr_class_interfaces: 0,
         };
         write_generic(core, SUPPORT_CONTEXT_BASE, context_data)?;
 
@@ -206,45 +195,6 @@ impl KtfJvmSupport {
         write_generic(core, context_data.ptr_vtables_base + (index * size_of::<u32>()) as u32, ptr_vtable)?;
 
         Ok(index as _)
-    }
-
-    pub fn register_class_interfaces(core: &mut ArmCore, ptr_class: u32, interfaces: &[u32]) -> Result<()> {
-        if interfaces.is_empty() {
-            return Ok(());
-        }
-
-        let ptr_interfaces = Allocator::alloc(core, ((interfaces.len() + 1) * size_of::<u32>()) as u32)?;
-        write_null_terminated_table(core, ptr_interfaces, interfaces)?;
-
-        let mut context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
-        let ptr_entry = Allocator::alloc(core, size_of::<KtfJvmClassInterfaceEntry>() as u32)?;
-        write_generic(
-            core,
-            ptr_entry,
-            KtfJvmClassInterfaceEntry {
-                ptr_class,
-                ptr_interfaces,
-                ptr_next: context_data.ptr_class_interfaces,
-            },
-        )?;
-
-        context_data.ptr_class_interfaces = ptr_entry;
-        write_generic(core, SUPPORT_CONTEXT_BASE, context_data)
-    }
-
-    pub fn class_interfaces(core: &ArmCore, ptr_class: u32) -> Result<Vec<u32>> {
-        let context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
-        let mut ptr_entry = context_data.ptr_class_interfaces;
-
-        while ptr_entry != 0 {
-            let entry: KtfJvmClassInterfaceEntry = read_generic(core, ptr_entry)?;
-            if entry.ptr_class == ptr_class {
-                return read_null_terminated_table(core, entry.ptr_interfaces);
-            }
-            ptr_entry = entry.ptr_next;
-        }
-
-        Ok(Vec::new())
     }
 
     pub fn current_java_exception_handler(core: &mut ArmCore) -> Result<u32> {

--- a/wie_ktf/src/runtime/java/jvm_support.rs
+++ b/wie_ktf/src/runtime/java/jvm_support.rs
@@ -10,7 +10,7 @@ mod name;
 mod value;
 mod vtable;
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::mem::size_of;
 use jvm_implementation::KtfJvmImplementation;
 
@@ -22,7 +22,7 @@ use jvm::{ClassDefinition, ClassInstance, ClassInstanceRef, Jvm, runtime::JavaLa
 use wie_backend::System;
 use wie_core_arm::{Allocator, ArmCore};
 use wie_jvm_support::JvmSupport;
-use wie_util::{Result, WieError, read_generic, read_null_terminated_table, write_generic};
+use wie_util::{Result, WieError, read_generic, read_null_terminated_table, write_generic, write_null_terminated_table};
 
 use wipi_types::ktf::InitParam2;
 
@@ -55,6 +55,16 @@ struct KtfJvmExceptionContext {
 struct KtfJvmSupportContext {
     ptr_vtables_base: u32,
     ptr_jvm_exception_context: u32,
+    ptr_class_interfaces: u32,
+}
+
+// AOT descriptors use ptr_interfaces for executable metadata, so Rust class relationships stay in the support context.
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct KtfJvmClassInterfaceEntry {
+    ptr_class: u32,
+    ptr_interfaces: u32,
+    ptr_next: u32,
 }
 
 const SUPPORT_CONTEXT_BASE: u32 = 0x7fff0000;
@@ -82,6 +92,7 @@ impl KtfJvmSupport {
         let context_data = KtfJvmSupportContext {
             ptr_vtables_base: ptr_jvm_context + 12,
             ptr_jvm_exception_context,
+            ptr_class_interfaces: 0,
         };
         write_generic(core, SUPPORT_CONTEXT_BASE, context_data)?;
 
@@ -197,6 +208,45 @@ impl KtfJvmSupport {
         Ok(index as _)
     }
 
+    pub fn register_class_interfaces(core: &mut ArmCore, ptr_class: u32, interfaces: &[u32]) -> Result<()> {
+        if interfaces.is_empty() {
+            return Ok(());
+        }
+
+        let ptr_interfaces = Allocator::alloc(core, ((interfaces.len() + 1) * size_of::<u32>()) as u32)?;
+        write_null_terminated_table(core, ptr_interfaces, interfaces)?;
+
+        let mut context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
+        let ptr_entry = Allocator::alloc(core, size_of::<KtfJvmClassInterfaceEntry>() as u32)?;
+        write_generic(
+            core,
+            ptr_entry,
+            KtfJvmClassInterfaceEntry {
+                ptr_class,
+                ptr_interfaces,
+                ptr_next: context_data.ptr_class_interfaces,
+            },
+        )?;
+
+        context_data.ptr_class_interfaces = ptr_entry;
+        write_generic(core, SUPPORT_CONTEXT_BASE, context_data)
+    }
+
+    pub fn class_interfaces(core: &ArmCore, ptr_class: u32) -> Result<Vec<u32>> {
+        let context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
+        let mut ptr_entry = context_data.ptr_class_interfaces;
+
+        while ptr_entry != 0 {
+            let entry: KtfJvmClassInterfaceEntry = read_generic(core, ptr_entry)?;
+            if entry.ptr_class == ptr_class {
+                return read_null_terminated_table(core, entry.ptr_interfaces);
+            }
+            ptr_entry = entry.ptr_next;
+        }
+
+        Ok(Vec::new())
+    }
+
     pub fn current_java_exception_handler(core: &mut ArmCore) -> Result<u32> {
         let context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
         let exception_context: KtfJvmExceptionContext = read_generic(core, context_data.ptr_jvm_exception_context)?;
@@ -210,6 +260,7 @@ mod test {
     use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
     use core::sync::atomic::{AtomicBool, Ordering};
 
+    use java_constants::ClassAccessFlags;
     use jvm::{Jvm, runtime::JavaLangString};
 
     use wie_backend::{DefaultTaskRunner, System};
@@ -261,13 +312,18 @@ mod test {
 
             assert_eq!(temp, vec![5, 6, 7, 8]);
 
-            done_clone.store(true, Ordering::Relaxed);
-
             // test 64bit parameter passing
             let date = jvm.new_class("java/util/Date", "(J)V", (0x12345678_abcdef01i64,)).await.unwrap();
             let time: i64 = jvm.invoke_virtual(&date, "getTime", "()J", ()).await.unwrap();
 
             assert_eq!(time, 0x12345678_abcdef01);
+
+            let calendar = jvm.new_class("java/util/GregorianCalendar", "()V", ()).await.unwrap();
+            assert!(jvm.is_instance(&*calendar, "java/util/Calendar"));
+            let cloneable = jvm.resolve_class("java/lang/Cloneable").await.unwrap();
+            assert!(cloneable.definition.access_flags().contains(ClassAccessFlags::INTERFACE));
+
+            done_clone.store(true, Ordering::Relaxed);
 
             Ok(())
         });

--- a/wie_ktf/src/runtime/java/jvm_support/array_class_definition.rs
+++ b/wie_ktf/src/runtime/java/jvm_support/array_class_definition.rs
@@ -63,7 +63,7 @@ impl JavaArrayClassDefinition {
                 method_count: 0,
                 fields_size: 0,
                 access_flag: 0x21, // ACC_PUBLIC | ACC_SUPER
-                unk6: 0,
+                interface_count: 0,
                 unk7: 0,
                 unk8: 0,
             },

--- a/wie_ktf/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie_ktf/src/runtime/java/jvm_support/class_definition.rs
@@ -19,10 +19,7 @@ use wie_util::{
 
 use crate::runtime::java::JavaSvcFunctions;
 
-use super::{
-    KtfJvmSupport, KtfJvmWord, Result, class_instance::JavaClassInstance, field::JavaField, method::JavaMethod, value::JavaValueCodec,
-    vtable::JavaVtable,
-};
+use super::{KtfJvmWord, Result, class_instance::JavaClassInstance, field::JavaField, method::JavaMethod, value::JavaValueCodec, vtable::JavaVtable};
 
 #[derive(Clone)]
 pub struct JavaClassDefinition {
@@ -62,11 +59,17 @@ impl JavaClassDefinition {
 
             interfaces.push(class.ptr_raw);
         }
+        let ptr_interfaces = if interfaces.is_empty() {
+            0
+        } else {
+            let ptr_interfaces = Allocator::alloc(core, ((interfaces.len() + 1) * size_of::<u32>()) as u32)?;
+            write_null_terminated_table(core, ptr_interfaces, &interfaces)?;
+            ptr_interfaces
+        };
 
         let field_offset_base: u32 = if let Some(x) = &parent_class { x.field_size()? as _ } else { 0 };
 
         let ptr_raw = Allocator::alloc(core, size_of::<RawJavaClass>() as u32)?;
-        KtfJvmSupport::register_class_interfaces(core, ptr_raw, &interfaces)?;
 
         let mut methods = Vec::new();
         for method in proto.methods.into_iter() {
@@ -109,12 +112,12 @@ impl JavaClassDefinition {
                 unk1: 0,
                 ptr_parent_class: parent_class.map(|x| x.ptr_raw).unwrap_or(0),
                 ptr_methods,
-                ptr_interfaces: 0,
+                ptr_interfaces,
                 ptr_fields_or_element_type: ptr_fields,
                 method_count: methods.len() as u16,
                 fields_size: field_offset as u16,
                 access_flag: proto.access_flags.bits(),
-                unk6: 0,
+                interface_count: interfaces.len() as u16,
                 unk7: 0,
                 unk8: 0,
             },
@@ -304,9 +307,11 @@ impl ClassDefinition for JavaClassDefinition {
     }
 
     fn interface_names(&self) -> Vec<String> {
-        KtfJvmSupport::class_interfaces(&self.core, self.ptr_raw)
-            .unwrap()
-            .into_iter()
+        let raw: RawJavaClass = read_generic(&self.core, self.ptr_raw).unwrap();
+        let descriptor: RawJavaClassDescriptor = read_generic(&self.core, raw.ptr_descriptor).unwrap();
+
+        (0..descriptor.interface_count)
+            .map(|index| read_generic(&self.core, descriptor.ptr_interfaces + u32::from(index) * size_of::<u32>() as u32).unwrap())
             .map(|ptr_class| JavaClassDefinition::from_raw(ptr_class, &self.core).name().unwrap())
             .collect()
     }

--- a/wie_ktf/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie_ktf/src/runtime/java/jvm_support/class_definition.rs
@@ -19,7 +19,10 @@ use wie_util::{
 
 use crate::runtime::java::JavaSvcFunctions;
 
-use super::{KtfJvmWord, Result, class_instance::JavaClassInstance, field::JavaField, method::JavaMethod, value::JavaValueCodec, vtable::JavaVtable};
+use super::{
+    KtfJvmSupport, KtfJvmWord, Result, class_instance::JavaClassInstance, field::JavaField, method::JavaMethod, value::JavaValueCodec,
+    vtable::JavaVtable,
+};
 
 #[derive(Clone)]
 pub struct JavaClassDefinition {
@@ -52,9 +55,18 @@ impl JavaClassDefinition {
             None
         };
 
+        let mut interfaces = Vec::with_capacity(proto.interfaces.len());
+        for name in proto.interfaces {
+            let class = jvm.resolve_class(name).await.unwrap().definition;
+            let class = class.as_any().downcast_ref::<JavaClassDefinition>().unwrap();
+
+            interfaces.push(class.ptr_raw);
+        }
+
         let field_offset_base: u32 = if let Some(x) = &parent_class { x.field_size()? as _ } else { 0 };
 
         let ptr_raw = Allocator::alloc(core, size_of::<RawJavaClass>() as u32)?;
+        KtfJvmSupport::register_class_interfaces(core, ptr_raw, &interfaces)?;
 
         let mut methods = Vec::new();
         for method in proto.methods.into_iter() {
@@ -101,7 +113,7 @@ impl JavaClassDefinition {
                 ptr_fields_or_element_type: ptr_fields,
                 method_count: methods.len() as u16,
                 fields_size: field_offset as u16,
-                access_flag: 0x21, // ACC_PUBLIC | ACC_SUPER
+                access_flag: proto.access_flags.bits(),
                 unk6: 0,
                 unk7: 0,
                 unk8: 0,
@@ -292,7 +304,11 @@ impl ClassDefinition for JavaClassDefinition {
     }
 
     fn interface_names(&self) -> Vec<String> {
-        Vec::new() // TODO we don't store interface now
+        KtfJvmSupport::class_interfaces(&self.core, self.ptr_raw)
+            .unwrap()
+            .into_iter()
+            .map(|ptr_class| JavaClassDefinition::from_raw(ptr_class, &self.core).name().unwrap())
+            .collect()
     }
 
     async fn prepare(&self, _: &Jvm) -> JvmResult<()> {


### PR DESCRIPTION
## Summary

- store Rust-defined KTF class interfaces in the guest class descriptor
- return declared interfaces from `ClassDefinition::interface_names()`
- preserve class proto access flags instead of forcing every class to `PUBLIC | SUPER`
- cover inherited class checks and interface flags in the KTF JVM test

## Root cause

KTF's guest-backed `JavaClassDefinition` discarded every `JavaClassProto::interfaces` entry and returned an empty interface list. It also replaced the proto access flags with a fixed value, so inherited interface checks and marker-interface behavior could fail.

A relocated KTF image confirms that descriptor `ptr_interfaces` points to an interface-class array and `interface_count` controls its length. Rust-defined classes now use the same guest-memory representation, and readers use the count instead of scanning beyond the array.

## Validation

- `cargo fmt`
- `cargo test -p wie_ktf`
- `cargo clippy --workspace`
- manual KTF launch
