### PR TITLE
Isolate KTF JVM contexts per task

### DIFF
--- a/wie_ktf/src/emulator.rs
+++ b/wie_ktf/src/emulator.rs
@@ -1,17 +1,19 @@
-use core::pin::Pin;
+use core::{mem::size_of, pin::Pin, task::Poll};
 
 use alloc::{borrow::ToOwned, boxed::Box, collections::BTreeMap, format, string::String, vec, vec::Vec};
 
+use bytemuck::Zeroable;
+use futures::future::poll_fn;
 use jvm::{ClassInstance, Result as JvmResult, runtime::JavaLangString};
 
 use wie_backend::{Emulator, Event, Options, Platform, System, TaskRunner};
 use wie_core_arm::{Allocator, ArmCore};
 use wie_jvm_support::JvmSupport;
-use wie_util::{Result, WieError};
+use wie_util::{Result, WieError, write_generic};
 
 use crate::{
     adf::{KtfAdf, find_client_bin},
-    runtime::KtfJvmSupport,
+    runtime::{KtfJvmSupport, KtfJvmThreadContext},
 };
 
 pub const IMAGE_BASE: u32 = 0x100000;
@@ -22,8 +24,29 @@ struct KtfTaskRunner {
 
 #[async_trait::async_trait]
 impl TaskRunner for KtfTaskRunner {
-    async fn run(&self, future: Pin<Box<dyn Future<Output = Result<()>> + Send>>) -> Result<()> {
-        self.core.run_in_thread(async move || future.await)?.await
+    async fn run(&self, mut future: Pin<Box<dyn Future<Output = Result<()>> + Send>>) -> Result<()> {
+        let mut core = self.core.clone();
+        let ptr_thread_context = Allocator::alloc(&mut core, size_of::<KtfJvmThreadContext>() as u32)?;
+        write_generic(&mut core, ptr_thread_context, KtfJvmThreadContext::zeroed())?;
+
+        let mut poll_core = self.core.clone();
+        let result = self
+            .core
+            .run_in_thread(move || {
+                poll_fn(move |context| {
+                    // KTF's first native init argument points at this cell and dereferences it for each stack check and try block.
+                    if let Err(error) = KtfJvmSupport::set_current_thread_context(&mut poll_core, ptr_thread_context) {
+                        return Poll::Ready(Err(error));
+                    }
+
+                    future.as_mut().poll(context)
+                })
+            })?
+            .await;
+
+        Allocator::free(&mut core, ptr_thread_context, size_of::<KtfJvmThreadContext>() as u32)?;
+
+        result
     }
 }
 
@@ -151,5 +174,59 @@ impl Emulator for KtfEmulator {
                 _ => WieError::FatalError(format!("{x}\n{reg_stack}")),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, sync::Arc};
+    use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+    use test_utils::TestPlatform;
+    use wie_backend::{System, YieldFuture};
+    use wie_core_arm::{Allocator, ArmCore};
+    use wie_util::{Result, WieError};
+
+    use super::{KtfJvmSupport, KtfTaskRunner};
+
+    #[test]
+    fn switches_jvm_thread_context_between_tasks() -> Result<()> {
+        let mut core = ArmCore::new(false, None)?;
+        Allocator::init(&mut core)?;
+
+        let mut system = System::new(Box::new(TestPlatform::new()), "", "", KtfTaskRunner { core: core.clone() });
+        let contexts = Arc::new([AtomicU32::new(0), AtomicU32::new(0)]);
+        let completed = Arc::new(AtomicUsize::new(0));
+
+        for index in 0..2 {
+            let core = core.clone();
+            let contexts = contexts.clone();
+            let completed = completed.clone();
+            system.spawn(async move || {
+                let before = KtfJvmSupport::current_thread_context(&core)?;
+                YieldFuture::new().await;
+                let after = KtfJvmSupport::current_thread_context(&core)?;
+                if before != after {
+                    return Err(WieError::FatalError("KTF JVM thread context changed while the task was suspended".into()));
+                }
+
+                contexts[index].store(before, Ordering::Relaxed);
+                completed.fetch_add(1, Ordering::Relaxed);
+
+                Ok(())
+            });
+        }
+
+        while completed.load(Ordering::Relaxed) != 2 {
+            system.tick()?;
+        }
+
+        let first = contexts[0].load(Ordering::Relaxed);
+        let second = contexts[1].load(Ordering::Relaxed);
+        assert_ne!(first, 0);
+        assert_ne!(second, 0);
+        assert_ne!(first, second);
+
+        Ok(())
     }
 }

--- a/wie_ktf/src/runtime.rs
+++ b/wie_ktf/src/runtime.rs
@@ -8,4 +8,4 @@ const SVC_CATEGORY_JAVA_INTERFACE: u32 = 2;
 const SVC_CATEGORY_WIPIC: u32 = 3;
 const SVC_CATEGORY_JAVA: u32 = 4;
 
-pub use self::java::jvm_support::KtfJvmSupport;
+pub use self::java::jvm_support::{KtfJvmSupport, KtfJvmThreadContext};

--- a/wie_ktf/src/runtime/init.rs
+++ b/wie_ktf/src/runtime/init.rs
@@ -6,7 +6,7 @@ use wie_backend::System;
 use wie_core_arm::{Allocator, ArmCore, EmulatedFunction, ResultWriter, SvcId};
 use wie_util::{Result, WieError, read_generic, read_null_terminated_string_bytes, write_generic};
 
-use wipi_types::ktf::{ExeInterface, ExeInterfaceFunctions, InitParam0, InitParam1, InitParam3, InitParam4, WipiExe};
+use wipi_types::ktf::{ExeInterface, ExeInterfaceFunctions, InitParam0, InitParam3, InitParam4, WipiExe};
 
 use crate::{
     adf::parse_bss_size,
@@ -44,7 +44,7 @@ pub async fn load_native(
     filename: &str,
     data: &[u8],
     ptr_jvm_context: u32,
-    ptr_jvm_exception_context: u32,
+    ptr_current_jvm_thread_context: u32,
 ) -> Result<ExeInterfaceFunctions> {
     let bss_size = parse_bss_size(filename)?;
 
@@ -73,9 +73,6 @@ pub async fn load_native(
 
     let ptr_param_0 = Allocator::alloc(core, size_of::<InitParam0>() as u32)?;
     write_generic(core, ptr_param_0, InitParam0 { unk: 0 })?;
-
-    let ptr_param_1 = Allocator::alloc(core, size_of::<InitParam1>() as u32)?;
-    write_generic(core, ptr_param_1, InitParam1 { ptr_jvm_exception_context })?;
 
     let param_3 = InitParam3 {
         unk1: 0,
@@ -121,7 +118,7 @@ pub async fn load_native(
     let result = core
         .run_function::<u32>(
             exe_interface_functions.fn_init,
-            &[ptr_param_0, ptr_param_1, ptr_jvm_context, ptr_param_3, ptr_param_4],
+            &[ptr_param_0, ptr_current_jvm_thread_context, ptr_jvm_context, ptr_param_3, ptr_param_4],
         )
         .await?;
 

--- a/wie_ktf/src/runtime/java/jvm_support.rs
+++ b/wie_ktf/src/runtime/java/jvm_support.rs
@@ -11,7 +11,7 @@ mod value;
 mod vtable;
 
 use alloc::boxed::Box;
-use core::mem::size_of;
+use core::mem::{offset_of, size_of};
 use jvm_implementation::KtfJvmImplementation;
 
 use bytemuck::{Pod, Zeroable};
@@ -45,7 +45,7 @@ pub type KtfJvmWord = u32;
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
-struct KtfJvmExceptionContext {
+pub struct KtfJvmThreadContext {
     unk: [u32; 8],
     current_java_exception_handler: u32,
 }
@@ -54,7 +54,7 @@ struct KtfJvmExceptionContext {
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct KtfJvmSupportContext {
     ptr_vtables_base: u32,
-    ptr_jvm_exception_context: u32,
+    ptr_current_jvm_thread_context: u32,
 }
 
 const SUPPORT_CONTEXT_BASE: u32 = 0x7fff0000;
@@ -72,18 +72,11 @@ impl KtfJvmSupport {
         let ptr_jvm_context = Allocator::alloc(core, size_of::<InitParam2>() as u32)?;
         write_generic(core, ptr_jvm_context, jvm_context)?;
 
-        let jvm_exception_context = KtfJvmExceptionContext {
-            unk: [0; 8],
-            current_java_exception_handler: 0,
-        };
-        let ptr_jvm_exception_context = Allocator::alloc(core, size_of::<KtfJvmExceptionContext>() as u32)?;
-        write_generic(core, ptr_jvm_exception_context, jvm_exception_context)?;
-
-        let context_data = KtfJvmSupportContext {
-            ptr_vtables_base: ptr_jvm_context + 12,
-            ptr_jvm_exception_context,
-        };
-        write_generic(core, SUPPORT_CONTEXT_BASE, context_data)?;
+        write_generic(
+            core,
+            SUPPORT_CONTEXT_BASE + offset_of!(KtfJvmSupportContext, ptr_vtables_base) as u32,
+            ptr_jvm_context + 12,
+        )?;
 
         let protos = [wie_wipi_java::get_protos().into(), wie_midp::get_protos().into()];
         let jvm_implementation = KtfJvmImplementation::new(core);
@@ -141,7 +134,12 @@ impl KtfJvmSupport {
             .new_class(
                 "net/wie/KtfClassLoader",
                 "(Ljava/lang/ClassLoader;Ljava/lang/String;II)V",
-                (system_class_loader, binary_name, ptr_jvm_context as i32, ptr_jvm_exception_context as i32),
+                (
+                    system_class_loader,
+                    binary_name,
+                    ptr_jvm_context as i32,
+                    (SUPPORT_CONTEXT_BASE + offset_of!(KtfJvmSupportContext, ptr_current_jvm_thread_context) as u32) as i32,
+                ),
             )
             .await
             .unwrap();
@@ -198,26 +196,44 @@ impl KtfJvmSupport {
     }
 
     pub fn current_java_exception_handler(core: &mut ArmCore) -> Result<u32> {
-        let context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
-        let exception_context: KtfJvmExceptionContext = read_generic(core, context_data.ptr_jvm_exception_context)?;
+        let ptr_thread_context = Self::current_thread_context(core)?;
+        let thread_context: KtfJvmThreadContext = read_generic(core, ptr_thread_context)?;
 
-        Ok(exception_context.current_java_exception_handler)
+        Ok(thread_context.current_java_exception_handler)
+    }
+
+    pub fn set_current_thread_context(core: &mut ArmCore, ptr_thread_context: u32) -> Result<()> {
+        write_generic(
+            core,
+            SUPPORT_CONTEXT_BASE + offset_of!(KtfJvmSupportContext, ptr_current_jvm_thread_context) as u32,
+            ptr_thread_context,
+        )
+    }
+
+    pub fn current_thread_context(core: &ArmCore) -> Result<u32> {
+        let context_data: KtfJvmSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
+
+        Ok(context_data.ptr_current_jvm_thread_context)
     }
 }
 
 #[cfg(test)]
 mod test {
     use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
-    use core::sync::atomic::{AtomicBool, Ordering};
+    use core::{
+        mem::size_of,
+        sync::atomic::{AtomicBool, Ordering},
+    };
 
+    use bytemuck::Zeroable;
     use java_constants::ClassAccessFlags;
     use jvm::{Jvm, runtime::JavaLangString};
 
     use wie_backend::{DefaultTaskRunner, System};
     use wie_core_arm::{Allocator, ArmCore};
-    use wie_util::{Result, WieError};
+    use wie_util::{Result, WieError, write_generic};
 
-    use super::{JavaArrayClassInstance, JavaClassDefinition, JavaMethod, KtfJvmSupport};
+    use super::{JavaArrayClassInstance, JavaClassDefinition, JavaMethod, KtfJvmSupport, KtfJvmThreadContext};
 
     use test_utils::TestPlatform;
 
@@ -229,6 +245,10 @@ mod test {
         let stack = Allocator::alloc(&mut core, 0x100)?;
         context.sp = stack + 0x100;
         core.restore_context(&context);
+
+        let ptr_thread_context = Allocator::alloc(&mut core, size_of::<KtfJvmThreadContext>() as u32)?;
+        write_generic(&mut core, ptr_thread_context, KtfJvmThreadContext::zeroed())?;
+        KtfJvmSupport::set_current_thread_context(&mut core, ptr_thread_context)?;
 
         let (jvm, _) = KtfJvmSupport::init(&mut core, system, None).await?;
 

--- a/wie_ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs
+++ b/wie_ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs
@@ -52,7 +52,7 @@ impl KtfClassLoader {
         parent: ClassInstanceRef<ClassLoader>,
         binary_name: ClassInstanceRef<String>,
         ptr_jvm_context: i32,
-        ptr_jvm_exception_context: i32,
+        ptr_current_jvm_thread_context: i32,
     ) -> JvmResult<()> {
         tracing::debug!("net.wie.KtfClassLoader::<init>({this:?}, {parent:?}, {binary_name:?})");
 
@@ -82,7 +82,7 @@ impl KtfClassLoader {
             &name_rust,
             cast_slice(&data),
             ptr_jvm_context as _,
-            ptr_jvm_exception_context as _,
+            ptr_current_jvm_thread_context as _,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- allocate a guest-backed KTF JVM thread context for each scheduled task
- switch the native runtime's current-context pointer whenever a task is polled
- resolve exception handlers from the active task context
- cover context restoration across cooperative task yields

## Root cause

The KTF native runtime re-reads its first initialization argument as a pointer to the current JVM thread context. Sharing one context across all cooperative tasks allowed interleaved try/catch chains to overwrite each other, so a resumed task could restore another task's exception handler.

## Impact

Exception and stack state now follow the active KTF task while remaining authoritative in guest memory. Interleaved asynchronous work no longer corrupts the exception-handler chain.

## Validation

- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test -p wie_ktf`
- `npm run build:dev`
- WASM smoke test with interleaved asynchronous exceptions
- native smoke test
