### PR TITLE
Update RustJava virtual dispatch integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "classfile"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/RustJava.git#b9da252fec16c144e844f7ff7256e0749c31fdec"
+source = "git+https://github.com/dlunch/RustJava.git#ba5797b8eb4cf376fdd63129903d319d1d7acf98"
 dependencies = [
  "java_constants",
  "nom 8.0.0",
@@ -2109,7 +2109,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "java_class_proto"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/RustJava.git#b9da252fec16c144e844f7ff7256e0749c31fdec"
+source = "git+https://github.com/dlunch/RustJava.git#ba5797b8eb4cf376fdd63129903d319d1d7acf98"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -2330,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "java_constants"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/RustJava.git#b9da252fec16c144e844f7ff7256e0749c31fdec"
+source = "git+https://github.com/dlunch/RustJava.git#ba5797b8eb4cf376fdd63129903d319d1d7acf98"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -2338,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "java_runtime"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/RustJava.git#b9da252fec16c144e844f7ff7256e0749c31fdec"
+source = "git+https://github.com/dlunch/RustJava.git#ba5797b8eb4cf376fdd63129903d319d1d7acf98"
 dependencies = [
  "async-trait",
  "bytemuck",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "jvm"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/RustJava.git#b9da252fec16c144e844f7ff7256e0749c31fdec"
+source = "git+https://github.com/dlunch/RustJava.git#ba5797b8eb4cf376fdd63129903d319d1d7acf98"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "jvm_rust"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/RustJava.git#b9da252fec16c144e844f7ff7256e0749c31fdec"
+source = "git+https://github.com/dlunch/RustJava.git#ba5797b8eb4cf376fdd63129903d319d1d7acf98"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/wie_j2me/src/emulator.rs
+++ b/wie_j2me/src/emulator.rs
@@ -92,6 +92,7 @@ impl J2MEEmulator {
             let resource_stream = jvm
                 .invoke_virtual(
                     &class_loader,
+                    "java/lang/ClassLoader",
                     "getResourceAsStream",
                     "(Ljava/lang/String;)Ljava/io/InputStream;",
                     (resource_name.clone(),),

--- a/wie_jvm_support/src/lib.rs
+++ b/wie_jvm_support/src/lib.rs
@@ -75,11 +75,14 @@ impl JvmSupport {
                     .unwrap();
 
                 let _: () = jvm
-                    .invoke_virtual(&x, "printStackTrace", "(Ljava/io/PrintWriter;)V", (print_writer,))
+                    .invoke_virtual(&x, "java/lang/Throwable", "printStackTrace", "(Ljava/io/PrintWriter;)V", (print_writer,))
                     .await
                     .unwrap();
 
-                let trace = jvm.invoke_virtual(&string_writer, "toString", "()Ljava/lang/String;", []).await.unwrap();
+                let trace = jvm
+                    .invoke_virtual(&string_writer, "java/io/StringWriter", "toString", "()Ljava/lang/String;", [])
+                    .await
+                    .unwrap();
 
                 WieError::FatalError(format!("\n{}", JavaLangString::to_rust_string(jvm, &trace).await.unwrap()))
             }

--- a/wie_ktf/src/emulator.rs
+++ b/wie_ktf/src/emulator.rs
@@ -140,6 +140,7 @@ impl KtfEmulator {
         let _main_class: Box<dyn ClassInstance> = jvm
             .invoke_virtual(
                 &class_loader,
+                "net/wie/KtfClassLoader",
                 "loadClass",
                 "(Ljava/lang/String;)Ljava/lang/Class;",
                 (main_class_name_java.clone(),),

--- a/wie_ktf/src/runtime/java/interface.rs
+++ b/wie_ktf/src/runtime/java/interface.rs
@@ -244,7 +244,7 @@ async fn register_java_string(core: &mut ArmCore, jvm: &mut Jvm, offset: u32, le
         .unwrap();
     let strings_field: ClassInstanceRef<Vector> = jvm.get_field(&ktf_class_loader, "nativeStrings", "Ljava/util/Vector;").await.unwrap();
     let _: bool = jvm
-        .invoke_virtual(&strings_field, "add", "(Ljava/lang/Object;)Z", (instance.clone(),))
+        .invoke_virtual(&strings_field, "java/util/Vector", "add", "(Ljava/lang/Object;)Z", (instance.clone(),))
         .await
         .unwrap();
 

--- a/wie_ktf/src/runtime/java/jvm_support.rs
+++ b/wie_ktf/src/runtime/java/jvm_support.rs
@@ -99,16 +99,28 @@ impl KtfJvmSupport {
             .new_class("java/util/jar/JarFile", "(Ljava/lang/String;)V", (jar_name_java,))
             .await
             .unwrap();
-        let entries: ClassInstanceRef<Enumeration> = jvm.invoke_virtual(&jar_file, "entries", "()Ljava/util/Enumeration;", []).await.unwrap();
+        let entries: ClassInstanceRef<Enumeration> = jvm
+            .invoke_virtual(&jar_file, "java/util/jar/JarFile", "entries", "()Ljava/util/Enumeration;", [])
+            .await
+            .unwrap();
 
         let binary_name = loop {
-            let has_more_elements: bool = jvm.invoke_virtual(&entries, "hasMoreElements", "()Z", []).await.unwrap();
+            let has_more_elements: bool = jvm
+                .invoke_virtual(&entries, "java/util/Enumeration", "hasMoreElements", "()Z", [])
+                .await
+                .unwrap();
             if !has_more_elements {
                 return Err(WieError::FatalError("client.bin not found".into()));
             }
 
-            let entry: ClassInstanceRef<JarEntry> = jvm.invoke_virtual(&entries, "nextElement", "()Ljava/lang/Object;", []).await.unwrap();
-            let name = jvm.invoke_virtual(&entry, "getName", "()Ljava/lang/String;", []).await.unwrap();
+            let entry: ClassInstanceRef<JarEntry> = jvm
+                .invoke_virtual(&entries, "java/util/Enumeration", "nextElement", "()Ljava/lang/Object;", [])
+                .await
+                .unwrap();
+            let name = jvm
+                .invoke_virtual(&entry, "java/util/jar/JarEntry", "getName", "()Ljava/lang/String;", [])
+                .await
+                .unwrap();
             let name_rust = JavaLangString::to_rust_string(&jvm, &name).await.unwrap();
 
             if name_rust.starts_with("client.bin") {
@@ -270,7 +282,13 @@ mod test {
             let string2 = JavaLangString::from_rust_string(&jvm, "test2").await.unwrap();
 
             let string3 = jvm
-                .invoke_virtual(&string1, "concat", "(Ljava/lang/String;)Ljava/lang/String;", [string2.into()])
+                .invoke_virtual(
+                    &string1,
+                    "java/lang/String",
+                    "concat",
+                    "(Ljava/lang/String;)Ljava/lang/String;",
+                    [string2.into()],
+                )
                 .await
                 .unwrap();
 
@@ -284,7 +302,7 @@ mod test {
 
             // test 64bit parameter passing
             let date = jvm.new_class("java/util/Date", "(J)V", (0x12345678_abcdef01i64,)).await.unwrap();
-            let time: i64 = jvm.invoke_virtual(&date, "getTime", "()J", ()).await.unwrap();
+            let time: i64 = jvm.invoke_virtual(&date, "java/util/Date", "getTime", "()J", ()).await.unwrap();
 
             assert_eq!(time, 0x12345678_abcdef01);
 

--- a/wie_ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs
+++ b/wie_ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, vec};
 
 use bytemuck::cast_slice;
 use java_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
-use java_constants::FieldAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::{Class, ClassLoader, String};
 use jvm::{
     ClassInstanceRef, Jvm, Result as JvmResult,
@@ -33,15 +33,29 @@ impl KtfClassLoader {
             parent_class: Some("java/lang/ClassLoader"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/ClassLoader;Ljava/lang/String;II)V", Self::init, Default::default()),
-                JavaMethodProto::new("findClass", "(Ljava/lang/String;)Ljava/lang/Class;", Self::find_class, Default::default()),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/ClassLoader;Ljava/lang/String;II)V",
+                    Self::init,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "findClass",
+                    "(Ljava/lang/String;)Ljava/lang/Class;",
+                    Self::find_class,
+                    MethodAccessFlags::PROTECTED,
+                ),
             ],
             fields: vec![
-                JavaFieldProto::new("fnGetClass", "I", Default::default()),
-                JavaFieldProto::new("nativeStrings", "Ljava/util/Vector;", Default::default()),
-                JavaFieldProto::new("instance", "Lnet/wie/KtfClassLoader;", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("fnGetClass", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("nativeStrings", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new(
+                    "instance",
+                    "Lnet/wie/KtfClassLoader;",
+                    FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC,
+                ),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -69,7 +83,13 @@ impl KtfClassLoader {
         // load client.bin
         let name_rust = JavaLangString::to_rust_string(jvm, &binary_name).await.unwrap();
         let data_stream = jvm
-            .invoke_virtual(&this, "getResourceAsStream", "(Ljava/lang/String;)Ljava/io/InputStream;", (binary_name,))
+            .invoke_virtual(
+                &this,
+                "net/wie/KtfClassLoader",
+                "getResourceAsStream",
+                "(Ljava/lang/String;)Ljava/io/InputStream;",
+                (binary_name,),
+            )
             .await
             .unwrap();
         let data = JavaIoInputStream::read_until_end(jvm, &data_stream).await.unwrap();

--- a/wie_ktf/src/runtime/wipi_c/context.rs
+++ b/wie_ktf/src/runtime/wipi_c/context.rs
@@ -104,7 +104,7 @@ impl WIPICContext for KtfWIPICContext {
 
         let result = match stream {
             Some(stream) => {
-                let available: i32 = match self.jvm.invoke_virtual(&stream, "available", "()I", ()).await {
+                let available: i32 = match self.jvm.invoke_virtual(&stream, "java/io/InputStream", "available", "()I", ()).await {
                     Ok(available) => available,
                     Err(err) => return Err(JvmSupport::to_wie_err(&self.jvm, err).await),
                 };

--- a/wie_lgt/src/runtime/java/classes/net/wie/clet_wrapper.rs
+++ b/wie_lgt/src/runtime/java/classes/net/wie/clet_wrapper.rs
@@ -2,7 +2,7 @@ use alloc::{string::ToString, vec};
 
 use futures::TryFutureExt;
 use java_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
-use java_constants::FieldAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -20,18 +20,18 @@ impl CletWrapper {
             parent_class: Some("org/kwis/msp/lcdui/Jlet"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("startApp", "([Ljava/lang/String;)V", Self::start_app, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("startApp", "([Ljava/lang/String;)V", Self::start_app, MethodAccessFlags::PROTECTED),
             ],
             fields: vec![
-                JavaFieldProto::new("startClet", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("pauseClet", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("resumeClet", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("destroyClet", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("paintClet", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("handleCletEvent", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("startClet", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("pauseClet", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("resumeClet", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("destroyClet", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("paintClet", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("handleCletEvent", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -60,7 +60,13 @@ impl CletWrapper {
             .await?;
         let clet_wrapper_card = jvm.new_class("net/wie/CletWrapperCard", "(II)V", (paint_clet, handle_clet_event)).await?;
         let _: () = jvm
-            .invoke_virtual(&display, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (clet_wrapper_card,))
+            .invoke_virtual(
+                &display,
+                "org/kwis/msp/lcdui/Display",
+                "pushCard",
+                "(Lorg/kwis/msp/lcdui/Card;)V",
+                (clet_wrapper_card,),
+            )
             .await?;
 
         context

--- a/wie_lgt/src/runtime/java/classes/net/wie/clet_wrapper_card.rs
+++ b/wie_lgt/src/runtime/java/classes/net/wie/clet_wrapper_card.rs
@@ -2,6 +2,7 @@ use alloc::{string::ToString, vec};
 
 use futures::TryFutureExt;
 use java_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_midp::classes::javax::microedition::lcdui::Graphics;
@@ -18,16 +19,16 @@ impl CletWrapperCard {
             parent_class: Some("org/kwis/msp/lcdui/Card"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(II)V", Self::init, Default::default()),
-                JavaMethodProto::new("paint", "(Lorg/kwis/msp/lcdui/Graphics;)V", Self::paint, Default::default()),
-                JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, Default::default()),
-                JavaMethodProto::new("notifyEvent", "(III)V", Self::notify_event, Default::default()),
+                JavaMethodProto::new("<init>", "(II)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("paint", "(Lorg/kwis/msp/lcdui/Graphics;)V", Self::paint, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("notifyEvent", "(III)V", Self::notify_event, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("paintClet", "I", Default::default()),
-                JavaFieldProto::new("handleCletEvent", "I", Default::default()),
+                JavaFieldProto::new("paintClet", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("handleCletEvent", "I", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_lgt/src/runtime/java/classes/net/wie/lgt_class_loader.rs
+++ b/wie_lgt/src/runtime/java/classes/net/wie/lgt_class_loader.rs
@@ -6,7 +6,7 @@ use alloc::{
 use core::mem::size_of;
 
 use java_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
-use java_constants::FieldAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::{
     lang::{Class, ClassLoader, String},
     util::Vector,
@@ -31,15 +31,24 @@ impl LgtClassLoader {
             parent_class: Some("java/lang/ClassLoader"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/ClassLoader;I)V", Self::init, Default::default()),
-                JavaMethodProto::new("findClass", "(Ljava/lang/String;)Ljava/lang/Class;", Self::find_class, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/ClassLoader;I)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "findClass",
+                    "(Ljava/lang/String;)Ljava/lang/Class;",
+                    Self::find_class,
+                    MethodAccessFlags::PROTECTED,
+                ),
             ],
             fields: vec![
-                JavaFieldProto::new("generatedClasses", "I", Default::default()),
-                JavaFieldProto::new("nativeStrings", "Ljava/util/Vector;", Default::default()),
-                JavaFieldProto::new("instance", "Lnet/wie/LgtClassLoader;", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("generatedClasses", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("nativeStrings", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new(
+                    "instance",
+                    "Lnet/wie/LgtClassLoader;",
+                    FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC,
+                ),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_lgt/src/runtime/java/interface.rs
+++ b/wie_lgt/src/runtime/java/interface.rs
@@ -188,7 +188,7 @@ async fn java_string_literal(core: &mut ArmCore, jvm: &mut Jvm, _runtime_context
         .await
         .map_err(|JavaError::JavaException(instance)| WieError::JavaException(LgtJvmSupport::class_instance_raw(&*instance)))?;
     let _: bool = jvm
-        .invoke_virtual(&native_strings, "add", "(Ljava/lang/Object;)Z", (value.clone(),))
+        .invoke_virtual(&native_strings, "java/util/Vector", "add", "(Ljava/lang/Object;)Z", (value.clone(),))
         .await
         .map_err(|JavaError::JavaException(instance)| WieError::JavaException(LgtJvmSupport::class_instance_raw(&*instance)))?;
     let value = LgtJvmSupport::class_instance_raw(&*value);

--- a/wie_lgt/src/runtime/java/jvm_support.rs
+++ b/wie_lgt/src/runtime/java/jvm_support.rs
@@ -282,7 +282,7 @@ mod tests {
     };
 
     use java_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
-    use java_constants::FieldAccessFlags;
+    use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
     use java_runtime::classes::java::lang::String;
     use jvm::{Array, ClassDefinition, ClassInstance, ClassInstanceRef, JavaValue, Jvm, Method, Result as JvmResult, runtime::JavaLangString};
     use wipi_types::lgt::java::{
@@ -367,15 +367,21 @@ mod tests {
             let first = JavaLangString::from_rust_string(&jvm, "lgt").await.unwrap();
             let second = JavaLangString::from_rust_string(&jvm, "-native").await.unwrap();
             let combined = jvm
-                .invoke_virtual(&first, "concat", "(Ljava/lang/String;)Ljava/lang/String;", [second.into()])
+                .invoke_virtual(
+                    &first,
+                    "java/lang/String",
+                    "concat",
+                    "(Ljava/lang/String;)Ljava/lang/String;",
+                    [second.into()],
+                )
                 .await
                 .unwrap();
             assert_eq!(JavaLangString::to_rust_string(&jvm, &combined).await.unwrap(), "lgt-native");
-            let invalid_char: JvmResult<u16> = jvm.invoke_virtual(&first, "charAt", "(I)C", (i32::MAX,)).await;
+            let invalid_char: JvmResult<u16> = jvm.invoke_virtual(&first, "java/lang/String", "charAt", "(I)C", (i32::MAX,)).await;
             assert!(invalid_char.is_err());
 
             let date: Box<dyn ClassInstance> = jvm.new_class("java/util/Date", "(J)V", (0x12345678_abcdef01i64,)).await.unwrap();
-            let time: i64 = jvm.invoke_virtual(&date, "getTime", "()J", ()).await.unwrap();
+            let time: i64 = jvm.invoke_virtual(&date, "java/util/Date", "getTime", "()J", ()).await.unwrap();
             assert_eq!(time, 0x12345678_abcdef01);
 
             let native_date = date.as_any().downcast_ref::<JavaClassInstance>().unwrap();
@@ -534,7 +540,10 @@ mod tests {
                 .await
                 .unwrap();
             let chars = jvm.instantiate_array("C", input.len()).await.unwrap();
-            let read: i32 = jvm.invoke_virtual(&reader, "read", "([C)I", (chars.clone(),)).await.unwrap();
+            let read: i32 = jvm
+                .invoke_virtual(&reader, "java/io/Reader", "read", "([C)I", (chars.clone(),))
+                .await
+                .unwrap();
             assert!(read > 0 && read as usize <= input.len());
             assert_eq!(
                 jvm.load_array::<u16>(&chars, 0, read as usize).await.unwrap(),
@@ -548,9 +557,9 @@ mod tests {
                         name: "net/wie/test/Base",
                         parent_class: Some("java/lang/Object"),
                         interfaces: vec![],
-                        methods: vec![JavaMethodProto::new("value", "()I", base_value, Default::default())],
+                        methods: vec![JavaMethodProto::new("value", "()I", base_value, MethodAccessFlags::PUBLIC)],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -569,9 +578,9 @@ mod tests {
                         name: "net/wie/test/Child",
                         parent_class: Some("net/wie/test/Base"),
                         interfaces: vec![],
-                        methods: vec![JavaMethodProto::new("value", "()I", child_value, Default::default())],
+                        methods: vec![JavaMethodProto::new("value", "()I", child_value, MethodAccessFlags::PUBLIC)],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -580,7 +589,7 @@ mod tests {
             jvm.register_class(child_class, None).await.unwrap();
 
             let child = jvm.instantiate_class("net/wie/test/Child").await.unwrap();
-            let value: i32 = jvm.invoke_virtual(&child, "value", "()I", ()).await.unwrap();
+            let value: i32 = jvm.invoke_virtual(&child, "net/wie/test/Base", "value", "()I", ()).await.unwrap();
             assert_eq!(value, 2);
 
             let interface_class = implementation
@@ -592,7 +601,7 @@ mod tests {
                         interfaces: vec!["java/lang/Runnable", "java/lang/Cloneable"],
                         methods: vec![],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -617,13 +626,13 @@ mod tests {
                         parent_class: Some("org/kwis/msp/lcdui/Jlet"),
                         interfaces: vec![],
                         methods: vec![
-                            JavaMethodProto::new("startApp", "([Ljava/lang/String;)V", jlet_start, Default::default()),
-                            JavaMethodProto::new("pauseApp", "()V", jlet_pause, Default::default()),
-                            JavaMethodProto::new("resumeApp", "()V", jlet_resume, Default::default()),
-                            JavaMethodProto::new("destroyApp", "(Z)V", jlet_destroy, Default::default()),
+                            JavaMethodProto::new("startApp", "([Ljava/lang/String;)V", jlet_start, MethodAccessFlags::PROTECTED),
+                            JavaMethodProto::new("pauseApp", "()V", jlet_pause, MethodAccessFlags::PROTECTED),
+                            JavaMethodProto::new("resumeApp", "()V", jlet_resume, MethodAccessFlags::PROTECTED),
+                            JavaMethodProto::new("destroyApp", "(Z)V", jlet_destroy, MethodAccessFlags::PROTECTED),
                         ],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -651,9 +660,9 @@ mod tests {
                         name: "net/wie/test/DeepJlet",
                         parent_class: Some("net/wie/test/DirectJlet"),
                         interfaces: vec![],
-                        methods: vec![JavaMethodProto::new("pauseApp", "()V", deep_jlet_pause, Default::default())],
+                        methods: vec![JavaMethodProto::new("pauseApp", "()V", deep_jlet_pause, MethodAccessFlags::PROTECTED)],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -687,11 +696,11 @@ mod tests {
                         interfaces: vec![],
                         methods: vec![],
                         fields: vec![
-                            JavaFieldProto::new("word", "I", FieldAccessFlags::STATIC),
-                            JavaFieldProto::new("wide", "J", FieldAccessFlags::STATIC),
-                            JavaFieldProto::new("reference", "Ljava/lang/String;", FieldAccessFlags::STATIC),
+                            JavaFieldProto::new("word", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                            JavaFieldProto::new("wide", "J", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                            JavaFieldProto::new("reference", "Ljava/lang/String;", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
                         ],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -782,8 +791,8 @@ mod tests {
                         parent_class: Some("net/wie/test/StaticStorage"),
                         interfaces: vec![],
                         methods: vec![],
-                        fields: vec![JavaFieldProto::new("word", "I", FieldAccessFlags::STATIC)],
-                        access_flags: Default::default(),
+                        fields: vec![JavaFieldProto::new("word", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC)],
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -837,14 +846,14 @@ mod tests {
                         interfaces: vec![],
                         methods: vec![],
                         fields: vec![
-                            JavaFieldProto::new("f0", "I", Default::default()),
-                            JavaFieldProto::new("f1", "I", Default::default()),
-                            JavaFieldProto::new("f2", "I", Default::default()),
-                            JavaFieldProto::new("f3", "I", Default::default()),
-                            JavaFieldProto::new("f4", "I", Default::default()),
-                            JavaFieldProto::new("f5", "I", Default::default()),
+                            JavaFieldProto::new("f0", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("f1", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("f2", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("f3", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("f4", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("f5", "I", FieldAccessFlags::PRIVATE),
                         ],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -860,11 +869,11 @@ mod tests {
                         interfaces: vec![],
                         methods: vec![],
                         fields: vec![
-                            JavaFieldProto::new("own0", "I", Default::default()),
-                            JavaFieldProto::new("own1", "I", Default::default()),
-                            JavaFieldProto::new("static0", "I", FieldAccessFlags::STATIC),
+                            JavaFieldProto::new("own0", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("own1", "I", FieldAccessFlags::PRIVATE),
+                            JavaFieldProto::new("static0", "I", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
                         ],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -924,13 +933,13 @@ mod tests {
                         parent_class: Some("org/kwis/msp/lcdui/JletWrapper"),
                         interfaces: vec![],
                         methods: vec![
-                            JavaMethodProto::new("startApp", "([Ljava/lang/String;)V", jlet_start, Default::default()),
-                            JavaMethodProto::new("pauseApp", "()V", jlet_pause, Default::default()),
-                            JavaMethodProto::new("resumeApp", "()V", jlet_resume, Default::default()),
-                            JavaMethodProto::new("destroyApp", "(Z)V", jlet_destroy, Default::default()),
+                            JavaMethodProto::new("startApp", "([Ljava/lang/String;)V", jlet_start, MethodAccessFlags::PROTECTED),
+                            JavaMethodProto::new("pauseApp", "()V", jlet_pause, MethodAccessFlags::PROTECTED),
+                            JavaMethodProto::new("resumeApp", "()V", jlet_resume, MethodAccessFlags::PROTECTED),
+                            JavaMethodProto::new("destroyApp", "(Z)V", jlet_destroy, MethodAccessFlags::PROTECTED),
                         ],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -1011,9 +1020,9 @@ mod tests {
                         name: "net/wie/test/GeneratedInputStream",
                         parent_class: Some("java/io/InputStream"),
                         interfaces: vec![],
-                        methods: vec![JavaMethodProto::new("read", "()I", base_value, Default::default())],
+                        methods: vec![JavaMethodProto::new("read", "()I", base_value, MethodAccessFlags::PUBLIC)],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -1044,7 +1053,7 @@ mod tests {
             let linked_definition = linked_class.definition.as_any().downcast_ref::<super::JavaClassDefinition>().unwrap();
             assert_ne!(linked_definition.descriptor()?.ptr_methods, 0);
             let instance = jvm.instantiate_class("net/wie/test/GeneratedInputStream").await.unwrap();
-            let value: i32 = jvm.invoke_virtual(&instance, "read", "()I", ()).await.unwrap();
+            let value: i32 = jvm.invoke_virtual(&instance, "java/io/InputStream", "read", "()I", ()).await.unwrap();
             assert_eq!(value, 1);
 
             let generated_class = implementation
@@ -1054,9 +1063,9 @@ mod tests {
                         name: "net/wie/test/GeneratedRunnable",
                         parent_class: Some("java/lang/Object"),
                         interfaces: vec!["java/lang/Runnable"],
-                        methods: vec![JavaMethodProto::new("run", "()V", jlet_pause, Default::default())],
+                        methods: vec![JavaMethodProto::new("run", "()V", jlet_pause, MethodAccessFlags::PUBLIC)],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(()),
                 )
@@ -1120,7 +1129,9 @@ mod tests {
             let runnable_definition = runnable.definition.as_any().downcast_ref::<super::JavaClassDefinition>().unwrap();
             assert_eq!(reference.ptr_class_or_name, runnable_definition.ptr_raw);
             let instance = jvm.instantiate_class("net/wie/test/GeneratedRunnable").await.unwrap();
-            jvm.invoke_virtual::<_, ()>(&instance, "run", "()V", ()).await.unwrap();
+            jvm.invoke_virtual::<_, ()>(&instance, "java/lang/Runnable", "run", "()V", ())
+                .await
+                .unwrap();
 
             done_clone.store(true, Ordering::Relaxed);
             Ok(())

--- a/wie_lgt/src/runtime/java/jvm_support/method.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/method.rs
@@ -257,7 +257,7 @@ mod tests {
     };
 
     use java_class_proto::{JavaClassProto, JavaMethodProto};
-    use java_constants::MethodAccessFlags;
+    use java_constants::{ClassAccessFlags, MethodAccessFlags};
     use jvm::{JavaError, JavaValue, Jvm, Method, Result as JvmResult, runtime::JavaLangString};
     use spin::Mutex;
 
@@ -341,9 +341,14 @@ mod tests {
                         name: "net/wie/test/RustBridge",
                         parent_class: Some("java/lang/Object"),
                         interfaces: vec![],
-                        methods: vec![JavaMethodProto::new("wide", "(JD)J", rust_wide_bridge, MethodAccessFlags::STATIC)],
+                        methods: vec![JavaMethodProto::new(
+                            "wide",
+                            "(JD)J",
+                            rust_wide_bridge,
+                            MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                        )],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC,
                     },
                     Box::new(observed.clone()),
                 )
@@ -420,9 +425,13 @@ mod tests {
                         name: "net/wie/test/AbstractMethod",
                         parent_class: Some("java/lang/Object"),
                         interfaces: vec![],
-                        methods: vec![JavaMethodProto::new_abstract("call", "()V", MethodAccessFlags::ABSTRACT)],
+                        methods: vec![JavaMethodProto::new_abstract(
+                            "call",
+                            "()V",
+                            MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                        )],
                         fields: vec![],
-                        access_flags: Default::default(),
+                        access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
                     },
                     Box::new(()),
                 )

--- a/wie_lgt/src/runtime/wipi_c/context.rs
+++ b/wie_lgt/src/runtime/wipi_c/context.rs
@@ -92,7 +92,11 @@ impl WIPICContext for LgtWIPICContext {
         let stream = JavaLangClassLoader::get_resource_as_stream(&self.jvm, &class_loader, name).await.unwrap();
 
         if let Some(stream) = stream {
-            let available: i32 = self.jvm.invoke_virtual(&stream, "available", "()I", ()).await.unwrap();
+            let available: i32 = self
+                .jvm
+                .invoke_virtual(&stream, "java/io/InputStream", "available", "()I", ())
+                .await
+                .unwrap();
             return Ok(Some(available as _));
         }
         self.jvm.collect_garbage().unwrap();

--- a/wie_midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -18,13 +19,18 @@ impl Alert {
             parent_class: Some("javax/microedition/lcdui/Screen"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("setType", "(Ljavax/microedition/lcdui/AlertType;)V", Self::set_type, Default::default()),
-                JavaMethodProto::new("setTimeout", "(I)V", Self::set_timeout, Default::default()),
-                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "setType",
+                    "(Ljavax/microedition/lcdui/AlertType;)V",
+                    Self::set_type,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("setTimeout", "(I)V", Self::set_timeout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/alert_type.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/alert_type.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::FieldAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -16,17 +16,37 @@ impl AlertType {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PRIVATE),
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
             ],
             fields: vec![
-                JavaFieldProto::new("ALARM", "Ljavax/microedition/lcdui/AlertType;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("CONFIRMATION", "Ljavax/microedition/lcdui/AlertType;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("ERROR", "Ljavax/microedition/lcdui/AlertType;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("INFO", "Ljavax/microedition/lcdui/AlertType;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("WARNING", "Ljavax/microedition/lcdui/AlertType;", FieldAccessFlags::STATIC),
+                JavaFieldProto::new(
+                    "ALARM",
+                    "Ljavax/microedition/lcdui/AlertType;",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "CONFIRMATION",
+                    "Ljavax/microedition/lcdui/AlertType;",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "ERROR",
+                    "Ljavax/microedition/lcdui/AlertType;",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "INFO",
+                    "Ljavax/microedition/lcdui/AlertType;",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "WARNING",
+                    "Ljavax/microedition/lcdui/AlertType;",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/canvas.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/canvas.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::ClassAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -21,28 +21,32 @@ impl Canvas {
             parent_class: Some("javax/microedition/lcdui/Displayable"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("repaint", "()V", Self::repaint, Default::default()),
-                JavaMethodProto::new("repaint", "(IIII)V", Self::repaint_with_area, Default::default()),
-                JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, Default::default()),
-                JavaMethodProto::new_abstract("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Default::default()),
-                JavaMethodProto::new("getGameAction", "(I)I", Self::get_game_action, Default::default()),
-                JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, Default::default()),
-                JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, Default::default()),
-                JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, Default::default()),
-                JavaMethodProto::new("setFullScreenMode", "(Z)V", Self::set_full_screen_mode, Default::default()),
-                JavaMethodProto::new("isDoubleBuffered", "()Z", Self::is_double_buffered, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("repaint", "()V", Self::repaint, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("repaint", "(IIII)V", Self::repaint_with_area, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new_abstract(
+                    "paint",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new("getGameAction", "(I)I", Self::get_game_action, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("setFullScreenMode", "(Z)V", Self::set_full_screen_mode, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isDoubleBuffered", "()Z", Self::is_double_buffered, MethodAccessFlags::PUBLIC),
                 // wie private methods
-                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, Default::default()),
+                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "handlePaintEvent",
                     "(Ljavax/microedition/lcdui/Graphics;)V",
                     Self::handle_paint_event,
-                    Default::default(),
+                    MethodAccessFlags::empty(),
                 ),
             ],
             fields: vec![],
-            access_flags: ClassAccessFlags::ABSTRACT,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 
@@ -60,7 +64,9 @@ impl Canvas {
         tracing::debug!("javax.microedition.lcdui.Canvas::repaint({this:?})");
 
         let display = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let _: () = jvm.invoke_virtual(&display, "repaint", "(IIII)V", (0, 0, -1, -1)).await?;
+        let _: () = jvm
+            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
+            .await?;
 
         Ok(())
     }
@@ -77,7 +83,9 @@ impl Canvas {
         tracing::debug!("javax.microedition.lcdui.Canvas::repaint({this:?}, {x}, {y}, {width}, {height})");
 
         let display = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let _: () = jvm.invoke_virtual(&display, "repaint", "(IIII)V", (x, y, width, height)).await?;
+        let _: () = jvm
+            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (x, y, width, height))
+            .await?;
 
         Ok(())
     }
@@ -87,7 +95,9 @@ impl Canvas {
 
         let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         if !display.is_null() {
-            let _: () = jvm.invoke_virtual(&display, "handlePaintEvent", "()V", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
         }
 
         Ok(())
@@ -136,7 +146,9 @@ impl Canvas {
 
         let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         if !display.is_null() {
-            let _: () = jvm.invoke_virtual(&display, "setFullscreen", "(Z)V", (mode,)).await?;
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "setFullscreen", "(Z)V", (mode,))
+                .await?;
         }
 
         jvm.put_field(&mut this, "isInFullScreenMode", "Z", mode).await?;
@@ -160,9 +172,18 @@ impl Canvas {
         };
 
         let _: () = match event_type {
-            KeyboardEventType::KeyPressed => jvm.invoke_virtual(&this, "keyPressed", "(I)V", (code,)).await,
-            KeyboardEventType::KeyReleased => jvm.invoke_virtual(&this, "keyReleased", "(I)V", (code,)).await,
-            KeyboardEventType::KeyRepeated => jvm.invoke_virtual(&this, "keyRepeated", "(I)V", (code,)).await,
+            KeyboardEventType::KeyPressed => {
+                jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "keyPressed", "(I)V", (code,))
+                    .await
+            }
+            KeyboardEventType::KeyReleased => {
+                jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "keyReleased", "(I)V", (code,))
+                    .await
+            }
+            KeyboardEventType::KeyRepeated => {
+                jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "keyRepeated", "(I)V", (code,))
+                    .await
+            }
             _ => unimplemented!(),
         }?;
 
@@ -178,7 +199,13 @@ impl Canvas {
         tracing::debug!("javax.microedition.lcdui.Canvas::handlePaintEvent({this:?}, {graphics:?})");
 
         let _: () = jvm
-            .invoke_virtual(&this, "paint", "(Ljavax/microedition/lcdui/Graphics;)V", (graphics,))
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Canvas",
+                "paint",
+                "(Ljavax/microedition/lcdui/Graphics;)V",
+                (graphics,),
+            )
             .await?;
 
         Ok(())

--- a/wie_midp/src/classes/javax/microedition/lcdui/choice_group.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/choice_group.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -18,16 +19,16 @@ impl ChoiceGroup {
             parent_class: Some("javax/microedition/lcdui/Item"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "<init>",
                     "(Ljava/lang/String;I[Ljava/lang/String;[Ljavax/microedition/lcdui/Image;)V",
                     Self::init_with_elements,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/command.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/command.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -16,17 +17,17 @@ impl Command {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;II)V", Self::init, Default::default()),
-                JavaMethodProto::new("getLabel", "()Ljava/lang/String;", Self::get_label, Default::default()),
-                JavaMethodProto::new("getCommandType", "()I", Self::get_command_type, Default::default()),
-                JavaMethodProto::new("getPriority", "()I", Self::get_priority, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;II)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getLabel", "()Ljava/lang/String;", Self::get_label, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getCommandType", "()I", Self::get_command_type, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getPriority", "()I", Self::get_priority, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("label", "Ljava/lang/String;", Default::default()),
-                JavaFieldProto::new("commandType", "I", Default::default()),
-                JavaFieldProto::new("priority", "I", Default::default()),
+                JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commandType", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("priority", "I", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/command_listener.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/command_listener.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
 
-use java_constants::ClassAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use wie_jvm_support::WieJavaClassProto;
 
 // interface javax.microedition.lcdui.CommandListener
@@ -17,10 +17,10 @@ impl CommandListener {
             methods: vec![JavaMethodProto::new_abstract(
                 "commandAction",
                 "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
-                Default::default(),
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
             )],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/display.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::Runnable;
 use jvm::{ClassInstanceRef, JavaError, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -22,47 +22,47 @@ impl Display {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "setCurrent",
                     "(Ljavax/microedition/lcdui/Displayable;)V",
                     Self::set_current,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "getCurrent",
                     "()Ljavax/microedition/lcdui/Displayable;",
                     Self::get_current,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
-                JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, Default::default()),
-                JavaMethodProto::new("vibrate", "(I)Z", Self::vibrate, Default::default()),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("vibrate", "(I)Z", Self::vibrate, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getDisplay",
                     "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
                     Self::get_display,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 // wie private methods...
-                JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, Default::default()),
-                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, Default::default()),
-                JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, Default::default()),
-                JavaMethodProto::new("setFullscreen", "(Z)V", Self::set_fullscreen, Default::default()),
-                JavaMethodProto::new("repaint", "(IIII)V", Self::repaint, Default::default()),
-                JavaMethodProto::new("disablePaint", "()V", Self::disable_paint, Default::default()),
+                JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new("setFullscreen", "(Z)V", Self::set_fullscreen, MethodAccessFlags::empty()),
+                JavaMethodProto::new("repaint", "(IIII)V", Self::repaint, MethodAccessFlags::empty()),
+                JavaMethodProto::new("disablePaint", "()V", Self::disable_paint, MethodAccessFlags::empty()),
             ],
             fields: vec![
-                JavaFieldProto::new("isInFullScreenMode", "Z", Default::default()),
-                JavaFieldProto::new("currentDisplayable", "Ljavax/microedition/lcdui/Displayable;", Default::default()),
-                JavaFieldProto::new("screenImage", "Ljavax/microedition/lcdui/Image;", Default::default()),
-                JavaFieldProto::new("screenGraphics", "Ljavax/microedition/lcdui/Graphics;", Default::default()),
-                JavaFieldProto::new("width", "I", Default::default()),
-                JavaFieldProto::new("height", "I", Default::default()),
-                JavaFieldProto::new("paintDisabled", "Z", Default::default()),
+                JavaFieldProto::new("isInFullScreenMode", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("currentDisplayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("screenImage", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("screenGraphics", "Ljavax/microedition/lcdui/Graphics;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("width", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("height", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("paintDisabled", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -89,7 +89,13 @@ impl Display {
             )
             .await?;
         let screen_graphics: ClassInstanceRef<Graphics> = jvm
-            .invoke_virtual(&screen_image, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+            .invoke_virtual(
+                &screen_image,
+                "javax/microedition/lcdui/Image",
+                "getGraphics",
+                "()Ljavax/microedition/lcdui/Graphics;",
+                (),
+            )
             .await?;
 
         jvm.put_field(&mut this, "screenImage", "Ljavax/microedition/lcdui/Image;", screen_image)
@@ -128,7 +134,7 @@ impl Display {
             .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
             .await?;
         let _: () = jvm
-            .invoke_virtual(&event_queue, "callSerially", "(Ljava/lang/Runnable;)V", (event,))
+            .invoke_virtual(&event_queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (event,))
             .await?;
 
         Ok(())
@@ -148,7 +154,13 @@ impl Display {
 
         if !old_displayable.is_null() {
             let _: () = jvm
-                .invoke_virtual(&old_displayable, "setDisplay", "(Ljavax/microedition/lcdui/Display;)V", (None,))
+                .invoke_virtual(
+                    &old_displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "setDisplay",
+                    "(Ljavax/microedition/lcdui/Display;)V",
+                    (None,),
+                )
                 .await?;
         }
 
@@ -161,7 +173,13 @@ impl Display {
         .await?;
 
         let _: () = jvm
-            .invoke_virtual(&displayable, "setDisplay", "(Ljavax/microedition/lcdui/Display;)V", (this.clone(),))
+            .invoke_virtual(
+                &displayable,
+                "javax/microedition/lcdui/Displayable",
+                "setDisplay",
+                "(Ljavax/microedition/lcdui/Display;)V",
+                (this.clone(),),
+            )
             .await?;
 
         let fullscreen_mode: bool = jvm.get_field(&displayable, "isInFullScreenMode", "Z").await?;
@@ -170,7 +188,9 @@ impl Display {
         let width: i32 = jvm.get_field(&this, "width", "I").await?;
         let height: i32 = jvm.get_field(&this, "height", "I").await?;
 
-        let _: () = jvm.invoke_virtual(&this, "repaint", "(IIII)V", (0, 0, width, height)).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, width, height))
+            .await?;
 
         Ok(())
     }
@@ -228,7 +248,13 @@ impl Display {
 
         if !current_displayable.is_null() {
             let result: JvmResult<()> = jvm
-                .invoke_virtual(&current_displayable, "handleKeyEvent", "(II)V", (event_type, code))
+                .invoke_virtual(
+                    &current_displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "handleKeyEvent",
+                    "(II)V",
+                    (event_type, code),
+                )
                 .await;
 
             if let Err(x) = result {
@@ -254,12 +280,15 @@ impl Display {
             let result: JvmResult<()> = jvm
                 .invoke_virtual(
                     &current_displayable,
+                    "javax/microedition/lcdui/Displayable",
                     "handlePaintEvent",
                     "(Ljavax/microedition/lcdui/Graphics;)V",
                     (screen_graphics.clone(),),
                 )
                 .await;
-            let _: () = jvm.invoke_virtual(&screen_graphics, "reset", "()V", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
+                .await?;
 
             if let Err(x) = result {
                 Self::handle_exception(jvm, x).await?;
@@ -301,7 +330,13 @@ impl Display {
 
         if !current_displayable.is_null() {
             let result: JvmResult<()> = jvm
-                .invoke_virtual(&current_displayable, "handleNotifyEvent", "(III)V", (r#type, param1, param2))
+                .invoke_virtual(
+                    &current_displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "handleNotifyEvent",
+                    "(III)V",
+                    (r#type, param1, param2),
+                )
                 .await;
 
             if let Err(x) = result {
@@ -329,10 +364,12 @@ impl Display {
             .await?;
 
         let _: () = jvm
-            .invoke_virtual(&x, "printStackTrace", "(Ljava/io/PrintWriter;)V", (print_writer,))
+            .invoke_virtual(&x, "java/lang/Throwable", "printStackTrace", "(Ljava/io/PrintWriter;)V", (print_writer,))
             .await?;
 
-        let trace = jvm.invoke_virtual(&string_writer, "toString", "()Ljava/lang/String;", []).await?;
+        let trace = jvm
+            .invoke_virtual(&string_writer, "java/io/StringWriter", "toString", "()Ljava/lang/String;", [])
+            .await?;
         let trace = JavaLangString::to_rust_string(jvm, &trace).await?;
 
         tracing::warn!("Exception while event handling: {trace}");

--- a/wie_midp/src/classes/javax/microedition/lcdui/displayable.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/displayable.rs
@@ -1,6 +1,7 @@
 use alloc::{format, vec};
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -17,42 +18,42 @@ impl Displayable {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
                 JavaMethodProto::new(
                     "addCommand",
                     "(Ljavax/microedition/lcdui/Command;)V",
                     Self::add_command,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "setCommandListener",
                     "(Ljavax/microedition/lcdui/CommandListener;)V",
                     Self::set_command_listener,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
                 // wie private methods...
                 JavaMethodProto::new(
                     "setDisplay",
                     "(Ljavax/microedition/lcdui/Display;)V",
                     Self::set_display,
-                    Default::default(),
+                    MethodAccessFlags::empty(),
                 ),
-                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, Default::default()),
+                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "handlePaintEvent",
                     "(Ljavax/microedition/lcdui/Graphics;)V",
                     Self::handle_paint_event,
-                    Default::default(),
+                    MethodAccessFlags::empty(),
                 ),
-                JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, Default::default()),
+                JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::PROTECTED),
             ],
             fields: vec![
-                JavaFieldProto::new("currentDisplay", "Ljavax/microedition/lcdui/Display;", Default::default()),
-                JavaFieldProto::new("isInFullScreenMode", "Z", Default::default()),
+                JavaFieldProto::new("currentDisplay", "Ljavax/microedition/lcdui/Display;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("isInFullScreenMode", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 
@@ -109,7 +110,8 @@ impl Displayable {
         let width = if display.is_null() {
             context.system().platform().screen().width() as i32
         } else {
-            jvm.invoke_virtual(&display, "getWidth", "()I", ()).await?
+            jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "getWidth", "()I", ())
+                .await?
         };
 
         Ok(width)
@@ -122,7 +124,8 @@ impl Displayable {
         let height = if display.is_null() {
             context.system().platform().screen().height() as i32
         } else {
-            jvm.invoke_virtual(&display, "getHeight", "()I", ()).await?
+            jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "getHeight", "()I", ())
+                .await?
         };
 
         Ok(height)

--- a/wie_midp/src/classes/javax/microedition/lcdui/font.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/font.rs
@@ -1,7 +1,7 @@
 use alloc::{string::String as RustString, vec};
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{FieldAccessFlags, MethodAccessFlags};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, JavaChar, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -19,38 +19,83 @@ impl Font {
             interfaces: vec![],
             methods: vec![
                 JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
-                JavaMethodProto::new("stringWidth", "(Ljava/lang/String;)I", Self::string_width, Default::default()),
-                JavaMethodProto::new("substringWidth", "(Ljava/lang/String;II)I", Self::substring_width, Default::default()),
-                JavaMethodProto::new("charWidth", "(C)I", Self::char_width, Default::default()),
-                JavaMethodProto::new("charsWidth", "([CII)I", Self::chars_width, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty()),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("stringWidth", "(Ljava/lang/String;)I", Self::string_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "substringWidth",
+                    "(Ljava/lang/String;II)I",
+                    Self::substring_width,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("charWidth", "(C)I", Self::char_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("charsWidth", "([CII)I", Self::chars_width, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getFont",
                     "(III)Ljavax/microedition/lcdui/Font;",
                     Self::get_font,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "getDefaultFont",
                     "()Ljavax/microedition/lcdui/Font;",
                     Self::get_default_font,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("FACE_SYSTEM", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("FACE_PROPORTIONAL", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_PLAIN", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_BOLD", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_ITALIC", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_UNDERLINED", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("SIZE_SMALL", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("SIZE_MEDIUM", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("SIZE_LARGE", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new(
+                    "FACE_SYSTEM",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "FACE_MONOSPACE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "FACE_PROPORTIONAL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "STYLE_PLAIN",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "STYLE_BOLD",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "STYLE_ITALIC",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "STYLE_UNDERLINED",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIZE_SMALL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIZE_MEDIUM",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "SIZE_LARGE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/form.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -18,12 +19,12 @@ impl Form {
             parent_class: Some("javax/microedition/lcdui/Screen"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("append", "(Ljavax/microedition/lcdui/Item;)I", Self::append, Default::default()),
-                JavaMethodProto::new("append", "(Ljava/lang/String;)I", Self::append_string, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("append", "(Ljavax/microedition/lcdui/Item;)I", Self::append, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("append", "(Ljava/lang/String;)I", Self::append_string, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/game/game_canvas.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/game/game_canvas.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -17,22 +18,27 @@ impl GameCanvas {
             parent_class: Some("javax/microedition/lcdui/Canvas"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Z)V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "(Z)V", Self::init, MethodAccessFlags::PROTECTED),
                 JavaMethodProto::new(
                     "getGraphics",
                     "()Ljavax/microedition/lcdui/Graphics;",
                     Self::get_graphics,
-                    Default::default(),
+                    MethodAccessFlags::PROTECTED,
                 ),
-                JavaMethodProto::new("flushGraphics", "()V", Self::flush_graphics, Default::default()),
-                JavaMethodProto::new("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Self::paint, Default::default()),
+                JavaMethodProto::new("flushGraphics", "()V", Self::flush_graphics, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "paint",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    Self::paint,
+                    MethodAccessFlags::PROTECTED,
+                ),
             ],
             fields: vec![JavaFieldProto::new(
                 "offscreenImage",
                 "Ljavax/microedition/lcdui/Image;",
-                Default::default(),
+                FieldAccessFlags::PRIVATE,
             )],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -41,8 +47,12 @@ impl GameCanvas {
 
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Canvas", "<init>", "()V", ()).await?;
 
-        let width: i32 = jvm.invoke_virtual(&this, "getWidth", "()I", ()).await?;
-        let height: i32 = jvm.invoke_virtual(&this, "getHeight", "()I", ()).await?;
+        let width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await?;
+        let height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await?;
 
         let image: ClassInstanceRef<Image> = jvm
             .invoke_static(
@@ -77,7 +87,7 @@ impl GameCanvas {
     async fn flush_graphics(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.game.GameCanvas::flushGraphics({this:?})");
 
-        let _: () = jvm.invoke_virtual(&this, "repaint", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
 
         Ok(())
     }
@@ -88,7 +98,13 @@ impl GameCanvas {
         let offscreen_image: ClassInstanceRef<Image> = jvm.get_field(&this, "offscreenImage", "Ljavax/microedition/lcdui/Image;").await?;
 
         let _: () = jvm
-            .invoke_virtual(&g, "drawImage", "(Ljavax/microedition/lcdui/Image;III)V", (offscreen_image, 0, 0, 0))
+            .invoke_virtual(
+                &g,
+                "javax/microedition/lcdui/Graphics",
+                "drawImage",
+                "(Ljavax/microedition/lcdui/Image;III)V",
+                (offscreen_image, 0, 0, 0),
+            )
             .await?;
 
         Ok(())

--- a/wie_midp/src/classes/javax/microedition/lcdui/graphics.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/graphics.rs
@@ -5,7 +5,7 @@ use bytemuck::cast_vec;
 use jvm::{Array, ClassInstanceRef, JavaChar, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto, TypeConverter};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 
 use wie_backend::canvas::{ArgbPixel, Canvas as BackendCanvas, Clip, PixelType, Rgb8Pixel, TextAlignment, VecImageBuffer};
@@ -59,64 +59,74 @@ impl Graphics {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Image;)V", Self::init_with_image, Default::default()),
-                JavaMethodProto::new("reset", "()V", Self::reset, Default::default()),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljavax/microedition/lcdui/Image;)V",
+                    Self::init_with_image,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("reset", "()V", Self::reset, MethodAccessFlags::empty()),
                 // WIPI wrapper bridge only; this is not part of the MIDP Graphics API.
                 JavaMethodProto::new("setXORMode", "(Z)V", Self::set_xor_mode, MethodAccessFlags::PRIVATE),
-                JavaMethodProto::new("getFont", "()Ljavax/microedition/lcdui/Font;", Self::get_font, Default::default()),
-                JavaMethodProto::new("setColor", "(I)V", Self::set_color, Default::default()),
-                JavaMethodProto::new("setColor", "(III)V", Self::set_color_by_rgb, Default::default()),
-                JavaMethodProto::new("setFont", "(Ljavax/microedition/lcdui/Font;)V", Self::set_font, Default::default()),
-                JavaMethodProto::new("fillRect", "(IIII)V", Self::fill_rect, Default::default()),
-                JavaMethodProto::new("fillRoundRect", "(IIIIII)V", Self::fill_round_rect, Default::default()),
-                JavaMethodProto::new("fillArc", "(IIIIII)V", Self::fill_arc, Default::default()),
-                JavaMethodProto::new("drawLine", "(IIII)V", Self::draw_line, Default::default()),
-                JavaMethodProto::new("drawRect", "(IIII)V", Self::draw_rect, Default::default()),
-                JavaMethodProto::new("drawRoundRect", "(IIIIII)V", Self::draw_round_rect, Default::default()),
-                JavaMethodProto::new("drawArc", "(IIIIII)V", Self::draw_arc, Default::default()),
-                JavaMethodProto::new("drawChar", "(CIII)V", Self::draw_char, Default::default()),
-                JavaMethodProto::new("drawChars", "([CIIIII)V", Self::draw_chars, Default::default()),
-                JavaMethodProto::new("drawString", "(Ljava/lang/String;III)V", Self::draw_string, Default::default()),
-                JavaMethodProto::new("drawSubstring", "(Ljava/lang/String;IIIII)V", Self::draw_substring, Default::default()),
+                JavaMethodProto::new("getFont", "()Ljavax/microedition/lcdui/Font;", Self::get_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setColor", "(I)V", Self::set_color, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setColor", "(III)V", Self::set_color_by_rgb, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setFont", "(Ljavax/microedition/lcdui/Font;)V", Self::set_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillRect", "(IIII)V", Self::fill_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillRoundRect", "(IIIIII)V", Self::fill_round_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillArc", "(IIIIII)V", Self::fill_arc, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawLine", "(IIII)V", Self::draw_line, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawRect", "(IIII)V", Self::draw_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawRoundRect", "(IIIIII)V", Self::draw_round_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawArc", "(IIIIII)V", Self::draw_arc, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawChar", "(CIII)V", Self::draw_char, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawChars", "([CIIIII)V", Self::draw_chars, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawString", "(Ljava/lang/String;III)V", Self::draw_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "drawSubstring",
+                    "(Ljava/lang/String;IIIII)V",
+                    Self::draw_substring,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new(
                     "drawImage",
                     "(Ljavax/microedition/lcdui/Image;III)V",
                     Self::draw_image,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "drawRegion",
                     "(Ljavax/microedition/lcdui/Image;IIIIIIII)V",
                     Self::draw_region,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("setClip", "(IIII)V", Self::set_clip, Default::default()),
-                JavaMethodProto::new("clipRect", "(IIII)V", Self::clip_rect, Default::default()),
-                JavaMethodProto::new("getColor", "()I", Self::get_color, Default::default()),
-                JavaMethodProto::new("getClipX", "()I", Self::get_clip_x, Default::default()),
-                JavaMethodProto::new("getClipY", "()I", Self::get_clip_y, Default::default()),
-                JavaMethodProto::new("getClipWidth", "()I", Self::get_clip_width, Default::default()),
-                JavaMethodProto::new("getClipHeight", "()I", Self::get_clip_height, Default::default()),
-                JavaMethodProto::new("getTranslateX", "()I", Self::get_translate_x, Default::default()),
-                JavaMethodProto::new("getTranslateY", "()I", Self::get_translate_y, Default::default()),
-                JavaMethodProto::new("translate", "(II)V", Self::translate, Default::default()),
-                JavaMethodProto::new("drawRGB", "([IIIIIIIZ)V", Self::draw_rgb, Default::default()),
-                JavaMethodProto::new("setGrayScale", "(I)V", Self::set_gray_scale, Default::default()),
+                JavaMethodProto::new("setClip", "(IIII)V", Self::set_clip, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("clipRect", "(IIII)V", Self::clip_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getColor", "()I", Self::get_color, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipX", "()I", Self::get_clip_x, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipY", "()I", Self::get_clip_y, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipWidth", "()I", Self::get_clip_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipHeight", "()I", Self::get_clip_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getTranslateX", "()I", Self::get_translate_x, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getTranslateY", "()I", Self::get_translate_y, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("translate", "(II)V", Self::translate, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawRGB", "([IIIIIIIZ)V", Self::draw_rgb, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setGrayScale", "(I)V", Self::set_gray_scale, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("img", "Ljavax/microedition/lcdui/Image;", Default::default()),
-                JavaFieldProto::new("width", "I", Default::default()),
-                JavaFieldProto::new("height", "I", Default::default()),
-                JavaFieldProto::new("clipX", "I", Default::default()),
-                JavaFieldProto::new("clipY", "I", Default::default()),
-                JavaFieldProto::new("clipWidth", "I", Default::default()),
-                JavaFieldProto::new("clipHeight", "I", Default::default()),
-                JavaFieldProto::new("translateX", "I", Default::default()),
-                JavaFieldProto::new("translateY", "I", Default::default()),
-                JavaFieldProto::new("color", "I", Default::default()),
-                JavaFieldProto::new("xorMode", "Z", Default::default()),
+                JavaFieldProto::new("img", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("width", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("height", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("clipX", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("clipY", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("clipWidth", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("clipHeight", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("translateX", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("translateY", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("color", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("xorMode", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -125,15 +135,19 @@ impl Graphics {
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
-        let width: i32 = jvm.invoke_virtual(&image, "getWidth", "()I", ()).await?;
-        let height: i32 = jvm.invoke_virtual(&image, "getHeight", "()I", ()).await?;
+        let width: i32 = jvm
+            .invoke_virtual(&image, "javax/microedition/lcdui/Image", "getWidth", "()I", ())
+            .await?;
+        let height: i32 = jvm
+            .invoke_virtual(&image, "javax/microedition/lcdui/Image", "getHeight", "()I", ())
+            .await?;
 
         jvm.put_field(&mut this, "img", "Ljavax/microedition/lcdui/Image;", image).await?;
 
         jvm.put_field(&mut this, "width", "I", width).await?;
         jvm.put_field(&mut this, "height", "I", height).await?;
 
-        let _: () = jvm.invoke_virtual(&this, "reset", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Graphics", "reset", "()V", ()).await?;
 
         Ok(())
     }
@@ -941,9 +955,13 @@ mod test {
                 )
                 .await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x00ff00,)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x00ff00,))
+                .await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 100, 100)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 100, 100))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
 
@@ -954,11 +972,21 @@ mod test {
             assert_eq!(backend_image.colors()[0].g, 0xff);
             assert_eq!(backend_image.colors()[0].b, 0x00);
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x123456,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xf00faa,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setXORMode", "(Z)V", (true,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x123456,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xf00faa,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setXORMode", "(Z)V", (true,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
             let color = backend_image.get_pixel(0, 0);
@@ -966,15 +994,29 @@ mod test {
             assert_eq!(color.g, 0x34 ^ 0x0f);
             assert_eq!(color.b, 0x56 ^ 0xaa);
 
-            let _: () = jvm.invoke_virtual(&graphics, "setXORMode", "(Z)V", (false,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x123456,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setXORMode", "(Z)V", (true,)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setXORMode", "(Z)V", (false,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x123456,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setXORMode", "(Z)V", (true,))
+                .await?;
 
             let mut rgb_data = jvm.instantiate_array("I", 1).await?;
             jvm.store_array(&mut rgb_data, 0, vec![0x00ff0000i32]).await?;
             let _: () = jvm
-                .invoke_virtual(&graphics, "drawRGB", "([IIIIIIIZ)V", (rgb_data, 0, 1, 0, 0, 1, 1, true))
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawRGB",
+                    "([IIIIIIIZ)V",
+                    (rgb_data, 0, 1, 0, 0, 1, 1, true),
+                )
                 .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
@@ -1013,17 +1055,31 @@ mod test {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let (image, graphics) = new_graphics(&jvm).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (10, 10)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, 5, 5)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (10, 10))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (0, 0, 5, 5))
+                .await?;
 
-            let clip_x: i32 = jvm.invoke_virtual(&graphics, "getClipX", "()I", ()).await?;
-            let clip_y: i32 = jvm.invoke_virtual(&graphics, "getClipY", "()I", ()).await?;
+            let clip_x: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+                .await?;
+            let clip_y: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+                .await?;
             assert_eq!(clip_x, 0);
             assert_eq!(clip_y, 0);
 
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (-10, -10)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xff0000,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 100, 100)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (-10, -10))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xff0000,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 100, 100))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
             for (x, y) in [(10, 10), (14, 14)] {
@@ -1044,22 +1100,42 @@ mod test {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let (image, graphics) = new_graphics(&jvm).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, 20, 20)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (10, 10)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "clipRect", "(IIII)V", (0, 0, 5, 5)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (0, 0, 20, 20))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (10, 10))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "clipRect", "(IIII)V", (0, 0, 5, 5))
+                .await?;
 
-            let clip_x: i32 = jvm.invoke_virtual(&graphics, "getClipX", "()I", ()).await?;
-            let clip_y: i32 = jvm.invoke_virtual(&graphics, "getClipY", "()I", ()).await?;
-            let clip_width: i32 = jvm.invoke_virtual(&graphics, "getClipWidth", "()I", ()).await?;
-            let clip_height: i32 = jvm.invoke_virtual(&graphics, "getClipHeight", "()I", ()).await?;
+            let clip_x: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+                .await?;
+            let clip_y: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+                .await?;
+            let clip_width: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+                .await?;
+            let clip_height: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+                .await?;
             assert_eq!(clip_x, 0);
             assert_eq!(clip_y, 0);
             assert_eq!(clip_width, 5);
             assert_eq!(clip_height, 5);
 
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (-10, -10)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xff0000,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 100, 100)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (-10, -10))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xff0000,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 100, 100))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
             let color = backend_image.get_pixel(10, 10);
@@ -1078,10 +1154,18 @@ mod test {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let (image, graphics) = new_graphics(&jvm).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, 5, 5)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "clipRect", "(IIII)V", (20, 20, 5, 5)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xff0000,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 100, 100)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (0, 0, 5, 5))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "clipRect", "(IIII)V", (20, 20, 5, 5))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xff0000,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 100, 100))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
             for (x, y) in [(0, 0), (2, 2), (21, 21)] {
@@ -1098,15 +1182,25 @@ mod test {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let (image, graphics) = new_graphics(&jvm).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, -5, -5)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (0, 0, -5, -5))
+                .await?;
 
-            let clip_width: i32 = jvm.invoke_virtual(&graphics, "getClipWidth", "()I", ()).await?;
-            let clip_height: i32 = jvm.invoke_virtual(&graphics, "getClipHeight", "()I", ()).await?;
+            let clip_width: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+                .await?;
+            let clip_height: i32 = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+                .await?;
             assert_eq!(clip_width, 0);
             assert_eq!(clip_height, 0);
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xff0000,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 100, 100)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xff0000,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 100, 100))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
             for (x, y) in [(0, 0), (50, 50)] {
@@ -1123,9 +1217,13 @@ mod test {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let (image, graphics) = new_graphics(&jvm).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xff0000,)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xff0000,))
+                .await?;
             // MIDP: drawRect(2, 2, 0, 3) draws a 1px-wide, 4px-tall vertical line
-            let _: () = jvm.invoke_virtual(&graphics, "drawRect", "(IIII)V", (2, 2, 0, 3)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "drawRect", "(IIII)V", (2, 2, 0, 3))
+                .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;
             for y in 2..=5 {
@@ -1146,12 +1244,20 @@ mod test {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let (image, graphics) = new_graphics(&jvm).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (10, 10)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (10, 10))
+                .await?;
 
             let mut rgb_data = jvm.instantiate_array("I", 1).await?;
             jvm.store_array(&mut rgb_data, 0, vec![0x00ff0000i32]).await?;
             let _: () = jvm
-                .invoke_virtual(&graphics, "drawRGB", "([IIIIIIIZ)V", (rgb_data, 0, 1, 0, 0, 1, 1, false))
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawRGB",
+                    "([IIIIIIIZ)V",
+                    (rgb_data, 0, 1, 0, 0, 1, 1, false),
+                )
                 .await?;
 
             let backend_image = Image::image(&jvm, &image).await?;

--- a/wie_midp/src/classes/javax/microedition/lcdui/image.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/image.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use bytemuck::cast_vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{
     Array, ArrayRawBufferMut, ClassInstanceRef, Jvm, Result as JvmResult,
@@ -28,47 +28,47 @@ impl Image {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(II[BI)V", Self::init, Default::default()),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
+                JavaMethodProto::new("<init>", "(II[BI)V", Self::init, MethodAccessFlags::empty()),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getGraphics",
                     "()Ljavax/microedition/lcdui/Graphics;",
                     Self::get_graphics,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "(II)Ljavax/microedition/lcdui/Image;",
                     Self::create_image,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "([BII)Ljavax/microedition/lcdui/Image;",
                     Self::create_image_from_data,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "(Ljava/lang/String;)Ljavax/microedition/lcdui/Image;",
                     Self::create_image_from_name,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "(Ljavax/microedition/lcdui/Image;)Ljavax/microedition/lcdui/Image;",
                     Self::create_image_from_image,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("w", "I", Default::default()),
-                JavaFieldProto::new("h", "I", Default::default()),
-                JavaFieldProto::new("imgData", "[B", Default::default()),
-                JavaFieldProto::new("bpl", "I", Default::default()),
+                JavaFieldProto::new("w", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("h", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("imgData", "[B", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("bpl", "I", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/item.rs
@@ -15,7 +15,7 @@ impl Item {
             name: "javax/microedition/lcdui/Item",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty())],
+            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED)],
             fields: vec![],
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }

--- a/wie_midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/item.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -14,9 +15,9 @@ impl Item {
             name: "javax/microedition/lcdui/Item",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, Default::default())],
+            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty())],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/screen.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/screen.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -14,9 +15,9 @@ impl Screen {
             name: "javax/microedition/lcdui/Screen",
             parent_class: Some("javax/microedition/lcdui/Displayable"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, Default::default())],
+            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty())],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/lcdui/screen.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/screen.rs
@@ -15,7 +15,7 @@ impl Screen {
             name: "javax/microedition/lcdui/Screen",
             parent_class: Some("javax/microedition/lcdui/Displayable"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty())],
+            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED)],
             fields: vec![],
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }

--- a/wie_midp/src/classes/javax/microedition/lcdui/text_box.rs
+++ b/wie_midp/src/classes/javax/microedition/lcdui/text_box.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -19,10 +20,10 @@ impl TextBox {
                 "<init>",
                 "(Ljava/lang/String;Ljava/lang/String;II)V",
                 Self::init,
-                Default::default(),
+                MethodAccessFlags::PUBLIC,
             )],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/media/manager.rs
+++ b/wie_midp/src/classes/javax/microedition/media/manager.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::{io::InputStream, lang::String};
 use jvm::{ClassInstanceRef, Jvm, Result, runtime::JavaLangString};
 
@@ -22,10 +22,10 @@ impl Manager {
                 "createPlayer",
                 "(Ljava/io/InputStream;Ljava/lang/String;)Ljavax/microedition/media/Player;",
                 Self::create_player,
-                MethodAccessFlags::STATIC,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
             )],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::FINAL,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/media/media_exception.rs
+++ b/wie_midp/src/classes/javax/microedition/media/media_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl MediaException {
             parent_class: Some("java/lang/Exception"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/media/player.rs
+++ b/wie_midp/src/classes/javax/microedition/media/player.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
 
-use java_constants::ClassAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use wie_jvm_support::WieJavaClassProto;
 
 // interface javax.microedition.media.Player
@@ -15,12 +15,12 @@ impl Player {
             parent_class: None,
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new_abstract("start", "()V", Default::default()),
-                JavaMethodProto::new_abstract("stop", "()V", Default::default()),
-                JavaMethodProto::new_abstract("close", "()V", Default::default()),
+                JavaMethodProto::new_abstract("start", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("stop", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("close", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
             ],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_midp/src/classes/javax/microedition/midlet/midlet.rs
+++ b/wie_midp/src/classes/javax/microedition/midlet/midlet.rs
@@ -26,11 +26,7 @@ impl MIDlet {
                     Self::get_app_property,
                     MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
                 ),
-                JavaMethodProto::new_abstract(
-                    "startApp",
-                    "([Ljava/lang/String;)V",
-                    MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT,
-                ),
+                JavaMethodProto::new_abstract("startApp", "()V", MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT),
                 JavaMethodProto::new(
                     "notifyDestroyed",
                     "()V",

--- a/wie_midp/src/classes/javax/microedition/midlet/midlet.rs
+++ b/wie_midp/src/classes/javax/microedition/midlet/midlet.rs
@@ -1,7 +1,7 @@
 use alloc::{format, vec};
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{ClassAccessFlags, FieldAccessFlags};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -19,21 +19,34 @@ impl MIDlet {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
                 JavaMethodProto::new(
                     "getAppProperty",
                     "(Ljava/lang/String;)Ljava/lang/String;",
                     Self::get_app_property,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
                 ),
-                JavaMethodProto::new_abstract("startApp", "([Ljava/lang/String;)V", Default::default()),
-                JavaMethodProto::new("notifyDestroyed", "()V", Self::notify_destroyed, Default::default()),
+                JavaMethodProto::new_abstract(
+                    "startApp",
+                    "([Ljava/lang/String;)V",
+                    MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new(
+                    "notifyDestroyed",
+                    "()V",
+                    Self::notify_destroyed,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
             ],
             fields: vec![
-                JavaFieldProto::new("currentMIDlet", "Ljavax/microedition/midlet/MIDlet;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("display", "Ljavax/microedition/lcdui/Display;", Default::default()),
+                JavaFieldProto::new(
+                    "currentMIDlet",
+                    "Ljavax/microedition/midlet/MIDlet;",
+                    FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC,
+                ),
+                JavaFieldProto::new("display", "Ljavax/microedition/lcdui/Display;", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: ClassAccessFlags::ABSTRACT,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/rms/invalid_record_id_exception.rs
+++ b/wie_midp/src/classes/javax/microedition/rms/invalid_record_id_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl InvalidRecordIDException {
             parent_class: Some("javax/microedition/rms/RecordStoreException"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/javax/microedition/rms/record_store.rs
+++ b/wie_midp/src/classes/javax/microedition/rms/record_store.rs
@@ -3,7 +3,7 @@ use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
 use bytemuck::cast_vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -20,38 +20,38 @@ impl RecordStore {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("addRecord", "([BII)I", Self::add_record, Default::default()),
-                JavaMethodProto::new("deleteRecord", "(I)V", Self::delete_record, Default::default()),
-                JavaMethodProto::new("getSizeAvailable", "()I", Self::get_size_available, Default::default()),
-                JavaMethodProto::new("getNextRecordID", "()I", Self::get_next_record_id, Default::default()),
-                JavaMethodProto::new("getRecord", "(I)[B", Self::get_record, Default::default()),
-                JavaMethodProto::new("getRecord", "(I[BI)I", Self::get_record_array, Default::default()),
-                JavaMethodProto::new("getRecordSize", "(I)I", Self::get_record_size, Default::default()),
-                JavaMethodProto::new("setRecord", "(I[BII)V", Self::set_record, Default::default()),
-                JavaMethodProto::new("getNumRecords", "()I", Self::get_num_records, Default::default()),
-                JavaMethodProto::new("closeRecordStore", "()V", Self::close_record_store, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PRIVATE),
+                JavaMethodProto::new("addRecord", "([BII)I", Self::add_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("deleteRecord", "(I)V", Self::delete_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getSizeAvailable", "()I", Self::get_size_available, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getNextRecordID", "()I", Self::get_next_record_id, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getRecord", "(I)[B", Self::get_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getRecord", "(I[BI)I", Self::get_record_array, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getRecordSize", "(I)I", Self::get_record_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setRecord", "(I[BII)V", Self::set_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getNumRecords", "()I", Self::get_num_records, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("closeRecordStore", "()V", Self::close_record_store, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "openRecordStore",
                     "(Ljava/lang/String;Z)Ljavax/microedition/rms/RecordStore;",
                     Self::open_record_store,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "deleteRecordStore",
                     "(Ljava/lang/String;)V",
                     Self::delete_record_store,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "listRecordStores",
                     "()[Ljava/lang/String;",
                     Self::list_record_stores,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
-            fields: vec![JavaFieldProto::new("dbName", "Ljava/lang/String;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new("dbName", "Ljava/lang/String;", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -276,23 +276,35 @@ mod test {
 
             let mut data = jvm.instantiate_array("B", 2).await?;
             jvm.store_array(&mut data, 0, [1i8, 2]).await?;
-            let record_id: i32 = jvm.invoke_virtual(&store, "addRecord", "([BII)I", (data, 0, 2)).await?;
+            let record_id: i32 = jvm
+                .invoke_virtual(&store, "javax/microedition/rms/RecordStore", "addRecord", "([BII)I", (data, 0, 2))
+                .await?;
             assert_eq!(record_id, 1);
 
-            let count: i32 = jvm.invoke_virtual(&store, "getNumRecords", "()I", ()).await?;
+            let count: i32 = jvm
+                .invoke_virtual(&store, "javax/microedition/rms/RecordStore", "getNumRecords", "()I", ())
+                .await?;
             assert_eq!(count, 1);
 
-            let _: () = jvm.invoke_virtual(&store, "deleteRecord", "(I)V", (record_id,)).await?;
-            let count: i32 = jvm.invoke_virtual(&store, "getNumRecords", "()I", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&store, "javax/microedition/rms/RecordStore", "deleteRecord", "(I)V", (record_id,))
+                .await?;
+            let count: i32 = jvm
+                .invoke_virtual(&store, "javax/microedition/rms/RecordStore", "getNumRecords", "()I", ())
+                .await?;
             assert_eq!(count, 0);
 
-            let deleted: JvmResult<ClassInstanceRef<Array<i8>>> = jvm.invoke_virtual(&store, "getRecord", "(I)[B", (record_id,)).await;
+            let deleted: JvmResult<ClassInstanceRef<Array<i8>>> = jvm
+                .invoke_virtual(&store, "javax/microedition/rms/RecordStore", "getRecord", "(I)[B", (record_id,))
+                .await;
             let Err(JavaError::JavaException(exception)) = deleted else {
                 panic!("deleted record lookup succeeded");
             };
             assert!(jvm.is_instance(&*exception, "javax/microedition/rms/InvalidRecordIDException"));
 
-            let unknown: JvmResult<()> = jvm.invoke_virtual(&store, "deleteRecord", "(I)V", (99,)).await;
+            let unknown: JvmResult<()> = jvm
+                .invoke_virtual(&store, "javax/microedition/rms/RecordStore", "deleteRecord", "(I)V", (99,))
+                .await;
             let Err(JavaError::JavaException(exception)) = unknown else {
                 panic!("unknown record deletion succeeded");
             };

--- a/wie_midp/src/classes/javax/microedition/rms/record_store_exception.rs
+++ b/wie_midp/src/classes/javax/microedition/rms/record_store_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl RecordStoreException {
             parent_class: Some("java/lang/Exception"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/net/wie/event_queue.rs
+++ b/wie_midp/src/classes/net/wie/event_queue.rs
@@ -2,7 +2,7 @@ use alloc::{string::ToString, vec, vec::Vec};
 
 use futures::TryFutureExt;
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{FieldAccessFlags, MethodAccessFlags};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::Runnable;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -156,22 +156,22 @@ impl EventQueue {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, Default::default()),
-                JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, Default::default()),
-                JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getEventQueue",
                     "()Lnet/wie/EventQueue;",
                     Self::get_event_queue,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("eventQueue", "Lnet/wie/EventQueue;", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("callSeriallyEvents", "Ljava/util/Vector;", Default::default()),
+                JavaFieldProto::new("eventQueue", "Lnet/wie/EventQueue;", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("callSeriallyEvents", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -244,10 +244,14 @@ impl EventQueue {
                 break;
             } else {
                 let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-                if !jvm.invoke_virtual(&call_serially_events, "isEmpty", "()Z", ()).await? {
-                    let event: ClassInstanceRef<Runnable> =
-                        jvm.invoke_virtual(&call_serially_events, "remove", "(I)Ljava/lang/Object;", (0,)).await?;
-                    let _: () = jvm.invoke_virtual(&event, "run", "()V", ()).await?;
+                if !jvm
+                    .invoke_virtual(&call_serially_events, "java/util/Vector", "isEmpty", "()Z", ())
+                    .await?
+                {
+                    let event: ClassInstanceRef<Runnable> = jvm
+                        .invoke_virtual(&call_serially_events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
+                        .await?;
+                    let _: () = jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await?;
                 }
 
                 context.system().sleep(16).await; // TODO we need to wait for events
@@ -297,7 +301,9 @@ impl EventQueue {
 
         match event_kind {
             EventQueueEvent::RepaintEvent => {
-                let _: () = jvm.invoke_virtual(&display, "handlePaintEvent", "()V", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                    .await?;
             }
             EventQueueEvent::KeyEvent => {
                 let event_type = if let Some(event_type) = KeyboardEventType::from_raw(event[1]) {
@@ -307,7 +313,15 @@ impl EventQueue {
                 };
                 let code = event[2];
 
-                let _: () = jvm.invoke_virtual(&display, "handleKeyEvent", "(II)V", (event_type as i32, code)).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "handleKeyEvent",
+                        "(II)V",
+                        (event_type as i32, code),
+                    )
+                    .await?;
             }
             EventQueueEvent::NotifyEvent => {
                 let r#type = event[1];
@@ -315,7 +329,13 @@ impl EventQueue {
                 let param2 = event[3];
 
                 let _: () = jvm
-                    .invoke_virtual(&display, "handleNotifyEvent", "(III)V", (r#type, param1, param2))
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "handleNotifyEvent",
+                        "(III)V",
+                        (r#type, param1, param2),
+                    )
                     .await?;
             }
         }
@@ -349,7 +369,13 @@ impl EventQueue {
         tracing::debug!("net.wie.EventQueue::callSerially({this:?}, {event:?})");
 
         let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-        jvm.invoke_virtual(&call_serially_events, "addElement", "(Ljava/lang/Object;)V", [event.into()])
-            .await
+        jvm.invoke_virtual(
+            &call_serially_events,
+            "java/util/Vector",
+            "addElement",
+            "(Ljava/lang/Object;)V",
+            [event.into()],
+        )
+        .await
     }
 }

--- a/wie_midp/src/classes/net/wie/launcher.rs
+++ b/wie_midp/src/classes/net/wie/launcher.rs
@@ -52,8 +52,9 @@ impl Launcher {
         tracing::debug!("net.wie.Launcher::startMIDlet({midlet:?})");
 
         // run startApp
-        let class_name = midlet.class_definition().name();
-        let _: () = jvm.invoke_virtual(&midlet, &class_name, "startApp", "()V", (None,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&midlet, "javax/microedition/midlet/MIDlet", "startApp", "()V", ())
+            .await?;
 
         // spawn event loop
         context.spawn(jvm, Box::new(EventLoopRunner))?;

--- a/wie_midp/src/classes/net/wie/launcher.rs
+++ b/wie_midp/src/classes/net/wie/launcher.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec};
 
 use java_class_proto::{JavaMethodProto, MethodBody};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, JavaError, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -19,16 +19,21 @@ impl Launcher {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("start", "(Ljava/lang/String;)V", Self::start, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "start",
+                    "(Ljava/lang/String;)V",
+                    Self::start,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
                 JavaMethodProto::new(
                     "startMIDlet",
                     "(Ljavax/microedition/midlet/MIDlet;)V",
                     Self::start_midlet,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -47,7 +52,8 @@ impl Launcher {
         tracing::debug!("net.wie.Launcher::startMIDlet({midlet:?})");
 
         // run startApp
-        let _: () = jvm.invoke_virtual(&midlet, "startApp", "()V", (None,)).await?;
+        let class_name = midlet.class_definition().name();
+        let _: () = jvm.invoke_virtual(&midlet, &class_name, "startApp", "()V", (None,)).await?;
 
         // spawn event loop
         context.spawn(jvm, Box::new(EventLoopRunner))?;
@@ -70,8 +76,12 @@ impl MethodBody<JavaError, WieJvmContext> for EventLoopRunner {
 
         let event = jvm.instantiate_array("I", 4).await?;
         loop {
-            let _: () = jvm.invoke_virtual(&event_queue, "getNextEvent", "([I)V", (event.clone(),)).await?;
-            let _: () = jvm.invoke_virtual(&event_queue, "dispatchEvent", "([I)V", (event.clone(),)).await?;
+            let _: () = jvm
+                .invoke_virtual(&event_queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event.clone(),))
+                .await?;
         }
     }
 }

--- a/wie_midp/src/classes/net/wie/smaf_player.rs
+++ b/wie_midp/src/classes/net/wie/smaf_player.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::io::InputStream;
 use jvm::{ClassInstanceRef, Jvm, Result, runtime::JavaIoInputStream};
 
@@ -16,14 +17,14 @@ impl SmafPlayer {
             parent_class: Some("java/lang/Object"),
             interfaces: vec!["javax/microedition/media/Player"],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/io/InputStream;)V", Self::init, Default::default()),
-                JavaMethodProto::new("start", "()V", Self::start, Default::default()),
-                JavaMethodProto::new("start", "(Z)V", Self::start_with_repeat, Default::default()),
-                JavaMethodProto::new("stop", "()V", Self::stop, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/io/InputStream;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("start", "()V", Self::start, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("start", "(Z)V", Self::start_with_repeat, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("stop", "()V", Self::stop, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("close", "()V", Self::close, MethodAccessFlags::PUBLIC),
             ],
-            fields: vec![JavaFieldProto::new("audioHandle", "I", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new("audioHandle", "I", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_midp/src/classes/net/wie/wie_error.rs
+++ b/wie_midp/src/classes/net/wie/wie_error.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl WieError {
             parent_class: Some("java/lang/Error"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_skvm/src/classes/com/skt/m/graphics_2d.rs
+++ b/wie_skvm/src/classes/com/skt/m/graphics_2d.rs
@@ -335,7 +335,13 @@ mod test {
                     )
                     .await?;
                 let graphics: ClassInstanceRef<Graphics> = jvm
-                    .invoke_virtual(&target, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .invoke_virtual(
+                        &target,
+                        "javax/microedition/lcdui/Image",
+                        "getGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
                     .await?;
                 let graphics_2d: ClassInstanceRef<Graphics2D> = jvm
                     .invoke_static(
@@ -346,11 +352,21 @@ mod test {
                     )
                     .await?;
 
-                let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (1, 0)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, 2, 1)).await?;
-                let _: () = jvm.invoke_virtual(&graphics_2d, "setPixel", "(III)V", (0, 0, 0x123456)).await?;
-                let _: () = jvm.invoke_virtual(&graphics_2d, "setPixel", "(III)V", (2, 0, 0xffffff)).await?;
-                let pixel: i32 = jvm.invoke_virtual(&graphics_2d, "getPixel", "(II)I", (0, 0)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (1, 0))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (0, 0, 2, 1))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics_2d, "com/skt/m/Graphics2D", "setPixel", "(III)V", (0, 0, 0x123456))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics_2d, "com/skt/m/Graphics2D", "setPixel", "(III)V", (2, 0, 0xffffff))
+                    .await?;
+                let pixel: i32 = jvm
+                    .invoke_virtual(&graphics_2d, "com/skt/m/Graphics2D", "getPixel", "(II)I", (0, 0))
+                    .await?;
                 assert_eq!(pixel, 0x123456);
 
                 let source: ClassInstanceRef<Image> = jvm
@@ -362,18 +378,33 @@ mod test {
                     )
                     .await?;
                 let source_graphics: ClassInstanceRef<Graphics> = jvm
-                    .invoke_virtual(&source, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .invoke_virtual(
+                        &source,
+                        "javax/microedition/lcdui/Image",
+                        "getGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
                     .await?;
-                let _: () = jvm.invoke_virtual(&source_graphics, "setColor", "(I)V", (0xf00faa,)).await?;
-                let _: () = jvm.invoke_virtual(&source_graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
-                let _: () = jvm.invoke_virtual(&source_graphics, "setColor", "(I)V", (0xabcdef,)).await?;
-                let _: () = jvm.invoke_virtual(&source_graphics, "fillRect", "(IIII)V", (1, 0, 1, 1)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&source_graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xf00faa,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&source_graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&source_graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xabcdef,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&source_graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (1, 0, 1, 1))
+                    .await?;
 
                 let copy_mode: i32 = jvm.get_static_field("com/skt/m/Graphics2D", "DRAW_COPY", "I").await?;
                 let xor_mode: i32 = jvm.get_static_field("com/skt/m/Graphics2D", "DRAW_XOR", "I").await?;
                 let _: () = jvm
                     .invoke_virtual(
                         &graphics_2d,
+                        "com/skt/m/Graphics2D",
                         "drawImage",
                         "(IILjavax/microedition/lcdui/Image;IIIII)V",
                         (0, 0, source.clone(), 0, 0, 2, 1, copy_mode),
@@ -382,6 +413,7 @@ mod test {
                 let _: () = jvm
                     .invoke_virtual(
                         &graphics_2d,
+                        "com/skt/m/Graphics2D",
                         "drawImage",
                         "(IILjavax/microedition/lcdui/Image;IIIII)V",
                         (0, 0, source, 0, 0, 1, 1, xor_mode),
@@ -398,15 +430,21 @@ mod test {
                 let clipped = target_image.get_pixel(3, 0);
                 assert_eq!((clipped.r, clipped.g, clipped.b), (0, 0, 0));
 
-                let _: () = jvm.invoke_virtual(&graphics_2d, "invertRect", "(IIII)V", (0, 0, 4, 1)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics_2d, "com/skt/m/Graphics2D", "invertRect", "(IIII)V", (0, 0, 4, 1))
+                    .await?;
                 let target_image = Image::image(&jvm, &target).await?;
                 let inverted = target_image.get_pixel(1, 0);
                 assert_eq!((inverted.r, inverted.g, inverted.b), (0xff, 0xff, 0xff));
                 let outside_clip = target_image.get_pixel(3, 0);
                 assert_eq!((outside_clip.r, outside_clip.g, outside_clip.b), (0, 0, 0));
 
-                let _: () = jvm.invoke_virtual(&graphics_2d, "invertRect", "(IIII)V", (0, 0, 0, 1)).await?;
-                let negative_size: JvmResult<()> = jvm.invoke_virtual(&graphics_2d, "invertRect", "(IIII)V", (0, 0, -1, 1)).await;
+                let _: () = jvm
+                    .invoke_virtual(&graphics_2d, "com/skt/m/Graphics2D", "invertRect", "(IIII)V", (0, 0, 0, 1))
+                    .await?;
+                let negative_size: JvmResult<()> = jvm
+                    .invoke_virtual(&graphics_2d, "com/skt/m/Graphics2D", "invertRect", "(IIII)V", (0, 0, -1, 1))
+                    .await;
                 let Err(JavaError::JavaException(exception)) = negative_size else {
                     panic!("Graphics2D.invertRect accepted a negative width");
                 };
@@ -443,21 +481,27 @@ mod test {
                 let sis_image: ClassInstanceRef<SISImage> = jvm
                     .invoke_static("com/skt/m/SISImage", "createSISImage", "([BII)Lcom/skt/m/SISImage;", (data.clone(), 0, 3))
                     .await?;
-                let max_frame_id: i32 = jvm.invoke_virtual(&sis_image, "getMaxFrameID", "()I", ()).await?;
-                let max_object_id: i32 = jvm.invoke_virtual(&sis_image, "getMaxObjectID", "()I", ()).await?;
+                let max_frame_id: i32 = jvm.invoke_virtual(&sis_image, "com/skt/m/SISImage", "getMaxFrameID", "()I", ()).await?;
+                let max_object_id: i32 = jvm.invoke_virtual(&sis_image, "com/skt/m/SISImage", "getMaxObjectID", "()I", ()).await?;
                 assert_eq!((max_frame_id, max_object_id), (0, 0));
 
                 let frame: ClassInstanceRef<Image> = jvm
-                    .invoke_virtual(&sis_image, "getFrame", "(I)Ljavax/microedition/lcdui/Image;", (0,))
+                    .invoke_virtual(&sis_image, "com/skt/m/SISImage", "getFrame", "(I)Ljavax/microedition/lcdui/Image;", (0,))
                     .await?;
                 let object: ClassInstanceRef<Image> = jvm
-                    .invoke_virtual(&sis_image, "getObject", "(IZ)Ljavax/microedition/lcdui/Image;", (0, false))
+                    .invoke_virtual(
+                        &sis_image,
+                        "com/skt/m/SISImage",
+                        "getObject",
+                        "(IZ)Ljavax/microedition/lcdui/Image;",
+                        (0, false),
+                    )
                     .await?;
                 assert!(frame.is_null());
                 assert!(object.is_null());
 
                 let invalid_frame: JvmResult<ClassInstanceRef<Image>> = jvm
-                    .invoke_virtual(&sis_image, "getFrame", "(I)Ljavax/microedition/lcdui/Image;", (1,))
+                    .invoke_virtual(&sis_image, "com/skt/m/SISImage", "getFrame", "(I)Ljavax/microedition/lcdui/Image;", (1,))
                     .await;
                 let Err(JavaError::JavaException(exception)) = invalid_frame else {
                     panic!("SISImage.getFrame accepted an out-of-range ID");
@@ -465,7 +509,13 @@ mod test {
                 assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
 
                 let invalid_object: JvmResult<ClassInstanceRef<Image>> = jvm
-                    .invoke_virtual(&sis_image, "getObject", "(IZ)Ljavax/microedition/lcdui/Image;", (-1, false))
+                    .invoke_virtual(
+                        &sis_image,
+                        "com/skt/m/SISImage",
+                        "getObject",
+                        "(IZ)Ljavax/microedition/lcdui/Image;",
+                        (-1, false),
+                    )
                     .await;
                 let Err(JavaError::JavaException(exception)) = invalid_object else {
                     panic!("SISImage.getObject accepted an out-of-range ID");
@@ -481,11 +531,18 @@ mod test {
                     )
                     .await?;
                 let graphics: ClassInstanceRef<Graphics> = jvm
-                    .invoke_virtual(&target, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .invoke_virtual(
+                        &target,
+                        "javax/microedition/lcdui/Image",
+                        "getGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
                     .await?;
                 let _: () = jvm
                     .invoke_virtual(
                         &sis_image,
+                        "com/skt/m/SISImage",
                         "paintFrame",
                         "(Ljavax/microedition/lcdui/Graphics;III)V",
                         (graphics.clone(), 0, 0, 0),
@@ -495,6 +552,7 @@ mod test {
                 let invalid_frame: JvmResult<()> = jvm
                     .invoke_virtual(
                         &sis_image,
+                        "com/skt/m/SISImage",
                         "paintFrame",
                         "(Ljavax/microedition/lcdui/Graphics;III)V",
                         (graphics.clone(), 1, 0, 0),
@@ -508,6 +566,7 @@ mod test {
                 let invalid_object: JvmResult<()> = jvm
                     .invoke_virtual(
                         &sis_image,
+                        "com/skt/m/SISImage",
                         "paintObject",
                         "(Ljavax/microedition/lcdui/Graphics;IIIZ)V",
                         (graphics.clone(), 1, 0, 0, false),
@@ -520,6 +579,7 @@ mod test {
                 let _: () = jvm
                     .invoke_virtual(
                         &sis_image,
+                        "com/skt/m/SISImage",
                         "paintObject",
                         "(Ljavax/microedition/lcdui/Graphics;IIIZ)V",
                         (graphics, 0, 0, 0, false),

--- a/wie_skvm/src/classes/com/skt/m/progress_bar.rs
+++ b/wie_skvm/src/classes/com/skt/m/progress_bar.rs
@@ -80,15 +80,39 @@ mod test {
             let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "Loading").await?.into();
             let progress_bar: ClassInstanceRef<ProgressBar> = jvm.new_class("com/skt/m/ProgressBar", "(Ljava/lang/String;)V", (name,)).await?.into();
 
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getMaxValue", "()I", ()).await?, 100);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getValue", "()I", ()).await?, 0);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&progress_bar, "com/skt/m/ProgressBar", "getMaxValue", "()I", ())
+                    .await?,
+                100
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&progress_bar, "com/skt/m/ProgressBar", "getValue", "()I", ())
+                    .await?,
+                0
+            );
 
-            let _: () = jvm.invoke_virtual(&progress_bar, "setValue", "(I)V", (125,)).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getValue", "()I", ()).await?, 100);
+            let _: () = jvm
+                .invoke_virtual(&progress_bar, "com/skt/m/ProgressBar", "setValue", "(I)V", (125,))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&progress_bar, "com/skt/m/ProgressBar", "getValue", "()I", ())
+                    .await?,
+                100
+            );
 
-            let _: () = jvm.invoke_virtual(&progress_bar, "setMaxValue", "(I)V", (40,)).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getMaxValue", "()I", ()).await?, 40);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&progress_bar, "getValue", "()I", ()).await?, 40);
+            let _: () = jvm
+                .invoke_virtual(&progress_bar, "com/skt/m/ProgressBar", "setMaxValue", "(I)V", (40,))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&progress_bar, "com/skt/m/ProgressBar", "getMaxValue", "()I", ())
+                    .await?,
+                40
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&progress_bar, "com/skt/m/ProgressBar", "getValue", "()I", ())
+                    .await?,
+                40
+            );
             Ok(())
         });
 

--- a/wie_skvm/src/classes/com/skt/m/sms_message.rs
+++ b/wie_skvm/src/classes/com/skt/m/sms_message.rs
@@ -196,7 +196,7 @@ mod test {
             |jvm| async move {
                 let unknown: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "UNKNOWN", "I").await?;
                 let default_message: ClassInstanceRef<SMSMessage> = jvm.new_class("com/skt/m/SMSMessage", "()V", ()).await?.into();
-                let default_type: i32 = jvm.invoke_virtual(&default_message, "getType", "()I", ()).await?;
+                let default_type: i32 = jvm.invoke_virtual(&default_message, "com/skt/m/SMSMessage", "getType", "()I", ()).await?;
                 assert_eq!(default_type, unknown);
 
                 let mut short_data = jvm.instantiate_array("B", 3).await?;
@@ -206,10 +206,14 @@ mod test {
                     .new_class("com/skt/m/SMSMessage", "([BLjava/lang/String;)V", (short_data.clone(), sender.clone()))
                     .await?
                     .into();
-                let short_type: i32 = jvm.invoke_virtual(&short_message, "getType", "()I", ()).await?;
+                let short_type: i32 = jvm.invoke_virtual(&short_message, "com/skt/m/SMSMessage", "getType", "()I", ()).await?;
                 let expected_short_type: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "SHORT_MESSAGE", "I").await?;
-                let returned_short_data: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&short_message, "getShortMessage", "()[B", ()).await?;
-                let returned_sender: ClassInstanceRef<String> = jvm.invoke_virtual(&short_message, "getSender", "()Ljava/lang/String;", ()).await?;
+                let returned_short_data: ClassInstanceRef<Array<i8>> = jvm
+                    .invoke_virtual(&short_message, "com/skt/m/SMSMessage", "getShortMessage", "()[B", ())
+                    .await?;
+                let returned_sender: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&short_message, "com/skt/m/SMSMessage", "getSender", "()Ljava/lang/String;", ())
+                    .await?;
                 assert_eq!(short_type, expected_short_type);
                 assert_eq!(
                     returned_short_data.instance.as_ref().map(|instance| instance.identity()),
@@ -225,10 +229,13 @@ mod test {
                     .new_class("com/skt/m/SMSMessage", "(Ljava/lang/String;[B)V", (cname.clone(), app_data.clone()))
                     .await?
                     .into();
-                let app_type: i32 = jvm.invoke_virtual(&app_message, "getType", "()I", ()).await?;
+                let app_type: i32 = jvm.invoke_virtual(&app_message, "com/skt/m/SMSMessage", "getType", "()I", ()).await?;
                 let expected_app_type: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "APPLICATION_DATA", "I").await?;
-                let returned_cname: ClassInstanceRef<String> = jvm.invoke_virtual(&app_message, "getCName", "()Ljava/lang/String;", ()).await?;
-                let returned_app_data: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&app_message, "getAppData", "()[B", ()).await?;
+                let returned_cname: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&app_message, "com/skt/m/SMSMessage", "getCName", "()Ljava/lang/String;", ())
+                    .await?;
+                let returned_app_data: ClassInstanceRef<Array<i8>> =
+                    jvm.invoke_virtual(&app_message, "com/skt/m/SMSMessage", "getAppData", "()[B", ()).await?;
                 assert_eq!(app_type, expected_app_type);
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_cname).await?, "weather");
                 assert_eq!(jvm.load_array::<i8>(&returned_app_data, 0, 2).await?, [10i8, 20]);
@@ -244,18 +251,27 @@ mod test {
                     )
                     .await?
                     .into();
-                let download_type: i32 = jvm.invoke_virtual(&download_message, "getType", "()I", ()).await?;
+                let download_type: i32 = jvm
+                    .invoke_virtual(&download_message, "com/skt/m/SMSMessage", "getType", "()I", ())
+                    .await?;
                 let expected_download_type: i32 = jvm.get_static_field("com/skt/m/SMSMessage", "DOWNLOAD_NOTIFICATION", "I").await?;
-                let returned_url: ClassInstanceRef<String> = jvm.invoke_virtual(&download_message, "getURL", "()Ljava/lang/String;", ()).await?;
-                let returned_name: ClassInstanceRef<String> = jvm.invoke_virtual(&download_message, "getName", "()Ljava/lang/String;", ()).await?;
-                let returned_comment: ClassInstanceRef<String> =
-                    jvm.invoke_virtual(&download_message, "getComment", "()Ljava/lang/String;", ()).await?;
+                let returned_url: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&download_message, "com/skt/m/SMSMessage", "getURL", "()Ljava/lang/String;", ())
+                    .await?;
+                let returned_name: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&download_message, "com/skt/m/SMSMessage", "getName", "()Ljava/lang/String;", ())
+                    .await?;
+                let returned_comment: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&download_message, "com/skt/m/SMSMessage", "getComment", "()Ljava/lang/String;", ())
+                    .await?;
                 assert_eq!(download_type, expected_download_type);
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_url).await?, "https://example.invalid/app");
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_name).await?, "Example");
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_comment).await?, "Install");
 
-                let service_option: i8 = jvm.invoke_virtual(&download_message, "getServiceOption", "()B", ()).await?;
+                let service_option: i8 = jvm
+                    .invoke_virtual(&download_message, "com/skt/m/SMSMessage", "getServiceOption", "()B", ())
+                    .await?;
                 assert_eq!(service_option, 0);
 
                 Ok(())

--- a/wie_skvm/src/classes/com/skt/m3d/graphics_3d.rs
+++ b/wie_skvm/src/classes/com/skt/m3d/graphics_3d.rs
@@ -173,7 +173,13 @@ mod tests {
                     )
                     .await?;
                 let graphics: ClassInstanceRef<Graphics> = jvm
-                    .invoke_virtual(&image, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .invoke_virtual(
+                        &image,
+                        "javax/microedition/lcdui/Image",
+                        "getGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
                     .await?;
                 let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "triangle").await?.into();
                 let object: ClassInstanceRef<Object3D> = jvm.new_class("com/skt/m3d/Object3D", "(Ljava/lang/String;)V", (name,)).await?.into();

--- a/wie_skvm/src/classes/com/skt/m3d/object_3d.rs
+++ b/wie_skvm/src/classes/com/skt/m3d/object_3d.rs
@@ -183,7 +183,9 @@ mod tests {
                 .await?
                 .into();
 
-            let returned_name: ClassInstanceRef<String> = jvm.invoke_virtual(&object, "getName", "()Ljava/lang/String;", ()).await?;
+            let returned_name: ClassInstanceRef<String> = jvm
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "getName", "()Ljava/lang/String;", ())
+                .await?;
             assert_eq!(
                 returned_name.instance.as_ref().map(|instance| instance.identity()),
                 initial_name.instance.as_ref().map(|instance| instance.identity())
@@ -191,28 +193,39 @@ mod tests {
 
             let renamed: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "renamed").await?.into();
             let _: () = jvm
-                .invoke_virtual(&object, "setName", "(Ljava/lang/String;)V", (renamed.clone(),))
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "setName", "(Ljava/lang/String;)V", (renamed.clone(),))
                 .await?;
-            let returned_name: ClassInstanceRef<String> = jvm.invoke_virtual(&object, "getName", "()Ljava/lang/String;", ()).await?;
+            let returned_name: ClassInstanceRef<String> = jvm
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "getName", "()Ljava/lang/String;", ())
+                .await?;
             assert_eq!(
                 returned_name.instance.as_ref().map(|instance| instance.identity()),
                 renamed.instance.as_ref().map(|instance| instance.identity())
             );
 
-            let _: () = jvm.invoke_virtual(&object, "addVertex", "(III)V", (1, 2, 3)).await?;
-            let _: () = jvm.invoke_virtual(&object, "addTriangle", "(IIII)V", (0, 1, 2, 0xff00ff)).await?;
-            let _: () = jvm.invoke_virtual(&object, "rotate", "(III)V", (10, 20, 30)).await?;
-            let _: () = jvm.invoke_virtual(&object, "translate", "(III)V", (40, 50, 60)).await?;
-            let _: () = jvm.invoke_virtual(&object, "scale", "(III)V", (2, 3, 4)).await?;
+            let _: () = jvm
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "addVertex", "(III)V", (1, 2, 3))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "addTriangle", "(IIII)V", (0, 1, 2, 0xff00ff))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "rotate", "(III)V", (10, 20, 30))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&object, "com/skt/m3d/Object3D", "translate", "(III)V", (40, 50, 60))
+                .await?;
+            let _: () = jvm.invoke_virtual(&object, "com/skt/m3d/Object3D", "scale", "(III)V", (2, 3, 4)).await?;
 
-            let row_0: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow0", "()[I", ()).await?;
-            let row_1: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow1", "()[I", ()).await?;
-            let row_2: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow2", "()[I", ()).await?;
+            let row_0: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "com/skt/m3d/Object3D", "getMatrixRow0", "()[I", ()).await?;
+            let row_1: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "com/skt/m3d/Object3D", "getMatrixRow1", "()[I", ()).await?;
+            let row_2: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "com/skt/m3d/Object3D", "getMatrixRow2", "()[I", ()).await?;
             assert_eq!(jvm.load_array::<i32>(&row_0, 0, 4).await?, [MATRIX_SCALE, 0, 0, 0]);
             assert_eq!(jvm.load_array::<i32>(&row_1, 0, 4).await?, [0, MATRIX_SCALE, 0, 0]);
             assert_eq!(jvm.load_array::<i32>(&row_2, 0, 4).await?, [0, 0, MATRIX_SCALE, 0]);
 
-            let another_row_0: ClassInstanceRef<Array<i32>> = jvm.invoke_virtual(&object, "getMatrixRow0", "()[I", ()).await?;
+            let another_row_0: ClassInstanceRef<Array<i32>> =
+                jvm.invoke_virtual(&object, "com/skt/m3d/Object3D", "getMatrixRow0", "()[I", ()).await?;
             assert_ne!(
                 another_row_0.instance.as_ref().map(|instance| instance.identity()),
                 row_0.instance.as_ref().map(|instance| instance.identity())

--- a/wie_skvm/src/classes/com/xce/io/file_input_stream.rs
+++ b/wie_skvm/src/classes/com/xce/io/file_input_stream.rs
@@ -105,7 +105,7 @@ impl FileInputStream {
         tracing::debug!("com.xce.io.FileInputStream::available({this:?})");
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let available = jvm.invoke_virtual(&file, "available", "()I", ()).await?;
+        let available = jvm.invoke_virtual(&file, "com/xce/io/XFile", "available", "()I", ()).await?;
 
         Ok(available)
     }
@@ -114,7 +114,7 @@ impl FileInputStream {
         tracing::debug!("com.xce.io.FileInputStream::close({this:?})");
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let _: () = jvm.invoke_virtual(&file, "close", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&file, "com/xce/io/XFile", "close", "()V", ()).await?;
 
         Ok(())
     }
@@ -127,11 +127,11 @@ impl FileInputStream {
         let mode: i32 = jvm.get_field(&file, "mode", "I").await?;
         if file_type == STDSTREAM || mode == READ_RESOURCE {
             let stream: ClassInstanceRef<InputStream> = jvm.get_field(&file, "is", "Ljava/io/InputStream;").await?;
-            let _: () = jvm.invoke_virtual(&stream, "mark", "(I)V", (read_limit,)).await?;
+            let _: () = jvm.invoke_virtual(&stream, "java/io/InputStream", "mark", "(I)V", (read_limit,)).await?;
             let position: i32 = jvm.get_field(&file, "offset", "I").await?;
             jvm.put_field(&mut this, "markPosition", "I", position).await?;
         } else {
-            let position: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (0, SEEK_CUR)).await?;
+            let position: i32 = jvm.invoke_virtual(&file, "com/xce/io/XFile", "seek", "(II)I", (0, SEEK_CUR)).await?;
             jvm.put_field(&mut this, "markPosition", "I", position).await?;
         }
         jvm.put_field(&mut this, "marked", "Z", true).await?;
@@ -148,7 +148,9 @@ impl FileInputStream {
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
         let buffer: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 1).await?.into();
-        let read: i32 = jvm.invoke_virtual(&file, "read", "([BII)I", (buffer.clone(), 0, 1)).await?;
+        let read: i32 = jvm
+            .invoke_virtual(&file, "com/xce/io/XFile", "read", "([BII)I", (buffer.clone(), 0, 1))
+            .await?;
         if read <= 0 {
             return Ok(-1);
         }
@@ -170,7 +172,8 @@ impl FileInputStream {
         }
         let length = jvm.array_length(&buffer).await? as i32;
 
-        jvm.invoke_virtual(&this, "read", "([BII)I", (buffer, 0, length)).await
+        jvm.invoke_virtual(&this, "com/xce/io/FileInputStream", "read", "([BII)I", (buffer, 0, length))
+            .await
     }
 
     async fn read_array(
@@ -195,7 +198,9 @@ impl FileInputStream {
         }
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let read: i32 = jvm.invoke_virtual(&file, "read", "([BII)I", (buf, offset, length)).await?;
+        let read: i32 = jvm
+            .invoke_virtual(&file, "com/xce/io/XFile", "read", "([BII)I", (buf, offset, length))
+            .await?;
 
         Ok(if read == 0 { -1 } else { read })
     }
@@ -213,12 +218,14 @@ impl FileInputStream {
         let mode: i32 = jvm.get_field(&file, "mode", "I").await?;
         if file_type == STDSTREAM || mode == READ_RESOURCE {
             let stream: ClassInstanceRef<InputStream> = jvm.get_field(&file, "is", "Ljava/io/InputStream;").await?;
-            let _: () = jvm.invoke_virtual(&stream, "reset", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&stream, "java/io/InputStream", "reset", "()V", ()).await?;
             let position: i32 = jvm.get_field(&this, "markPosition", "I").await?;
             jvm.put_field(&mut file, "offset", "I", position).await?;
         } else {
             let position: i32 = jvm.get_field(&this, "markPosition", "I").await?;
-            let _: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (position, SEEK_SET)).await?;
+            let _: i32 = jvm
+                .invoke_virtual(&file, "com/xce/io/XFile", "seek", "(II)I", (position, SEEK_SET))
+                .await?;
         }
 
         Ok(())
@@ -236,7 +243,9 @@ impl FileInputStream {
         let mut remaining = count;
         while remaining > 0 {
             let request = remaining.min(scratch_size as i64) as i32;
-            let read: i32 = jvm.invoke_virtual(&this, "read", "([BII)I", (scratch.clone(), 0, request)).await?;
+            let read: i32 = jvm
+                .invoke_virtual(&this, "com/xce/io/FileInputStream", "read", "([BII)I", (scratch.clone(), 0, request))
+                .await?;
             if read <= 0 {
                 break;
             }

--- a/wie_skvm/src/classes/com/xce/io/file_output_stream.rs
+++ b/wie_skvm/src/classes/com/xce/io/file_output_stream.rs
@@ -68,10 +68,12 @@ impl FileOutputStream {
         let file: ClassInstanceRef<XFile> = jvm.new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, WRITE)).await?.into();
         if truncate {
             let raf = XFile::raf(jvm, file.clone()).await?;
-            let _: () = jvm.invoke_virtual(&raf, "setLength", "(J)V", (0_i64,)).await?;
+            let _: () = jvm
+                .invoke_virtual(&raf, "java/io/RandomAccessFile", "setLength", "(J)V", (0_i64,))
+                .await?;
         }
         let whence = if !truncate && existed { SEEK_END } else { SEEK_SET };
-        let _: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (0, whence)).await?;
+        let _: i32 = jvm.invoke_virtual(&file, "com/xce/io/XFile", "seek", "(II)I", (0, whence)).await?;
         jvm.put_field(&mut this, "file", "Lcom/xce/io/XFile;", file).await?;
 
         Ok(())
@@ -126,7 +128,7 @@ impl FileOutputStream {
         let mut buffer = jvm.instantiate_array("B", 1).await?;
         jvm.store_array(&mut buffer, 0, [byte as i8]).await?;
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let _: i32 = jvm.invoke_virtual(&file, "write", "([BII)I", (buffer, 0, 1)).await?;
+        let _: i32 = jvm.invoke_virtual(&file, "com/xce/io/XFile", "write", "([BII)I", (buffer, 0, 1)).await?;
 
         Ok(())
     }
@@ -153,7 +155,9 @@ impl FileOutputStream {
         }
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let _: i32 = jvm.invoke_virtual(&file, "write", "([BII)I", (buffer, offset, length)).await?;
+        let _: i32 = jvm
+            .invoke_virtual(&file, "com/xce/io/XFile", "write", "([BII)I", (buffer, offset, length))
+            .await?;
 
         Ok(())
     }
@@ -162,7 +166,7 @@ impl FileOutputStream {
         tracing::debug!("com.xce.io.FileOutputStream::close({this:?})");
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let _: () = jvm.invoke_virtual(&file, "close", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&file, "com/xce/io/XFile", "close", "()V", ()).await?;
 
         Ok(())
     }
@@ -171,7 +175,7 @@ impl FileOutputStream {
         tracing::debug!("com.xce.io.FileOutputStream::flush({this:?})");
 
         let file: ClassInstanceRef<XFile> = jvm.get_field(&this, "file", "Lcom/xce/io/XFile;").await?;
-        let _: () = jvm.invoke_virtual(&file, "flush", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&file, "com/xce/io/XFile", "flush", "()V", ()).await?;
 
         Ok(())
     }

--- a/wie_skvm/src/classes/com/xce/io/x_file.rs
+++ b/wie_skvm/src/classes/com/xce/io/x_file.rs
@@ -168,9 +168,17 @@ impl XFile {
         jvm.put_field(&mut this, "offset", "I", 0).await?;
 
         if mode == READ_RESOURCE {
-            let class = jvm.invoke_virtual(&this, "getClass", "()Ljava/lang/Class;", ()).await?;
+            let class = jvm
+                .invoke_virtual(&this, "com/xce/io/XFile", "getClass", "()Ljava/lang/Class;", ())
+                .await?;
             let resource_stream: ClassInstanceRef<InputStream> = jvm
-                .invoke_virtual(&class, "getResourceAsStream", "(Ljava/lang/String;)Ljava/io/InputStream;", (name,))
+                .invoke_virtual(
+                    &class,
+                    "java/lang/Class",
+                    "getResourceAsStream",
+                    "(Ljava/lang/String;)Ljava/io/InputStream;",
+                    (name,),
+                )
                 .await?;
             if resource_stream.is_null() {
                 return Err(jvm.exception("java/io/IOException", "Resource not found").await);
@@ -200,7 +208,9 @@ impl XFile {
                 .new_class("java/io/RandomAccessFile", "(Ljava/io/File;Ljava/lang/String;)V", (file, file_mode))
                 .await?
                 .into();
-            let descriptor: ClassInstanceRef<FileDescriptor> = jvm.invoke_virtual(&raf, "getFD", "()Ljava/io/FileDescriptor;", ()).await?;
+            let descriptor: ClassInstanceRef<FileDescriptor> = jvm
+                .invoke_virtual(&raf, "java/io/RandomAccessFile", "getFD", "()Ljava/io/FileDescriptor;", ())
+                .await?;
             let fd: i32 = jvm.get_field(&descriptor, "fd", "I").await?;
 
             jvm.put_field(&mut this, "type", "I", NORMAL).await?;
@@ -241,7 +251,7 @@ impl XFile {
         }
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let exists = jvm.invoke_virtual(&file, "exists", "()Z", ()).await?;
+        let exists = jvm.invoke_virtual(&file, "java/io/File", "exists", "()Z", ()).await?;
 
         Ok(exists)
     }
@@ -258,11 +268,11 @@ impl XFile {
         }
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let exists: bool = jvm.invoke_virtual(&file, "exists", "()Z", ()).await?;
+        let exists: bool = jvm.invoke_virtual(&file, "java/io/File", "exists", "()Z", ()).await?;
         if !exists {
             return Err(jvm.exception("java/io/IOException", "File not found").await);
         }
-        let size: i64 = jvm.invoke_virtual(&file, "length", "()J", ()).await?;
+        let size: i64 = jvm.invoke_virtual(&file, "java/io/File", "length", "()J", ()).await?;
         if size < 0 || size > i32::MAX as i64 {
             return Err(jvm.exception("java/io/IOException", "File is too large").await);
         }
@@ -282,7 +292,7 @@ impl XFile {
         }
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let deleted: bool = jvm.invoke_virtual(&file, "delete", "()Z", ()).await?;
+        let deleted: bool = jvm.invoke_virtual(&file, "java/io/File", "delete", "()Z", ()).await?;
         if !deleted {
             return Err(jvm.exception("java/io/IOException", "Unable to delete file").await);
         }
@@ -303,13 +313,13 @@ impl XFile {
             if is.is_null() {
                 return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
             }
-            let available = jvm.invoke_virtual(&is, "available", "()I", ()).await?;
+            let available = jvm.invoke_virtual(&is, "java/io/InputStream", "available", "()I", ()).await?;
 
             Ok(available)
         } else {
             let raf: ClassInstanceRef<RandomAccessFile> = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-            let file_length: i64 = jvm.invoke_virtual(&raf, "length", "()J", ()).await?;
-            let file_pointer: i64 = jvm.invoke_virtual(&raf, "getFilePointer", "()J", ()).await?;
+            let file_length: i64 = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "length", "()J", ()).await?;
+            let file_pointer: i64 = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "getFilePointer", "()J", ()).await?;
 
             Ok((file_length - file_pointer).clamp(0, i32::MAX as i64) as i32)
         }
@@ -344,14 +354,16 @@ impl XFile {
                 return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
             }
 
-            jvm.invoke_virtual(&is, "read", "([BII)I", (data, offset, length)).await?
+            jvm.invoke_virtual(&is, "java/io/InputStream", "read", "([BII)I", (data, offset, length))
+                .await?
         } else {
             if mode != READ && mode != READ_WRITE {
                 return Err(jvm.exception("java/io/IOException", "File is not open for reading").await);
             }
             let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
 
-            jvm.invoke_virtual(&raf, "read", "([BII)I", (data, offset, length)).await?
+            jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "read", "([BII)I", (data, offset, length))
+                .await?
         };
 
         if read > 0 {
@@ -390,13 +402,17 @@ impl XFile {
             if os.is_null() {
                 return Err(jvm.exception("java/io/IOException", "File is not open for writing").await);
             }
-            let _: () = jvm.invoke_virtual(&os, "write", "([BII)V", (data, offset, length)).await?;
+            let _: () = jvm
+                .invoke_virtual(&os, "java/io/OutputStream", "write", "([BII)V", (data, offset, length))
+                .await?;
         } else {
             if mode != WRITE && mode != READ_WRITE {
                 return Err(jvm.exception("java/io/IOException", "File is not open for writing").await);
             }
             let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-            let _: () = jvm.invoke_virtual(&raf, "write", "([BII)V", (data, offset, length)).await?;
+            let _: () = jvm
+                .invoke_virtual(&raf, "java/io/RandomAccessFile", "write", "([BII)V", (data, offset, length))
+                .await?;
         }
 
         let old_offset: i32 = jvm.get_field(&this, "offset", "I").await?;
@@ -414,10 +430,10 @@ impl XFile {
             return Ok(());
         } else if mode == READ_RESOURCE {
             let is: ClassInstanceRef<InputStream> = jvm.get_field(&this, "is", "Ljava/io/InputStream;").await?;
-            let _: () = jvm.invoke_virtual(&is, "close", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&is, "java/io/InputStream", "close", "()V", ()).await?;
         } else {
             let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-            let _: () = jvm.invoke_virtual(&raf, "close", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "close", "()V", ()).await?;
         }
 
         Ok(())
@@ -432,7 +448,7 @@ impl XFile {
             if os.is_null() {
                 return Err(jvm.exception("java/io/IOException", "File is not open for writing").await);
             }
-            let _: () = jvm.invoke_virtual(&os, "flush", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&os, "java/io/OutputStream", "flush", "()V", ()).await?;
         }
 
         Ok(())
@@ -451,11 +467,11 @@ impl XFile {
         let new_pos = match whence {
             SEEK_SET => Some(n as i64),
             SEEK_CUR => {
-                let current: i64 = jvm.invoke_virtual(&raf, "getFilePointer", "()J", ()).await?;
+                let current: i64 = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "getFilePointer", "()J", ()).await?;
                 current.checked_add(n as i64)
             }
             SEEK_END => {
-                let length: i64 = jvm.invoke_virtual(&raf, "length", "()J", ()).await?;
+                let length: i64 = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "length", "()J", ()).await?;
                 length.checked_add(n as i64)
             }
             _ => return Err(jvm.exception("java/io/IOException", "Invalid whence").await),
@@ -467,7 +483,7 @@ impl XFile {
             return Err(jvm.exception("java/io/IOException", "Invalid seek position").await);
         }
 
-        let _: () = jvm.invoke_virtual(&raf, "seek", "(J)V", (new_pos,)).await?;
+        let _: () = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "seek", "(J)V", (new_pos,)).await?;
         jvm.put_field(&mut this, "offset", "I", new_pos as i32).await?;
 
         Ok(new_pos as i32)
@@ -554,14 +570,16 @@ mod tests {
 
                 let mut source = jvm.instantiate_array("B", 4).await?;
                 jvm.store_array(&mut source, 0, [10_i8, 20, 30, 40]).await?;
-                let written: i32 = jvm.invoke_virtual(&file, "write", "([BII)I", (source, 1, 2)).await?;
+                let written: i32 = jvm.invoke_virtual(&file, "com/xce/io/XFile", "write", "([BII)I", (source, 1, 2)).await?;
                 assert_eq!(written, 2);
 
-                let position: i32 = jvm.invoke_virtual(&file, "seek", "(II)I", (0, seek_set)).await?;
+                let position: i32 = jvm.invoke_virtual(&file, "com/xce/io/XFile", "seek", "(II)I", (0, seek_set)).await?;
                 assert_eq!(position, 0);
 
                 let target: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 4).await?.into();
-                let read: i32 = jvm.invoke_virtual(&file, "read", "([BII)I", (target.clone(), 1, 2)).await?;
+                let read: i32 = jvm
+                    .invoke_virtual(&file, "com/xce/io/XFile", "read", "([BII)I", (target.clone(), 1, 2))
+                    .await?;
                 assert_eq!(read, 2);
                 assert_eq!(jvm.load_array::<i8>(&target, 0, 4).await?, [0, 20, 30, 0]);
 
@@ -584,31 +602,56 @@ mod tests {
                     .into();
                 let mut source = jvm.instantiate_array("B", 4).await?;
                 jvm.store_array(&mut source, 0, [1_i8, 2, 3, 4]).await?;
-                let _: () = jvm.invoke_virtual(&output, "write", "([BII)V", (source, 1, 2)).await?;
-                let _: () = jvm.invoke_virtual(&output, "flush", "()V", ()).await?;
-                let _: () = jvm.invoke_virtual(&output, "close", "()V", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&output, "com/xce/io/FileOutputStream", "write", "([BII)V", (source, 1, 2))
+                    .await?;
+                let _: () = jvm.invoke_virtual(&output, "com/xce/io/FileOutputStream", "flush", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&output, "com/xce/io/FileOutputStream", "close", "()V", ()).await?;
 
                 let append_output: ClassInstanceRef<FileOutputStream> = jvm
                     .new_class("com/xce/io/FileOutputStream", "(Ljava/lang/String;Z)V", (name.clone(), false))
                     .await?
                     .into();
-                let _: () = jvm.invoke_virtual(&append_output, "write", "(I)V", (4,)).await?;
-                let _: () = jvm.invoke_virtual(&append_output, "close", "()V", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&append_output, "com/xce/io/FileOutputStream", "write", "(I)V", (4,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&append_output, "com/xce/io/FileOutputStream", "close", "()V", ())
+                    .await?;
 
                 let input: ClassInstanceRef<FileInputStream> = jvm
                     .new_class("com/xce/io/FileInputStream", "(Ljava/lang/String;)V", (name,))
                     .await?
                     .into();
-                assert!(jvm.invoke_virtual::<_, bool>(&input, "markSupported", "()Z", ()).await?);
-                let _: () = jvm.invoke_virtual(&input, "mark", "(I)V", (8,)).await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 2);
-                let _: () = jvm.invoke_virtual(&input, "reset", "()V", ()).await?;
-                assert_eq!(jvm.invoke_virtual::<_, i64>(&input, "skip", "(J)J", (1_i64,)).await?, 1);
+                assert!(
+                    jvm.invoke_virtual::<_, bool>(&input, "com/xce/io/FileInputStream", "markSupported", "()Z", ())
+                        .await?
+                );
+                let _: () = jvm.invoke_virtual(&input, "com/xce/io/FileInputStream", "mark", "(I)V", (8,)).await?;
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "()I", ())
+                        .await?,
+                    2
+                );
+                let _: () = jvm.invoke_virtual(&input, "com/xce/io/FileInputStream", "reset", "()V", ()).await?;
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i64>(&input, "com/xce/io/FileInputStream", "skip", "(J)J", (1_i64,))
+                        .await?,
+                    1
+                );
 
                 let target: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 2).await?.into();
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "([B)I", (target.clone(),)).await?, 2);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "([B)I", (target.clone(),))
+                        .await?,
+                    2
+                );
                 assert_eq!(jvm.load_array::<i8>(&target, 0, 2).await?, [3, 4]);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, -1);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "()I", ())
+                        .await?,
+                    -1
+                );
 
                 Ok(())
             },
@@ -630,14 +673,16 @@ mod tests {
                     .into();
                 let data: ClassInstanceRef<Array<i8>> = jvm.instantiate_array("B", 2).await?.into();
 
-                let range_result: JvmResult<i32> = jvm.invoke_virtual(&file, "read", "([BII)I", (data, i32::MAX, 1)).await;
+                let range_result: JvmResult<i32> = jvm
+                    .invoke_virtual(&file, "com/xce/io/XFile", "read", "([BII)I", (data, i32::MAX, 1))
+                    .await;
                 let Err(JavaError::JavaException(exception)) = range_result else {
                     panic!("XFile.read accepted an invalid range");
                 };
                 assert!(jvm.is_instance(&*exception, "java/lang/IndexOutOfBoundsException"));
 
                 let null_data = ClassInstanceRef::<Array<i8>>::new(None);
-                let null_result: JvmResult<i32> = jvm.invoke_virtual(&file, "write", "([BII)I", (null_data, 0, 1)).await;
+                let null_result: JvmResult<i32> = jvm.invoke_virtual(&file, "com/xce/io/XFile", "write", "([BII)I", (null_data, 0, 1)).await;
                 let Err(JavaError::JavaException(exception)) = null_result else {
                     panic!("XFile.write accepted null");
                 };
@@ -660,14 +705,20 @@ mod tests {
                     .new_class("com/xce/io/FileOutputStream", "(Ljava/lang/String;Z)V", (name.clone(), false))
                     .await?
                     .into();
-                let _: () = jvm.invoke_virtual(&output, "write", "(I)V", (0xAB,)).await?;
-                let _: () = jvm.invoke_virtual(&output, "close", "()V", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&output, "com/xce/io/FileOutputStream", "write", "(I)V", (0xAB,))
+                    .await?;
+                let _: () = jvm.invoke_virtual(&output, "com/xce/io/FileOutputStream", "close", "()V", ()).await?;
 
                 let input: ClassInstanceRef<FileInputStream> = jvm
                     .new_class("com/xce/io/FileInputStream", "(Ljava/lang/String;)V", (name,))
                     .await?
                     .into();
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 0xAB);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "()I", ())
+                        .await?,
+                    0xAB
+                );
 
                 Ok(())
             },
@@ -725,18 +776,29 @@ mod tests {
             Box::new([Box::new([XFile::as_proto(), FileInputStream::as_proto(), FileOutputStream::as_proto()])]),
             |jvm| async move {
                 let input: ClassInstanceRef<FileInputStream> = jvm.new_class("com/xce/io/FileInputStream", "(I)V", (0,)).await?.into();
-                assert!(jvm.invoke_virtual::<_, bool>(&input, "markSupported", "()Z", ()).await?);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "available", "()I", ()).await?, 0);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, -1);
-                let _: () = jvm.invoke_virtual(&input, "mark", "(I)V", (1,)).await?;
-                let _: () = jvm.invoke_virtual(&input, "reset", "()V", ()).await?;
+                assert!(
+                    jvm.invoke_virtual::<_, bool>(&input, "com/xce/io/FileInputStream", "markSupported", "()Z", ())
+                        .await?
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "available", "()I", ())
+                        .await?,
+                    0
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "()I", ())
+                        .await?,
+                    -1
+                );
+                let _: () = jvm.invoke_virtual(&input, "com/xce/io/FileInputStream", "mark", "(I)V", (1,)).await?;
+                let _: () = jvm.invoke_virtual(&input, "com/xce/io/FileInputStream", "reset", "()V", ()).await?;
 
                 let first: ClassInstanceRef<FileOutputStream> = jvm.new_class("com/xce/io/FileOutputStream", "(I)V", (1,)).await?.into();
-                let _: () = jvm.invoke_virtual(&first, "write", "(I)V", (1,)).await?;
-                let _: () = jvm.invoke_virtual(&first, "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&first, "com/xce/io/FileOutputStream", "write", "(I)V", (1,)).await?;
+                let _: () = jvm.invoke_virtual(&first, "com/xce/io/FileOutputStream", "close", "()V", ()).await?;
                 let second: ClassInstanceRef<FileOutputStream> = jvm.new_class("com/xce/io/FileOutputStream", "(I)V", (1,)).await?.into();
-                let _: () = jvm.invoke_virtual(&second, "write", "(I)V", (2,)).await?;
-                let _: () = jvm.invoke_virtual(&second, "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&second, "com/xce/io/FileOutputStream", "write", "(I)V", (2,)).await?;
+                let _: () = jvm.invoke_virtual(&second, "com/xce/io/FileOutputStream", "close", "()V", ()).await?;
 
                 Ok(())
             },
@@ -753,7 +815,7 @@ mod tests {
                 let write: i32 = jvm.get_static_field("com/xce/io/XFile", "WRITE", "I").await?;
                 let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "write-only.dat").await?.into();
                 let write_only: ClassInstanceRef<XFile> = jvm.new_class("com/xce/io/XFile", "(Ljava/lang/String;I)V", (name, write)).await?.into();
-                let available_result: JvmResult<i32> = jvm.invoke_virtual(&write_only, "available", "()I", ()).await;
+                let available_result: JvmResult<i32> = jvm.invoke_virtual(&write_only, "com/xce/io/XFile", "available", "()I", ()).await;
                 let Err(JavaError::JavaException(exception)) = available_result else {
                     panic!("write-only XFile reported readable bytes");
                 };
@@ -770,8 +832,10 @@ mod tests {
 
                 let mut one_byte = jvm.instantiate_array("B", 1).await?;
                 jvm.store_array(&mut one_byte, 0, [1_i8]).await?;
-                let _: i32 = jvm.invoke_virtual(&write_only, "write", "([BII)I", (one_byte, 0, 1)).await?;
-                let _: () = jvm.invoke_virtual(&write_only, "close", "()V", ()).await?;
+                let _: i32 = jvm
+                    .invoke_virtual(&write_only, "com/xce/io/XFile", "write", "([BII)I", (one_byte, 0, 1))
+                    .await?;
+                let _: () = jvm.invoke_virtual(&write_only, "com/xce/io/XFile", "close", "()V", ()).await?;
 
                 let read: i32 = jvm.get_static_field("com/xce/io/XFile", "READ", "I").await?;
                 let name: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "write-only.dat").await?.into();
@@ -797,12 +861,20 @@ mod tests {
                     .new_class("com/xce/io/FileInputStream", "(Lcom/xce/io/XFile;)V", (resource.clone(),))
                     .await?
                     .into();
-                let _: () = jvm.invoke_virtual(&input, "mark", "(I)V", (2,)).await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 7);
+                let _: () = jvm.invoke_virtual(&input, "com/xce/io/FileInputStream", "mark", "(I)V", (2,)).await?;
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "()I", ())
+                        .await?,
+                    7
+                );
                 assert_eq!(jvm.get_field::<i32>(&resource, "offset", "I").await?, 1);
-                let _: () = jvm.invoke_virtual(&input, "reset", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&input, "com/xce/io/FileInputStream", "reset", "()V", ()).await?;
                 assert_eq!(jvm.get_field::<i32>(&resource, "offset", "I").await?, 0);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&input, "read", "()I", ()).await?, 7);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&input, "com/xce/io/FileInputStream", "read", "()I", ())
+                        .await?,
+                    7
+                );
 
                 Ok(())
             },

--- a/wie_skvm/src/classes/com/xce/lcdui/toolkit.rs
+++ b/wie_skvm/src/classes/com/xce/lcdui/toolkit.rs
@@ -237,11 +237,13 @@ impl Toolkit {
         jvm.put_static_field("com/xce/lcdui/Toolkit", "DEFAULT_FONT", "Ljavax/microedition/lcdui/Font;", font.clone())
             .await?;
 
-        let font_height: i32 = jvm.invoke_virtual(&font, "getHeight", "()I", ()).await?;
+        let font_height: i32 = jvm.invoke_virtual(&font, "javax/microedition/lcdui/Font", "getHeight", "()I", ()).await?;
         jvm.put_static_field("com/xce/lcdui/Toolkit", "FONT_HEIGHT", "I", font_height).await?;
         jvm.put_static_field("com/xce/lcdui/Toolkit", "FONT_GAP", "I", 0).await?;
 
-        let max_char_width: i32 = jvm.invoke_virtual(&font, "charWidth", "(C)I", ('W' as u16,)).await?;
+        let max_char_width: i32 = jvm
+            .invoke_virtual(&font, "javax/microedition/lcdui/Font", "charWidth", "(C)I", ('W' as u16,))
+            .await?;
         jvm.put_static_field("com/xce/lcdui/Toolkit", "MAX_CHARWIDTH", "I", max_char_width)
             .await?;
 
@@ -300,11 +302,11 @@ impl Toolkit {
 
         let image_data = match JavaIoInputStream::read_until_end(jvm, &stream).await {
             Ok(image_data) => {
-                let _: () = jvm.invoke_virtual(&stream, "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&stream, "java/io/InputStream", "close", "()V", ()).await?;
                 image_data
             }
             Err(error) => {
-                let _: JvmResult<()> = jvm.invoke_virtual(&stream, "close", "()V", ()).await;
+                let _: JvmResult<()> = jvm.invoke_virtual(&stream, "java/io/InputStream", "close", "()V", ()).await;
                 return Err(error);
             }
         };
@@ -367,11 +369,17 @@ impl Toolkit {
         let font: ClassInstanceRef<Font> = jvm
             .get_static_field("com/xce/lcdui/Toolkit", "DEFAULT_FONT", "Ljavax/microedition/lcdui/Font;")
             .await?;
-        let string_length: i32 = jvm.invoke_virtual(&string, "length", "()I", ()).await?;
+        let string_length: i32 = jvm.invoke_virtual(&string, "java/lang/String", "length", "()I", ()).await?;
         let mut fitting_length = 0;
         for length in 1..=string_length {
             let width: i32 = jvm
-                .invoke_virtual(&font, "substringWidth", "(Ljava/lang/String;II)I", (string.clone(), 0, length))
+                .invoke_virtual(
+                    &font,
+                    "javax/microedition/lcdui/Font",
+                    "substringWidth",
+                    "(Ljava/lang/String;II)I",
+                    (string.clone(), 0, length),
+                )
                 .await?;
             if width > max_width {
                 break;
@@ -506,7 +514,15 @@ mod tests {
                 let font = jvm
                     .get_static_field("com/xce/lcdui/Toolkit", "DEFAULT_FONT", "Ljavax/microedition/lcdui/Font;")
                     .await?;
-                let width: i32 = jvm.invoke_virtual(&font, "stringWidth", "(Ljava/lang/String;)I", (text.clone(),)).await?;
+                let width: i32 = jvm
+                    .invoke_virtual(
+                        &font,
+                        "javax/microedition/lcdui/Font",
+                        "stringWidth",
+                        "(Ljava/lang/String;)I",
+                        (text.clone(),),
+                    )
+                    .await?;
                 let split: i32 = jvm
                     .invoke_static("com/xce/lcdui/Toolkit", "splitString", "(Ljava/lang/String;I)I", (text, width))
                     .await?;

--- a/wie_skvm/src/classes/com/xce/lcdui/x_display.rs
+++ b/wie_skvm/src/classes/com/xce/lcdui/x_display.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{FieldAccessFlags, MethodAccessFlags};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -18,20 +18,20 @@ impl XDisplay {
             interfaces: vec![],
             methods: vec![
                 JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("refresh", "(IIII)V", Self::refresh, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("refresh", "(IIII)V", Self::refresh, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
                 JavaMethodProto::new(
                     "copyLCD",
                     "(Ljavax/microedition/lcdui/Graphics;Ljavax/microedition/lcdui/Image;IIII)V",
                     Self::copy_lcd,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("width", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("height", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("height2", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("width", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("height", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("height2", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_skvm/src/classes/com/xce/lcdui/x_text_field.rs
+++ b/wie_skvm/src/classes/com/xce/lcdui/x_text_field.rs
@@ -83,9 +83,10 @@ impl XTextField {
     }
 
     async fn truncate_text(jvm: &Jvm, text: ClassInstanceRef<String>, max_size: i32) -> JvmResult<ClassInstanceRef<String>> {
-        let length: i32 = jvm.invoke_virtual(&text, "length", "()I", ()).await?;
+        let length: i32 = jvm.invoke_virtual(&text, "java/lang/String", "length", "()I", ()).await?;
         if length > max_size {
-            jvm.invoke_virtual(&text, "substring", "(II)Ljava/lang/String;", (0, max_size)).await
+            jvm.invoke_virtual(&text, "java/lang/String", "substring", "(II)Ljava/lang/String;", (0, max_size))
+                .await
         } else {
             Ok(text)
         }
@@ -108,7 +109,7 @@ impl XTextField {
         tracing::debug!("com.xce.lcdui.XTextField::inputChar({this:?}, {key})");
 
         let text: ClassInstanceRef<String> = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
-        let length: i32 = jvm.invoke_virtual(&text, "length", "()I", ()).await?;
+        let length: i32 = jvm.invoke_virtual(&text, "java/lang/String", "length", "()I", ()).await?;
         let max_size: i32 = jvm.get_field(&this, "maxSize", "I").await?;
         if length >= max_size {
             return Ok(());
@@ -116,7 +117,13 @@ impl XTextField {
 
         let char_string: ClassInstanceRef<String> = jvm.invoke_static("java/lang/String", "valueOf", "(C)Ljava/lang/String;", (key,)).await?;
         let text: ClassInstanceRef<String> = jvm
-            .invoke_virtual(&text, "concat", "(Ljava/lang/String;)Ljava/lang/String;", (char_string,))
+            .invoke_virtual(
+                &text,
+                "java/lang/String",
+                "concat",
+                "(Ljava/lang/String;)Ljava/lang/String;",
+                (char_string,),
+            )
             .await?;
         jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await
     }
@@ -186,17 +193,45 @@ impl XTextField {
         let y: i32 = jvm.get_field(&this, "y", "I").await?;
         let width: i32 = jvm.get_field(&this, "width", "I").await?;
         let height: i32 = jvm.get_field(&this, "height", "I").await?;
-        let clip_x: i32 = jvm.invoke_virtual(&graphics, "getClipX", "()I", ()).await?;
-        let clip_y: i32 = jvm.invoke_virtual(&graphics, "getClipY", "()I", ()).await?;
-        let clip_width: i32 = jvm.invoke_virtual(&graphics, "getClipWidth", "()I", ()).await?;
-        let clip_height: i32 = jvm.invoke_virtual(&graphics, "getClipHeight", "()I", ()).await?;
+        let clip_x: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+            .await?;
+        let clip_y: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+            .await?;
+        let clip_width: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+            .await?;
+        let clip_height: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+            .await?;
 
-        let _: () = jvm.invoke_virtual(&graphics, "clipRect", "(IIII)V", (x, y, width, height)).await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "clipRect",
+                "(IIII)V",
+                (x, y, width, height),
+            )
+            .await?;
         let draw_result: JvmResult<()> = jvm
-            .invoke_virtual(&graphics, "drawString", "(Ljava/lang/String;III)V", (text, x, y, 20))
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "drawString",
+                "(Ljava/lang/String;III)V",
+                (text, x, y, 20),
+            )
             .await;
         let restore_result: JvmResult<()> = jvm
-            .invoke_virtual(&graphics, "setClip", "(IIII)V", (clip_x, clip_y, clip_width, clip_height))
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "setClip",
+                "(IIII)V",
+                (clip_x, clip_y, clip_width, clip_height),
+            )
             .await;
         draw_result?;
         restore_result
@@ -210,7 +245,8 @@ impl XTextField {
         let y: i32 = jvm.get_field(&this, "y", "I").await?;
         let width: i32 = jvm.get_field(&this, "width", "I").await?;
         let height: i32 = jvm.get_field(&this, "height", "I").await?;
-        jvm.invoke_virtual(&canvas, "repaint", "(IIII)V", (x, y, width, height)).await
+        jvm.invoke_virtual(&canvas, "javax/microedition/lcdui/Canvas", "repaint", "(IIII)V", (x, y, width, height))
+            .await
     }
 
     async fn set_max_size(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, max_size: i32) -> JvmResult<()> {
@@ -357,10 +393,18 @@ mod tests {
             _y: i32,
             _anchor: i32,
         ) -> JvmResult<()> {
-            let clip_x: i32 = jvm.invoke_virtual(&this, "getClipX", "()I", ()).await?;
-            let clip_y: i32 = jvm.invoke_virtual(&this, "getClipY", "()I", ()).await?;
-            let clip_width: i32 = jvm.invoke_virtual(&this, "getClipWidth", "()I", ()).await?;
-            let clip_height: i32 = jvm.invoke_virtual(&this, "getClipHeight", "()I", ()).await?;
+            let clip_x: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+                .await?;
+            let clip_y: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+                .await?;
+            let clip_width: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+                .await?;
+            let clip_height: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+                .await?;
             jvm.put_field(&mut this, "observedClipX", "I", clip_x).await?;
             jvm.put_field(&mut this, "observedClipY", "I", clip_y).await?;
             jvm.put_field(&mut this, "observedClipWidth", "I", clip_width).await?;
@@ -387,56 +431,85 @@ mod tests {
                     .await?
                     .into();
 
-                let max_size: i32 = jvm.invoke_virtual(&field, "getMaxSize", "()I", ()).await?;
-                let focused: bool = jvm.invoke_virtual(&field, "hasFocus", "()Z", ()).await?;
+                let max_size: i32 = jvm.invoke_virtual(&field, "com/xce/lcdui/XTextField", "getMaxSize", "()I", ()).await?;
+                let focused: bool = jvm.invoke_virtual(&field, "com/xce/lcdui/XTextField", "hasFocus", "()Z", ()).await?;
                 assert_eq!(max_size, 5);
                 assert!(!focused);
 
-                let _: () = jvm.invoke_virtual(&field, "keyPressed", "(I)V", ('z' as i32,)).await?;
-                let text: ClassInstanceRef<String> = jvm.invoke_virtual(&field, "getText", "()Ljava/lang/String;", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "keyPressed", "(I)V", ('z' as i32,))
+                    .await?;
+                let text: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "getText", "()Ljava/lang/String;", ())
+                    .await?;
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &text).await?, "abc");
 
-                let _: () = jvm.invoke_virtual(&field, "setFocus", "(Z)V", (true,)).await?;
-                let _: () = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", (3, 5, 40, 12)).await?;
-                let _: () = jvm.invoke_virtual(&field, "keyPressed", "(I)V", ('d' as i32,)).await?;
-                let _: () = jvm.invoke_virtual(&field, "keyRepeated", "(I)V", ('e' as i32,)).await?;
-                let _: () = jvm.invoke_virtual(&field, "inputChar", "(C)V", ('f' as JavaChar,)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setFocus", "(Z)V", (true,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setBounds", "(IIII)V", (3, 5, 40, 12))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "keyPressed", "(I)V", ('d' as i32,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "keyRepeated", "(I)V", ('e' as i32,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "inputChar", "(C)V", ('f' as JavaChar,))
+                    .await?;
 
-                let text: ClassInstanceRef<String> = jvm.invoke_virtual(&field, "getText", "()Ljava/lang/String;", ()).await?;
+                let text: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "getText", "()Ljava/lang/String;", ())
+                    .await?;
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &text).await?, "abcde");
-                assert!(jvm.invoke_virtual::<_, bool>(&field, "hasFocus", "()Z", ()).await?);
+                assert!(
+                    jvm.invoke_virtual::<_, bool>(&field, "com/xce/lcdui/XTextField", "hasFocus", "()Z", ())
+                        .await?
+                );
 
                 for bounds in [(9, 8, -1, 4), (7, 6, 4, -1)] {
-                    let bounds_result: JvmResult<()> = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", bounds).await;
+                    let bounds_result: JvmResult<()> = jvm
+                        .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setBounds", "(IIII)V", bounds)
+                        .await;
                     let Err(JavaError::JavaException(exception)) = bounds_result else {
                         panic!("XTextField.setBounds accepted a negative size");
                     };
                     assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
                 }
 
-                let _: () = jvm.invoke_virtual(&field, "setMaxSize", "(I)V", (3,)).await?;
+                let _: () = jvm.invoke_virtual(&field, "com/xce/lcdui/XTextField", "setMaxSize", "(I)V", (3,)).await?;
                 let replacement: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "wxyz").await?.into();
-                let _: () = jvm.invoke_virtual(&field, "setText", "(Ljava/lang/String;)V", (replacement,)).await?;
-                let text: ClassInstanceRef<String> = jvm.invoke_virtual(&field, "getText", "()Ljava/lang/String;", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setText", "(Ljava/lang/String;)V", (replacement,))
+                    .await?;
+                let text: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "getText", "()Ljava/lang/String;", ())
+                    .await?;
                 assert_eq!(JavaLangString::to_rust_string(&jvm, &text).await?, "wxy");
 
-                let _: () = jvm.invoke_virtual(&field, "repaint", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&field, "com/xce/lcdui/XTextField", "repaint", "()V", ()).await?;
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintCount", "I").await?, 1);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintX", "I").await?, 3);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintY", "I").await?, 5);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintWidth", "I").await?, 40);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintHeight", "I").await?, 12);
 
-                let _: () = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", (1, 2, 0, 0)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setBounds", "(IIII)V", (1, 2, 0, 0))
+                    .await?;
 
-                let negative_result: JvmResult<()> = jvm.invoke_virtual(&field, "setMaxSize", "(I)V", (-1,)).await;
+                let negative_result: JvmResult<()> = jvm.invoke_virtual(&field, "com/xce/lcdui/XTextField", "setMaxSize", "(I)V", (-1,)).await;
                 let Err(JavaError::JavaException(exception)) = negative_result else {
                     panic!("XTextField.setMaxSize accepted a negative value");
                 };
                 assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
 
                 let null_text = ClassInstanceRef::<String>::new(None);
-                let null_result: JvmResult<()> = jvm.invoke_virtual(&field, "setText", "(Ljava/lang/String;)V", (null_text,)).await;
+                let null_result: JvmResult<()> = jvm
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setText", "(Ljava/lang/String;)V", (null_text,))
+                    .await;
                 let Err(JavaError::JavaException(exception)) = null_result else {
                     panic!("XTextField.setText accepted null");
                 };
@@ -469,20 +542,46 @@ mod tests {
                     .into();
                 let graphics: ClassInstanceRef<Graphics> = jvm.new_class("javax/microedition/lcdui/TrackingGraphics", "()V", ()).await?.into();
 
-                let _: () = jvm.invoke_virtual(&field, "setBounds", "(IIII)V", (3, 5, 4, 6)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (1, 2, 10, 11)).await?;
                 let _: () = jvm
-                    .invoke_virtual(&field, "paint", "(Ljavax/microedition/lcdui/Graphics;)V", (graphics.clone(),))
+                    .invoke_virtual(&field, "com/xce/lcdui/XTextField", "setBounds", "(IIII)V", (3, 5, 4, 6))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (1, 2, 10, 11))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &field,
+                        "com/xce/lcdui/XTextField",
+                        "paint",
+                        "(Ljavax/microedition/lcdui/Graphics;)V",
+                        (graphics.clone(),),
+                    )
                     .await?;
 
                 assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipX", "I").await?, 3);
                 assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipY", "I").await?, 5);
                 assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipWidth", "I").await?, 4);
                 assert_eq!(jvm.get_field::<i32>(&graphics, "observedClipHeight", "I").await?, 6);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipX", "()I", ()).await?, 1);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipY", "()I", ()).await?, 2);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipWidth", "()I", ()).await?, 10);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipHeight", "()I", ()).await?, 11);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+                        .await?,
+                    1
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+                        .await?,
+                    2
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+                        .await?,
+                    10
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+                        .await?,
+                    11
+                );
 
                 Ok(())
             },

--- a/wie_skvm/src/classes/net/wie/wie_audio_clip.rs
+++ b/wie_skvm/src/classes/net/wie/wie_audio_clip.rs
@@ -138,17 +138,21 @@ mod test {
                 (data.clone(), 0, 3),
                 (data.clone(), 1, 2),
             ] {
-                let _: () = jvm.invoke_virtual(&clip, "open", "([BII)V", (array, offset, length)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&clip, "net/wie/WieAudioClip", "open", "([BII)V", (array, offset, length))
+                    .await?;
             }
-            let _: () = jvm.invoke_virtual(&clip, "play", "()V", ()).await?;
-            let _: () = jvm.invoke_virtual(&clip, "loop", "()V", ()).await?;
-            let _: () = jvm.invoke_virtual(&clip, "pause", "()V", ()).await?;
-            let _: () = jvm.invoke_virtual(&clip, "resume", "()V", ()).await?;
-            let _: () = jvm.invoke_virtual(&clip, "stop", "()V", ()).await?;
-            let _: () = jvm.invoke_virtual(&clip, "close", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "net/wie/WieAudioClip", "play", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "net/wie/WieAudioClip", "loop", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "net/wie/WieAudioClip", "pause", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "net/wie/WieAudioClip", "resume", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "net/wie/WieAudioClip", "stop", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&clip, "net/wie/WieAudioClip", "close", "()V", ()).await?;
 
             for (offset, length) in [(-1, 1), (0, -1), (3, 1), (2, 2)] {
-                let invalid: JvmResult<()> = jvm.invoke_virtual(&clip, "open", "([BII)V", (data.clone(), offset, length)).await;
+                let invalid: JvmResult<()> = jvm
+                    .invoke_virtual(&clip, "net/wie/WieAudioClip", "open", "([BII)V", (data.clone(), offset, length))
+                    .await;
                 let Err(JavaError::JavaException(exception)) = invalid else {
                     panic!("AudioClip.open accepted invalid range ({offset}, {length})");
                 };
@@ -156,7 +160,9 @@ mod test {
             }
 
             let null_data = ClassInstanceRef::<Array<i8>>::new(None);
-            let null_result: JvmResult<()> = jvm.invoke_virtual(&clip, "open", "([BII)V", (null_data, 0, 0)).await;
+            let null_result: JvmResult<()> = jvm
+                .invoke_virtual(&clip, "net/wie/WieAudioClip", "open", "([BII)V", (null_data, 0, 0))
+                .await;
             let Err(JavaError::JavaException(exception)) = null_result else {
                 panic!("AudioClip.open accepted a null byte array");
             };

--- a/wie_wipi_java/src/classes/net/wie/card_canvas.rs
+++ b/wie_wipi_java/src/classes/net/wie/card_canvas.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::{Class, String};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -115,21 +116,26 @@ impl CardCanvas {
             parent_class: Some("javax/microedition/lcdui/Canvas"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Self::paint, Default::default()),
-                JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, Default::default()),
-                JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, Default::default()),
-                JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, Default::default()),
-                JavaMethodProto::new("pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", Self::push_card, Default::default()),
-                JavaMethodProto::new("popCard", "()Lorg/kwis/msp/lcdui/Card;", Self::pop_card, Default::default()),
-                JavaMethodProto::new("removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", Self::remove_card, Default::default()),
-                JavaMethodProto::new("countCard", "()I", Self::count_card, Default::default()),
-                JavaMethodProto::new("removeAllCards", "()V", Self::remove_all_cards, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "paint",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    Self::paint,
+                    MethodAccessFlags::PROTECTED,
+                ),
+                JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", Self::push_card, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("popCard", "()Lorg/kwis/msp/lcdui/Card;", Self::pop_card, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", Self::remove_card, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("countCard", "()I", Self::count_card, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("removeAllCards", "()V", Self::remove_all_cards, MethodAccessFlags::PUBLIC),
                 // wie private
-                JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, Default::default()),
+                JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::PROTECTED),
             ],
-            fields: vec![JavaFieldProto::new("cards", "Ljava/util/Vector;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new("cards", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -138,7 +144,9 @@ impl CardCanvas {
 
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Canvas", "<init>", "()V", ()).await?;
 
-        let _: () = jvm.invoke_virtual(&this, "setFullScreenMode", "(Z)V", (true,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "setFullScreenMode", "(Z)V", (true,))
+            .await?;
 
         let cards = jvm.new_class("java/util/Vector", "()V", ()).await?;
         jvm.put_field(&mut this, "cards", "Ljava/util/Vector;", cards).await?;
@@ -154,20 +162,30 @@ impl CardCanvas {
             .await?;
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
 
         for i in 0..length {
-            let card = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (i,)).await?;
-            let x: i32 = jvm.invoke_virtual(&card, "getX", "()I", ()).await?;
-            let y: i32 = jvm.invoke_virtual(&card, "getY", "()I", ()).await?;
+            let card = jvm
+                .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (i,))
+                .await?;
+            let x: i32 = jvm.invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "getX", "()I", ()).await?;
+            let y: i32 = jvm.invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "getY", "()I", ()).await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "reset", "()V", ()).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (x, y)).await?;
+            let _: () = jvm.invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "reset", "()V", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "translate", "(II)V", (x, y))
+                .await?;
 
             let paint_result: JvmResult<()> = jvm
-                .invoke_virtual(&card, "paint", "(Lorg/kwis/msp/lcdui/Graphics;)V", (graphics.clone(),))
+                .invoke_virtual(
+                    &card,
+                    "org/kwis/msp/lcdui/Card",
+                    "paint",
+                    "(Lorg/kwis/msp/lcdui/Graphics;)V",
+                    (graphics.clone(),),
+                )
                 .await;
-            let reset_result: JvmResult<()> = jvm.invoke_virtual(&graphics, "reset", "()V", ()).await;
+            let reset_result: JvmResult<()> = jvm.invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "reset", "()V", ()).await;
             paint_result?;
             reset_result?;
         }
@@ -181,11 +199,15 @@ impl CardCanvas {
         let key_code = WIPIKeyCode::from_midp_raw(key_code);
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
 
         for i in (0..length).rev() {
-            let card = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (i,)).await?;
-            let propagate: bool = jvm.invoke_virtual(&card, "keyNotify", "(II)Z", (1i32, key_code)).await?;
+            let card = jvm
+                .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (i,))
+                .await?;
+            let propagate: bool = jvm
+                .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "keyNotify", "(II)Z", (1i32, key_code))
+                .await?;
 
             if !propagate {
                 break;
@@ -201,11 +223,15 @@ impl CardCanvas {
         let key_code = WIPIKeyCode::from_midp_raw(key_code);
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
 
         for i in (0..length).rev() {
-            let card = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (i,)).await?;
-            let propagate: bool = jvm.invoke_virtual(&card, "keyNotify", "(II)Z", (3i32, key_code)).await?;
+            let card = jvm
+                .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (i,))
+                .await?;
+            let propagate: bool = jvm
+                .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "keyNotify", "(II)Z", (3i32, key_code))
+                .await?;
 
             if !propagate {
                 break;
@@ -221,11 +247,15 @@ impl CardCanvas {
         let key_code = WIPIKeyCode::from_midp_raw(key_code);
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
 
         for i in (0..length).rev() {
-            let card = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (i,)).await?;
-            let propagate: bool = jvm.invoke_virtual(&card, "keyNotify", "(II)Z", (2i32, key_code)).await?;
+            let card = jvm
+                .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (i,))
+                .await?;
+            let propagate: bool = jvm
+                .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "keyNotify", "(II)Z", (2i32, key_code))
+                .await?;
 
             if !propagate {
                 break;
@@ -244,23 +274,37 @@ impl CardCanvas {
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
         let canvas: ClassInstanceRef<MidpCanvas> = jvm.get_field(&c, "canvas", "Ljavax/microedition/lcdui/Canvas;").await?;
-        let index: i32 = jvm.invoke_virtual(&cards, "indexOf", "(Ljava/lang/Object;)I", (c.clone(),)).await?;
+        let index: i32 = jvm
+            .invoke_virtual(&cards, "java/util/Vector", "indexOf", "(Ljava/lang/Object;)I", (c.clone(),))
+            .await?;
         if !canvas.is_null() || index >= 0 {
             return Ok(());
         }
 
-        let _: () = jvm.invoke_virtual(&cards, "addElement", "(Ljava/lang/Object;)V", (c.clone(),)).await?;
+        let _: () = jvm
+            .invoke_virtual(&cards, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (c.clone(),))
+            .await?;
 
         let _: () = jvm
-            .invoke_virtual(&c, "setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", (this.clone(),))
+            .invoke_virtual(
+                &c,
+                "org/kwis/msp/lcdui/Card",
+                "setCanvas",
+                "(Ljavax/microedition/lcdui/Canvas;)V",
+                (this.clone(),),
+            )
             .await?;
-        let _: () = jvm.invoke_virtual(&c, "showNotify", "(Z)V", (true,)).await?;
+        let _: () = jvm.invoke_virtual(&c, "org/kwis/msp/lcdui/Card", "showNotify", "(Z)V", (true,)).await?;
 
-        let _: () = jvm.invoke_virtual(&this, "repaint", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
 
         // HACK: disable java level paint on clet app
-        let class: ClassInstanceRef<Class> = jvm.invoke_virtual(&c, "getClass", "()Ljava/lang/Class;", ()).await?;
-        let class_name: ClassInstanceRef<String> = jvm.invoke_virtual(&class, "getName", "()Ljava/lang/String;", ()).await?;
+        let class: ClassInstanceRef<Class> = jvm
+            .invoke_virtual(&c, "org/kwis/msp/lcdui/Card", "getClass", "()Ljava/lang/Class;", ())
+            .await?;
+        let class_name: ClassInstanceRef<String> = jvm
+            .invoke_virtual(&class, "java/lang/Class", "getName", "()Ljava/lang/String;", ())
+            .await?;
         let class_name_str = JavaLangString::to_rust_string(jvm, &class_name).await?;
 
         if class_name_str == "CletCard" || class_name_str == "net/wie/CletWrapperCard" {
@@ -269,7 +313,9 @@ impl CardCanvas {
                 .await?;
             let midp_display: ClassInstanceRef<MidpDisplay> =
                 jvm.get_field(&wipi_display, "midpDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-            let _: () = jvm.invoke_virtual(&midp_display, "disablePaint", "()V", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&midp_display, "javax/microedition/lcdui/Display", "disablePaint", "()V", ())
+                .await?;
         }
 
         Ok(())
@@ -279,18 +325,30 @@ impl CardCanvas {
         tracing::debug!("net.wie.CardCanvas::popCard({this:?})");
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length: i32 = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length: i32 = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
         if length == 0 {
             return Ok(None.into());
         }
 
-        let card: ClassInstanceRef<Card> = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (length - 1,)).await?;
-        let _: () = jvm.invoke_virtual(&card, "showNotify", "(Z)V", (false,)).await?;
-        let _: ClassInstanceRef<Card> = jvm.invoke_virtual(&cards, "remove", "(I)Ljava/lang/Object;", (length - 1,)).await?;
-        let _: () = jvm
-            .invoke_virtual(&card, "setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", (None,))
+        let card: ClassInstanceRef<Card> = jvm
+            .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (length - 1,))
             .await?;
-        let _: () = jvm.invoke_virtual(&this, "repaint", "()V", ()).await?;
+        let _: () = jvm
+            .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "showNotify", "(Z)V", (false,))
+            .await?;
+        let _: ClassInstanceRef<Card> = jvm
+            .invoke_virtual(&cards, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (length - 1,))
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &card,
+                "org/kwis/msp/lcdui/Card",
+                "setCanvas",
+                "(Ljavax/microedition/lcdui/Canvas;)V",
+                (None,),
+            )
+            .await?;
+        let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
 
         Ok(card)
     }
@@ -303,19 +361,29 @@ impl CardCanvas {
         }
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let index: i32 = jvm.invoke_virtual(&cards, "indexOf", "(Ljava/lang/Object;)I", (card.clone(),)).await?;
+        let index: i32 = jvm
+            .invoke_virtual(&cards, "java/util/Vector", "indexOf", "(Ljava/lang/Object;)I", (card.clone(),))
+            .await?;
         if index < 0 {
             return Ok(false);
         }
 
-        let _: () = jvm.invoke_virtual(&card, "showNotify", "(Z)V", (false,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "showNotify", "(Z)V", (false,))
+            .await?;
         let _: bool = jvm
-            .invoke_virtual(&cards, "removeElement", "(Ljava/lang/Object;)Z", (card.clone(),))
+            .invoke_virtual(&cards, "java/util/Vector", "removeElement", "(Ljava/lang/Object;)Z", (card.clone(),))
             .await?;
         let _: () = jvm
-            .invoke_virtual(&card, "setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", (None,))
+            .invoke_virtual(
+                &card,
+                "org/kwis/msp/lcdui/Card",
+                "setCanvas",
+                "(Ljavax/microedition/lcdui/Canvas;)V",
+                (None,),
+            )
             .await?;
-        let _: () = jvm.invoke_virtual(&this, "repaint", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
 
         Ok(true)
     }
@@ -324,26 +392,36 @@ impl CardCanvas {
         tracing::debug!("net.wie.CardCanvas::countCard({this:?})");
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        jvm.invoke_virtual(&cards, "size", "()I", ()).await
+        jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await
     }
 
     async fn remove_all_cards(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("net.wie.CardCanvas::removeAllCards");
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
 
         for i in 0..length {
-            let card = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (i,)).await?;
-            let _: () = jvm.invoke_virtual(&card, "showNotify", "(Z)V", (false,)).await?;
+            let card = jvm
+                .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (i,))
+                .await?;
             let _: () = jvm
-                .invoke_virtual(&card, "setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", (None,))
+                .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "showNotify", "(Z)V", (false,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &card,
+                    "org/kwis/msp/lcdui/Card",
+                    "setCanvas",
+                    "(Ljavax/microedition/lcdui/Canvas;)V",
+                    (None,),
+                )
                 .await?;
         }
 
-        let _: () = jvm.invoke_virtual(&cards, "removeAllElements", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&cards, "java/util/Vector", "removeAllElements", "()V", ()).await?;
         if length != 0 {
-            let _: () = jvm.invoke_virtual(&this, "repaint", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
         }
 
         Ok(())
@@ -360,13 +438,17 @@ impl CardCanvas {
         tracing::debug!("net.wie.CardCanvas::handleNotifyEvent({this:?}, {type}, {param1}, {param2})");
 
         let cards = jvm.get_field(&this, "cards", "Ljava/util/Vector;").await?;
-        let length: i32 = jvm.invoke_virtual(&cards, "size", "()I", ()).await?;
+        let length: i32 = jvm.invoke_virtual(&cards, "java/util/Vector", "size", "()I", ()).await?;
         if length == 0 {
             return Ok(());
         }
-        let top_card = jvm.invoke_virtual(&cards, "elementAt", "(I)Ljava/lang/Object;", (length - 1,)).await?;
+        let top_card = jvm
+            .invoke_virtual(&cards, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (length - 1,))
+            .await?;
 
-        let _: () = jvm.invoke_virtual(&top_card, "notifyEvent", "(III)V", (r#type, param1, param2)).await?;
+        let _: () = jvm
+            .invoke_virtual(&top_card, "org/kwis/msp/lcdui/Card", "notifyEvent", "(III)V", (r#type, param1, param2))
+            .await?;
 
         Ok(())
     }

--- a/wie_wipi_java/src/classes/net/wie/wipi_file_output_stream.rs
+++ b/wie_wipi_java/src/classes/net/wie/wipi_file_output_stream.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::io::RandomAccessFile;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -18,15 +19,15 @@ impl WIPIFileOutputStream {
             parent_class: Some("java/io/OutputStream"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/io/File;)V", Self::init, Default::default()),
-                JavaMethodProto::new("write", "(I)V", Self::write, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
+                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/io/File;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("write", "(I)V", Self::write, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("close", "()V", Self::close, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("file", "Lorg/kwis/msp/io/File;", Default::default()),
-                JavaFieldProto::new("closed", "Z", Default::default()),
+                JavaFieldProto::new("file", "Lorg/kwis/msp/io/File;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("closed", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -54,7 +55,9 @@ impl WIPIFileOutputStream {
         jvm.store_array(&mut buffer, 0, [byte as i8]).await?;
 
         let raf: ClassInstanceRef<RandomAccessFile> = jvm.get_field(&file, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let _: () = jvm.invoke_virtual(&raf, "write", "([BII)V", (buffer, 0, 1)).await?;
+        let _: () = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "write", "([BII)V", (buffer, 0, 1))
+            .await?;
 
         Ok(())
     }

--- a/wie_wipi_java/src/classes/net/wie/wipi_midlet.rs
+++ b/wie_wipi_java/src/classes/net/wie/wipi_midlet.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -17,19 +18,19 @@ impl WIPIMIDlet {
             parent_class: Some("javax/microedition/midlet/MIDlet"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("startApp", "()V", Self::start_app, Default::default()),
-                JavaMethodProto::new("pauseApp", "()V", Self::pause_app, Default::default()),
-                JavaMethodProto::new("destroyApp", "(Z)V", Self::destroy_app, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("startApp", "()V", Self::start_app, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("pauseApp", "()V", Self::pause_app, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("destroyApp", "(Z)V", Self::destroy_app, MethodAccessFlags::PROTECTED),
                 JavaMethodProto::new(
                     "setCurrentJlet",
                     "(Lorg/kwis/msp/lcdui/Jlet;)V",
                     Self::set_current_jlet,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
             ],
-            fields: vec![JavaFieldProto::new("jlet", "Lorg/kwis/msp/lcdui/Jlet;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new("jlet", "Lorg/kwis/msp/lcdui/Jlet;", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -60,7 +61,9 @@ impl WIPIMIDlet {
         let args_array = jvm.instantiate_array("Ljava/lang/String;", 0).await?;
 
         let jlet = jvm.get_field(&this, "jlet", "Lorg/kwis/msp/lcdui/Jlet;").await?;
-        let _: () = jvm.invoke_virtual(&jlet, "startApp", "([Ljava/lang/String;)V", (args_array,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&jlet, "org/kwis/msp/lcdui/Jlet", "startApp", "([Ljava/lang/String;)V", (args_array,))
+            .await?;
 
         Ok(())
     }
@@ -69,7 +72,7 @@ impl WIPIMIDlet {
         tracing::debug!("net.wie.WIPIMIDlet::pauseApp({this:?})");
 
         let jlet = jvm.get_field(&this, "jlet", "Lorg/kwis/msp/lcdui/Jlet;").await?;
-        let _: () = jvm.invoke_virtual(&jlet, "pauseApp", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&jlet, "org/kwis/msp/lcdui/Jlet", "pauseApp", "()V", ()).await?;
 
         Ok(())
     }
@@ -78,7 +81,9 @@ impl WIPIMIDlet {
         tracing::debug!("net.wie.WIPIMIDlet::destroyApp({this:?}, {unconditional:?})");
 
         let jlet = jvm.get_field(&this, "jlet", "Lorg/kwis/msp/lcdui/Jlet;").await?;
-        let _: () = jvm.invoke_virtual(&jlet, "destroyApp", "(Z)V", (unconditional,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&jlet, "org/kwis/msp/lcdui/Jlet", "destroyApp", "(Z)V", (unconditional,))
+            .await?;
 
         Ok(())
     }

--- a/wie_wipi_java/src/classes/org/kwis/msf/io/network.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msf/io/network.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -16,16 +16,21 @@ impl Network {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("connect", "()I", Self::connect, MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "connect",
+                    "()I",
+                    Self::connect,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                ),
                 JavaMethodProto::new(
                     "disconnect",
                     "()V",
                     Self::disconnect,
-                    MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msf/io/scheme_not_found_exception.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msf/io/scheme_not_found_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl SchemeNotFoundException {
             parent_class: Some("java/io/IOException"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msf/io/socket.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msf/io/socket.rs
@@ -15,18 +15,38 @@ impl Socket {
             parent_class: None,
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new_abstract("accept", "()Lorg/kwis/msf/io/Socket;", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("close", "()V", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("getInputStream", "()Ljava/io/InputStream;", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("getMessageCount", "()I", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("getMessageMaxLength", "()I", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("getOutputStream", "()Ljava/io/OutputStream;", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("isStream", "()Z", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("recv", "(Lorg/kwis/msf/io/Message;)V", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("send", "(Lorg/kwis/msf/io/Message;)V", MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "accept",
+                    "()Lorg/kwis/msf/io/Socket;",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract("close", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "getInputStream",
+                    "()Ljava/io/InputStream;",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract("getMessageCount", "()I", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("getMessageMaxLength", "()I", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "getOutputStream",
+                    "()Ljava/io/OutputStream;",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract("isStream", "()Z", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "recv",
+                    "(Lorg/kwis/msf/io/Message;)V",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract(
+                    "send",
+                    "(Lorg/kwis/msf/io/Message;)V",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
             ],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msf/io/url.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msf/io/url.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -17,16 +17,16 @@ impl URL {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "find",
                     "(Ljava/lang/String;)Lorg/kwis/msf/io/Socket;",
                     Self::find,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/db/data_base.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/db/data_base.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -20,59 +20,79 @@ impl DataBase {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljavax/microedition/rms/RecordStore;)V", Self::init, Default::default()),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljavax/microedition/rms/RecordStore;)V",
+                    Self::init,
+                    MethodAccessFlags::PRIVATE,
+                ),
                 JavaMethodProto::new(
                     "openDataBase",
                     "(Ljava/lang/String;IZ)Lorg/kwis/msp/db/DataBase;",
                     Self::open_data_base,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "openDataBase",
                     "(Ljava/lang/String;IZI)Lorg/kwis/msp/db/DataBase;",
                     Self::open_data_base_with_flags,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("getNumberOfRecords", "()I", Self::get_number_of_records, Default::default()),
-                JavaMethodProto::new("closeDataBase", "()V", Self::close_data_base, Default::default()),
-                JavaMethodProto::new("insertRecord", "([B)I", Self::insert_record, Default::default()),
-                JavaMethodProto::new("insertRecord", "([BII)I", Self::insert_record_with_offset, Default::default()),
-                JavaMethodProto::new("selectRecord", "(I)[B", Self::select_record, Default::default()),
-                JavaMethodProto::new("updateRecord", "(I[B)V", Self::update_record, Default::default()),
-                JavaMethodProto::new("updateRecord", "(I[BII)V", Self::update_record_with_offset, Default::default()),
+                JavaMethodProto::new("getNumberOfRecords", "()I", Self::get_number_of_records, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("closeDataBase", "()V", Self::close_data_base, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("insertRecord", "([B)I", Self::insert_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("insertRecord", "([BII)I", Self::insert_record_with_offset, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("selectRecord", "(I)[B", Self::select_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("updateRecord", "(I[B)V", Self::update_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("updateRecord", "(I[BII)V", Self::update_record_with_offset, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "deleteDataBase",
                     "(Ljava/lang/String;)V",
                     Self::delete_data_base,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "deleteDataBase",
                     "(Ljava/lang/String;I)V",
                     Self::delete_data_base_with_flag,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("deleteRecord", "(I)V", Self::delete_record, Default::default()),
-                JavaMethodProto::new("selectRecord", "(I[BI)V", Self::select_record_into, Default::default()),
+                JavaMethodProto::new("deleteRecord", "(I)V", Self::delete_record, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("selectRecord", "(I[BI)V", Self::select_record_into, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "sortRecord",
                     "(Lorg/kwis/msp/db/DataFilter;Lorg/kwis/msp/db/DataComparator;)[I",
                     Self::sort_record,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("listDataBases", "()[Ljava/lang/String;", Self::list_data_bases, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getAccessMode", "(Ljava/lang/String;)I", Self::get_access_mode, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getDataBaseName", "()Ljava/lang/String;", Self::get_data_base_name, Default::default()),
-                JavaMethodProto::new("getDataBaseSize", "()I", Self::get_data_base_size, Default::default()),
-                JavaMethodProto::new("getRecordSize", "()I", Self::get_record_size, Default::default()),
-                JavaMethodProto::new("getSizeAvailable", "()I", Self::get_size_available, Default::default()),
-                JavaMethodProto::new("getLastModified", "()J", Self::get_last_modified, Default::default()),
+                JavaMethodProto::new(
+                    "listDataBases",
+                    "()[Ljava/lang/String;",
+                    Self::list_data_bases,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "getAccessMode",
+                    "(Ljava/lang/String;)I",
+                    Self::get_access_mode,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "getDataBaseName",
+                    "()Ljava/lang/String;",
+                    Self::get_data_base_name,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getDataBaseSize", "()I", Self::get_data_base_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getRecordSize", "()I", Self::get_record_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getSizeAvailable", "()I", Self::get_size_available, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getLastModified", "()J", Self::get_last_modified, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("recordStore", "Ljavax/microedition/rms/RecordStore;", Default::default()),
-                JavaFieldProto::new("recordSize", "I", Default::default()),
+                JavaFieldProto::new("recordStore", "Ljavax/microedition/rms/RecordStore;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("recordSize", "I", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
     async fn init(jvm: &Jvm, _: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, record_store: ClassInstanceRef<RecordStore>) -> JvmResult<()> {
@@ -140,14 +160,16 @@ impl DataBase {
         tracing::debug!("org.kwis.msp.db.DataBase::getNumberOfRecords({this:?})");
 
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
-        jvm.invoke_virtual(&record_store, "getNumRecords", "()I", ()).await
+        jvm.invoke_virtual(&record_store, "javax/microedition/rms/RecordStore", "getNumRecords", "()I", ())
+            .await
     }
 
     async fn close_data_base(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<DataBase>) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.db.DataBase::closeDataBase({this:?})");
 
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
-        jvm.invoke_virtual(&record_store, "closeRecordStore", "()V", ()).await
+        jvm.invoke_virtual(&record_store, "javax/microedition/rms/RecordStore", "closeRecordStore", "()V", ())
+            .await
     }
 
     async fn insert_record(
@@ -159,7 +181,9 @@ impl DataBase {
         tracing::debug!("org.kwis.msp.db.DataBase::insertRecord({this:?}, {data:?})");
 
         let length = jvm.array_length(&data).await? as i32;
-        let result = jvm.invoke_virtual(&this, "insertRecord", "([BII)I", (data, 0, length)).await?;
+        let result = jvm
+            .invoke_virtual(&this, "org/kwis/msp/db/DataBase", "insertRecord", "([BII)I", (data, 0, length))
+            .await?;
 
         Ok(result)
     }
@@ -176,7 +200,13 @@ impl DataBase {
 
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
         let record_id = jvm
-            .invoke_virtual(&record_store, "addRecord", "([BII)I", (data, offset, num_bytes))
+            .invoke_virtual(
+                &record_store,
+                "javax/microedition/rms/RecordStore",
+                "addRecord",
+                "([BII)I",
+                (data, offset, num_bytes),
+            )
             .await?;
 
         Ok(DataBase::to_wipi_record_id(record_id))
@@ -188,7 +218,9 @@ impl DataBase {
         let record_id = DataBase::to_midp_record_id(record_id);
 
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
-        let result = jvm.invoke_virtual(&record_store, "getRecord", "(I)[B", (record_id,)).await;
+        let result = jvm
+            .invoke_virtual(&record_store, "javax/microedition/rms/RecordStore", "getRecord", "(I)[B", (record_id,))
+            .await;
 
         // TODO check exception type
         if result.is_err() {
@@ -210,7 +242,13 @@ impl DataBase {
         let length = jvm.array_length(&data).await? as i32;
 
         let _: () = jvm
-            .invoke_virtual(&this, "updateRecord", "(I[BII)V", (record_id, data, 0, length))
+            .invoke_virtual(
+                &this,
+                "org/kwis/msp/db/DataBase",
+                "updateRecord",
+                "(I[BII)V",
+                (record_id, data, 0, length),
+            )
             .await?;
 
         Ok(())
@@ -231,7 +269,13 @@ impl DataBase {
 
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
         let _: () = jvm
-            .invoke_virtual(&record_store, "setRecord", "(I[BII)V", (record_id, data, offset, num_bytes))
+            .invoke_virtual(
+                &record_store,
+                "javax/microedition/rms/RecordStore",
+                "setRecord",
+                "(I[BII)V",
+                (record_id, data, offset, num_bytes),
+            )
             .await?;
 
         Ok(())
@@ -263,7 +307,9 @@ impl DataBase {
 
         let record_id = DataBase::to_midp_record_id(record_id);
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
-        let result: JvmResult<()> = jvm.invoke_virtual(&record_store, "deleteRecord", "(I)V", (record_id,)).await;
+        let result: JvmResult<()> = jvm
+            .invoke_virtual(&record_store, "javax/microedition/rms/RecordStore", "deleteRecord", "(I)V", (record_id,))
+            .await;
         if result.is_err() {
             return Err(jvm.exception("org/kwis/msp/db/DataBaseRecordException", "Record not found").await);
         }
@@ -283,7 +329,9 @@ impl DataBase {
 
         let record_id = DataBase::to_midp_record_id(record_id);
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
-        let record_size: JvmResult<i32> = jvm.invoke_virtual(&record_store, "getRecordSize", "(I)I", (record_id,)).await;
+        let record_size: JvmResult<i32> = jvm
+            .invoke_virtual(&record_store, "javax/microedition/rms/RecordStore", "getRecordSize", "(I)I", (record_id,))
+            .await;
         let record_size = match record_size {
             Ok(record_size) => record_size,
             Err(_) => return Err(jvm.exception("org/kwis/msp/db/DataBaseRecordException", "Record not found").await),
@@ -297,7 +345,13 @@ impl DataBase {
         }
 
         let _: i32 = jvm
-            .invoke_virtual(&record_store, "getRecord", "(I[BI)I", (record_id, buffer, offset))
+            .invoke_virtual(
+                &record_store,
+                "javax/microedition/rms/RecordStore",
+                "getRecord",
+                "(I[BI)I",
+                (record_id, buffer, offset),
+            )
             .await?;
 
         Ok(())
@@ -351,7 +405,8 @@ impl DataBase {
         tracing::debug!("org.kwis.msp.db.DataBase::getSizeAvailable({this:?})");
 
         let record_store = jvm.get_field(&this, "recordStore", "Ljavax/microedition/rms/RecordStore;").await?;
-        jvm.invoke_virtual(&record_store, "getSizeAvailable", "()I", ()).await
+        jvm.invoke_virtual(&record_store, "javax/microedition/rms/RecordStore", "getSizeAvailable", "()I", ())
+            .await
     }
 
     async fn get_last_modified(_: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i64> {
@@ -396,33 +451,53 @@ mod test {
                 )
                 .await?;
 
-            let database_name: ClassInstanceRef<String> = jvm.invoke_virtual(&database, "getDataBaseName", "()Ljava/lang/String;", ()).await?;
+            let database_name: ClassInstanceRef<String> = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getDataBaseName", "()Ljava/lang/String;", ())
+                .await?;
             assert_eq!(JavaLangString::to_rust_string(&jvm, &database_name).await?.as_str(), "storage-handset");
 
-            let record_size: i32 = jvm.invoke_virtual(&database, "getRecordSize", "()I", ()).await?;
+            let record_size: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getRecordSize", "()I", ())
+                .await?;
             assert_eq!(record_size, 32);
 
             let mut record = jvm.instantiate_array("B", 3).await?;
             jvm.store_array(&mut record, 0, [1i8, 2, 3]).await?;
-            let record_id: i32 = jvm.invoke_virtual(&database, "insertRecord", "([B)I", (record,)).await?;
+            let record_id: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "insertRecord", "([B)I", (record,))
+                .await?;
 
             let mut buffer = jvm.instantiate_array("B", 5).await?;
             jvm.store_array(&mut buffer, 0, [9i8; 5]).await?;
             let _: () = jvm
-                .invoke_virtual(&database, "selectRecord", "(I[BI)V", (record_id, buffer.clone(), 1))
+                .invoke_virtual(
+                    &database,
+                    "org/kwis/msp/db/DataBase",
+                    "selectRecord",
+                    "(I[BI)V",
+                    (record_id, buffer.clone(), 1),
+                )
                 .await?;
             assert_eq!(jvm.load_array::<i8>(&buffer, 0, 5).await?, [9i8, 1, 2, 3, 9]);
 
             let short_buffer = jvm.instantiate_array("B", 3).await?;
             let short_result: JvmResult<()> = jvm
-                .invoke_virtual(&database, "selectRecord", "(I[BI)V", (record_id, short_buffer, 1))
+                .invoke_virtual(
+                    &database,
+                    "org/kwis/msp/db/DataBase",
+                    "selectRecord",
+                    "(I[BI)V",
+                    (record_id, short_buffer, 1),
+                )
                 .await;
             let Err(JavaError::JavaException(exception)) = short_result else {
                 panic!("selectRecord accepted a buffer smaller than the record");
             };
             assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
 
-            let missing_result: JvmResult<()> = jvm.invoke_virtual(&database, "selectRecord", "(I[BI)V", (99, buffer.clone(), 0)).await;
+            let missing_result: JvmResult<()> = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "selectRecord", "(I[BI)V", (99, buffer.clone(), 0))
+                .await;
             let Err(JavaError::JavaException(exception)) = missing_result else {
                 panic!("selectRecord accepted an unknown record ID");
             };
@@ -431,6 +506,7 @@ mod test {
             let sorted: ClassInstanceRef<Array<i32>> = jvm
                 .invoke_virtual(
                     &database,
+                    "org/kwis/msp/db/DataBase",
                     "sortRecord",
                     "(Lorg/kwis/msp/db/DataFilter;Lorg/kwis/msp/db/DataComparator;)[I",
                     (ClassInstanceRef::<()>::new(None), ClassInstanceRef::<()>::new(None)),
@@ -446,9 +522,15 @@ mod test {
             let access_mode: i32 = jvm
                 .invoke_static("org/kwis/msp/db/DataBase", "getAccessMode", "(Ljava/lang/String;)I", (name.clone(),))
                 .await?;
-            let database_size: i32 = jvm.invoke_virtual(&database, "getDataBaseSize", "()I", ()).await?;
-            let size_available: i32 = jvm.invoke_virtual(&database, "getSizeAvailable", "()I", ()).await?;
-            let last_modified: i64 = jvm.invoke_virtual(&database, "getLastModified", "()J", ()).await?;
+            let database_size: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getDataBaseSize", "()I", ())
+                .await?;
+            let size_available: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getSizeAvailable", "()I", ())
+                .await?;
+            let last_modified: i64 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getLastModified", "()J", ())
+                .await?;
             assert_eq!(access_mode, 0);
             assert_eq!(database_size, 0);
             assert_eq!(size_available, 1_000_000);
@@ -477,36 +559,54 @@ mod test {
 
             let mut first = jvm.instantiate_array("B", 2).await?;
             jvm.store_array(&mut first, 0, [1i8, 2]).await?;
-            let first_id: i32 = jvm.invoke_virtual(&database, "insertRecord", "([B)I", (first,)).await?;
+            let first_id: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "insertRecord", "([B)I", (first,))
+                .await?;
 
             let mut second = jvm.instantiate_array("B", 2).await?;
             jvm.store_array(&mut second, 0, [3i8, 4]).await?;
-            let second_id: i32 = jvm.invoke_virtual(&database, "insertRecord", "([B)I", (second,)).await?;
+            let second_id: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "insertRecord", "([B)I", (second,))
+                .await?;
             assert_eq!((first_id, second_id), (0, 1));
 
-            let count: i32 = jvm.invoke_virtual(&database, "getNumberOfRecords", "()I", ()).await?;
+            let count: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getNumberOfRecords", "()I", ())
+                .await?;
             assert_eq!(count, 2);
 
-            let _: () = jvm.invoke_virtual(&database, "deleteRecord", "(I)V", (first_id,)).await?;
-            let count: i32 = jvm.invoke_virtual(&database, "getNumberOfRecords", "()I", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "deleteRecord", "(I)V", (first_id,))
+                .await?;
+            let count: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getNumberOfRecords", "()I", ())
+                .await?;
             assert_eq!(count, 1);
 
-            let deleted: JvmResult<ClassInstanceRef<Array<i8>>> = jvm.invoke_virtual(&database, "selectRecord", "(I)[B", (first_id,)).await;
+            let deleted: JvmResult<ClassInstanceRef<Array<i8>>> = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "selectRecord", "(I)[B", (first_id,))
+                .await;
             let Err(JavaError::JavaException(exception)) = deleted else {
                 panic!("deleted WIPI record lookup succeeded");
             };
             assert!(jvm.is_instance(&*exception, "org/kwis/msp/db/DataBaseRecordException"));
 
-            let remaining: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&database, "selectRecord", "(I)[B", (second_id,)).await?;
+            let remaining: ClassInstanceRef<Array<i8>> = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "selectRecord", "(I)[B", (second_id,))
+                .await?;
             assert_eq!(jvm.load_array::<i8>(&remaining, 0, 2).await?, [3i8, 4]);
 
-            let unknown: JvmResult<()> = jvm.invoke_virtual(&database, "deleteRecord", "(I)V", (99,)).await;
+            let unknown: JvmResult<()> = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "deleteRecord", "(I)V", (99,))
+                .await;
             let Err(JavaError::JavaException(exception)) = unknown else {
                 panic!("unknown WIPI record deletion succeeded");
             };
             assert!(jvm.is_instance(&*exception, "org/kwis/msp/db/DataBaseRecordException"));
 
-            let count: i32 = jvm.invoke_virtual(&database, "getNumberOfRecords", "()I", ()).await?;
+            let count: i32 = jvm
+                .invoke_virtual(&database, "org/kwis/msp/db/DataBase", "getNumberOfRecords", "()I", ())
+                .await?;
             assert_eq!(count, 1);
 
             Ok(())

--- a/wie_wipi_java/src/classes/org/kwis/msp/db/data_base_exception.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/db/data_base_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl DataBaseException {
             parent_class: Some("java/lang/Exception"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/db/data_base_record_exception.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/db/data_base_record_exception.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result};
 
@@ -16,11 +17,11 @@ impl DataBaseRecordException {
             parent_class: Some("org/kwis/msp/db/DataBaseException"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init_with_message, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/db/data_comparator.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/db/data_comparator.rs
@@ -14,9 +14,13 @@ impl DataComparator {
             name: "org/kwis/msp/db/DataComparator",
             parent_class: None,
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new_abstract("compare", "([B[B)I", MethodAccessFlags::ABSTRACT)],
+            methods: vec![JavaMethodProto::new_abstract(
+                "compare",
+                "([B[B)I",
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+            )],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/db/data_filter.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/db/data_filter.rs
@@ -14,9 +14,13 @@ impl DataFilter {
             name: "org/kwis/msp/db/DataFilter",
             parent_class: None,
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new_abstract("filter", "([B)Z", MethodAccessFlags::ABSTRACT)],
+            methods: vec![JavaMethodProto::new_abstract(
+                "filter",
+                "([B)Z",
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+            )],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/handset/backlight.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/handset/backlight.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -16,13 +16,13 @@ impl BackLight {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("alwaysOn", "()V", Self::always_on, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("on", "(III)V", Self::on, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("off", "()V", Self::off, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("before", "()V", Self::before, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("alwaysOn", "()V", Self::always_on, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("on", "(III)V", Self::on, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("off", "()V", Self::off, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("before", "()V", Self::before, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/handset/handset_property.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/handset/handset_property.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -21,17 +21,17 @@ impl HandsetProperty {
                     "getSystemProperty",
                     "(Ljava/lang/String;)Ljava/lang/String;",
                     Self::get_system_property,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "setSystemProperty",
                     "(Ljava/lang/String;Ljava/lang/String;)Z",
                     Self::set_system_property,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/io/file.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/io/file.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::{
     io::{DataInputStream, DataOutputStream, FileDescriptor, InputStream, OutputStream},
     lang::String,
@@ -43,47 +44,52 @@ impl File {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;II)V", Self::init_with_flag, Default::default()),
-                JavaMethodProto::new("write", "([B)I", Self::write, Default::default()),
-                JavaMethodProto::new("write", "([BII)I", Self::write_with_offset_length, Default::default()),
-                JavaMethodProto::new("read", "([B)I", Self::read, Default::default()),
-                JavaMethodProto::new("read", "([BII)I", Self::read_with_offset_length, Default::default()),
-                JavaMethodProto::new("seek", "(I)V", Self::seek, Default::default()),
-                JavaMethodProto::new("close", "()V", Self::close, Default::default()),
-                JavaMethodProto::new("sizeOf", "()I", Self::size_of, Default::default()),
-                JavaMethodProto::new("openInputStream", "()Ljava/io/InputStream;", Self::open_input_stream, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;II)V", Self::init_with_flag, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("write", "([B)I", Self::write, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("write", "([BII)I", Self::write_with_offset_length, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("read", "([B)I", Self::read, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("read", "([BII)I", Self::read_with_offset_length, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("seek", "(I)V", Self::seek, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("close", "()V", Self::close, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("sizeOf", "()I", Self::size_of, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "openInputStream",
+                    "()Ljava/io/InputStream;",
+                    Self::open_input_stream,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new(
                     "openDataInputStream",
                     "()Ljava/io/DataInputStream;",
                     Self::open_data_input_stream,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "openOutputStream",
                     "()Ljava/io/OutputStream;",
                     Self::open_output_stream,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "openDataOutputStream",
                     "()Ljava/io/DataOutputStream;",
                     Self::open_data_output_stream,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("write", "(I)I", Self::write_byte, Default::default()),
-                JavaMethodProto::new("read", "()I", Self::read_byte, Default::default()),
-                JavaMethodProto::new("tell", "()I", Self::tell, Default::default()),
+                JavaMethodProto::new("write", "(I)I", Self::write_byte, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("read", "()I", Self::read_byte, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("tell", "()I", Self::tell, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("file", "Ljava/io/File;", Default::default()),
-                JavaFieldProto::new("raf", "Ljava/io/RandomAccessFile;", Default::default()),
-                JavaFieldProto::new("inputStream", "Ljava/io/InputStream;", Default::default()),
-                JavaFieldProto::new("mode", "I", Default::default()),
-                JavaFieldProto::new("closed", "Z", Default::default()),
-                JavaFieldProto::new("outputStreamOpen", "Z", Default::default()),
+                JavaFieldProto::new("file", "Ljava/io/File;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("raf", "Ljava/io/RandomAccessFile;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("inputStream", "Ljava/io/InputStream;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("mode", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("closed", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("outputStreamOpen", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -138,10 +144,12 @@ impl File {
         let raf = raf.unwrap();
 
         if mode == Mode::WRITE_TRUNC {
-            let _: () = jvm.invoke_virtual(&raf, "setLength", "(J)V", (0i64,)).await?;
+            let _: () = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "setLength", "(J)V", (0i64,)).await?;
         }
 
-        let descriptor: ClassInstanceRef<FileDescriptor> = jvm.invoke_virtual(&raf, "getFD", "()Ljava/io/FileDescriptor;", ()).await?;
+        let descriptor: ClassInstanceRef<FileDescriptor> = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "getFD", "()Ljava/io/FileDescriptor;", ())
+            .await?;
         let input_stream: ClassInstanceRef<InputStream> = jvm
             .new_class("java/io/FileInputStream", "(Ljava/io/FileDescriptor;)V", (descriptor,))
             .await?
@@ -160,7 +168,8 @@ impl File {
     async fn write(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>, buf: ClassInstanceRef<Array<i8>>) -> JvmResult<i32> {
         let length = jvm.array_length(&buf).await? as i32;
 
-        jvm.invoke_virtual(&this, "write", "([BII)I", (buf, 0, length)).await
+        jvm.invoke_virtual(&this, "org/kwis/msp/io/File", "write", "([BII)I", (buf, 0, length))
+            .await
     }
 
     async fn write_with_offset_length(
@@ -174,7 +183,9 @@ impl File {
         tracing::debug!("org.kwis.msp.io.File::write({this:?}, {buf:?}, {offset:?}, {len:?})");
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let _: () = jvm.invoke_virtual(&raf, "write", "([BII)V", (buf, offset, len)).await?;
+        let _: () = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "write", "([BII)V", (buf, offset, len))
+            .await?;
 
         Ok(0)
     }
@@ -183,7 +194,9 @@ impl File {
         tracing::debug!("org.kwis.msp.io.File::seek({this:?}, {pos:?})");
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let _: () = jvm.invoke_virtual(&raf, "seek", "(J)V", (pos as i64,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "seek", "(J)V", (pos as i64,))
+            .await?;
 
         Ok(())
     }
@@ -191,7 +204,8 @@ impl File {
     async fn read(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>, buf: ClassInstanceRef<Array<i8>>) -> JvmResult<i32> {
         let length = jvm.array_length(&buf).await? as i32;
 
-        jvm.invoke_virtual(&this, "read", "([BII)I", (buf, 0, length)).await
+        jvm.invoke_virtual(&this, "org/kwis/msp/io/File", "read", "([BII)I", (buf, 0, length))
+            .await
     }
 
     async fn read_with_offset_length(
@@ -205,7 +219,9 @@ impl File {
         tracing::debug!("org.kwis.msp.io.File::read({this:?}, {buf:?})");
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let read = jvm.invoke_virtual(&raf, "read", "([BII)I", (buf, offset, length)).await?;
+        let read = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "read", "([BII)I", (buf, offset, length))
+            .await?;
 
         Ok(read)
     }
@@ -219,7 +235,7 @@ impl File {
         }
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let _: () = jvm.invoke_virtual(&raf, "close", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "close", "()V", ()).await?;
         jvm.put_field(&mut this, "closed", "Z", true).await?;
 
         Ok(())
@@ -229,7 +245,7 @@ impl File {
         tracing::debug!("org.kwis.msp.io.File::sizeOf({this:?})");
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let length: i64 = jvm.invoke_virtual(&raf, "length", "()J", ()).await?;
+        let length: i64 = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "length", "()J", ()).await?;
 
         Ok(length as _)
     }
@@ -250,7 +266,9 @@ impl File {
     async fn open_data_input_stream(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<DataInputStream>> {
         tracing::debug!("org.kwis.msp.io.File::openDataInputStream({this:?})");
 
-        let input_stream: ClassInstanceRef<InputStream> = jvm.invoke_virtual(&this, "openInputStream", "()Ljava/io/InputStream;", ()).await?;
+        let input_stream: ClassInstanceRef<InputStream> = jvm
+            .invoke_virtual(&this, "org/kwis/msp/io/File", "openInputStream", "()Ljava/io/InputStream;", ())
+            .await?;
         let data_input_stream = jvm
             .new_class("java/io/DataInputStream", "(Ljava/io/InputStream;)V", (input_stream,))
             .await?;
@@ -291,7 +309,9 @@ impl File {
     ) -> JvmResult<ClassInstanceRef<DataOutputStream>> {
         tracing::debug!("org.kwis.msp.io.File::openDataOutputStream({this:?})");
 
-        let output_stream: ClassInstanceRef<OutputStream> = jvm.invoke_virtual(&this, "openOutputStream", "()Ljava/io/OutputStream;", ()).await?;
+        let output_stream: ClassInstanceRef<OutputStream> = jvm
+            .invoke_virtual(&this, "org/kwis/msp/io/File", "openOutputStream", "()Ljava/io/OutputStream;", ())
+            .await?;
         let data_output_stream = jvm
             .new_class("java/io/DataOutputStream", "(Ljava/io/OutputStream;)V", (output_stream,))
             .await?;
@@ -306,7 +326,9 @@ impl File {
         jvm.store_array(&mut buffer, 0, [byte as i8]).await?;
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let _: () = jvm.invoke_virtual(&raf, "write", "([BII)V", (buffer, 0, 1)).await?;
+        let _: () = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "write", "([BII)V", (buffer, 0, 1))
+            .await?;
 
         Ok(1)
     }
@@ -316,7 +338,9 @@ impl File {
 
         let buffer = jvm.instantiate_array("B", 1).await?;
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let read: i32 = jvm.invoke_virtual(&raf, "read", "([BII)I", (buffer.clone(), 0, 1)).await?;
+        let read: i32 = jvm
+            .invoke_virtual(&raf, "java/io/RandomAccessFile", "read", "([BII)I", (buffer.clone(), 0, 1))
+            .await?;
         if read <= 0 {
             return Ok(-1);
         }
@@ -331,7 +355,7 @@ impl File {
         tracing::debug!("org.kwis.msp.io.File::tell({this:?})");
 
         let raf = jvm.get_field(&this, "raf", "Ljava/io/RandomAccessFile;").await?;
-        let position: i64 = jvm.invoke_virtual(&raf, "getFilePointer", "()J", ()).await?;
+        let position: i64 = jvm.invoke_virtual(&raf, "java/io/RandomAccessFile", "getFilePointer", "()J", ()).await?;
 
         Ok(position as i32)
     }
@@ -364,78 +388,89 @@ mod test {
                     .await?
                     .into();
 
-                let initial: i32 = jvm.invoke_virtual(&file, "tell", "()I", ()).await?;
+                let initial: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "tell", "()I", ()).await?;
                 assert_eq!(initial, 0);
 
-                let written: i32 = jvm.invoke_virtual(&file, "write", "(I)I", (0xfe,)).await?;
+                let written: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "write", "(I)I", (0xfe,)).await?;
                 assert_eq!(written, 1);
-                let after_write: i32 = jvm.invoke_virtual(&file, "tell", "()I", ()).await?;
+                let after_write: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "tell", "()I", ()).await?;
                 assert_eq!(after_write, 1);
 
-                let _: () = jvm.invoke_virtual(&file, "seek", "(I)V", (0,)).await?;
-                let value: i32 = jvm.invoke_virtual(&file, "read", "()I", ()).await?;
-                let eof: i32 = jvm.invoke_virtual(&file, "read", "()I", ()).await?;
+                let _: () = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "seek", "(I)V", (0,)).await?;
+                let value: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "read", "()I", ()).await?;
+                let eof: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "read", "()I", ()).await?;
                 assert_eq!(value, 0xfe);
                 assert_eq!(eof, -1);
 
-                let _: () = jvm.invoke_virtual(&file, "seek", "(I)V", (1,)).await?;
-                let output: ClassInstanceRef<OutputStream> = jvm.invoke_virtual(&file, "openOutputStream", "()Ljava/io/OutputStream;", ()).await?;
-                let _: () = jvm.invoke_virtual(&output, "write", "(I)V", (0xab,)).await?;
-                let after_output_write: i32 = jvm.invoke_virtual(&file, "tell", "()I", ()).await?;
+                let _: () = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "seek", "(I)V", (1,)).await?;
+                let output: ClassInstanceRef<OutputStream> = jvm
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "openOutputStream", "()Ljava/io/OutputStream;", ())
+                    .await?;
+                let _: () = jvm.invoke_virtual(&output, "java/io/OutputStream", "write", "(I)V", (0xab,)).await?;
+                let after_output_write: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "tell", "()I", ()).await?;
                 assert_eq!(after_output_write, 2);
 
                 let second_open: JvmResult<ClassInstanceRef<DataOutputStream>> = jvm
-                    .invoke_virtual(&file, "openDataOutputStream", "()Ljava/io/DataOutputStream;", ())
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "openDataOutputStream", "()Ljava/io/DataOutputStream;", ())
                     .await;
                 let Err(JavaError::JavaException(exception)) = second_open else {
                     panic!("concurrent data output stream opened");
                 };
                 assert!(jvm.is_instance(&*exception, "java/io/IOException"));
 
-                let _: () = jvm.invoke_virtual(&output, "close", "()V", ()).await?;
-                let closed_write: JvmResult<()> = jvm.invoke_virtual(&output, "write", "(I)V", (0xff,)).await;
+                let _: () = jvm.invoke_virtual(&output, "java/io/OutputStream", "close", "()V", ()).await?;
+                let closed_write: JvmResult<()> = jvm.invoke_virtual(&output, "java/io/OutputStream", "write", "(I)V", (0xff,)).await;
                 let Err(JavaError::JavaException(exception)) = closed_write else {
                     panic!("closed output stream accepted a write");
                 };
                 assert!(jvm.is_instance(&*exception, "java/io/IOException"));
 
                 let data_output: ClassInstanceRef<DataOutputStream> = jvm
-                    .invoke_virtual(&file, "openDataOutputStream", "()Ljava/io/DataOutputStream;", ())
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "openDataOutputStream", "()Ljava/io/DataOutputStream;", ())
                     .await?;
-                let _: () = jvm.invoke_virtual(&output, "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&output, "java/io/OutputStream", "close", "()V", ()).await?;
 
-                let second_open: JvmResult<ClassInstanceRef<OutputStream>> =
-                    jvm.invoke_virtual(&file, "openOutputStream", "()Ljava/io/OutputStream;", ()).await;
+                let second_open: JvmResult<ClassInstanceRef<OutputStream>> = jvm
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "openOutputStream", "()Ljava/io/OutputStream;", ())
+                    .await;
                 let Err(JavaError::JavaException(exception)) = second_open else {
                     panic!("closed old stream released the active data output stream");
                 };
                 assert!(jvm.is_instance(&*exception, "java/io/IOException"));
 
-                let _: () = jvm.invoke_virtual(&data_output, "writeByte", "(I)V", (0xcd,)).await?;
-                let after_data_output_write: i32 = jvm.invoke_virtual(&file, "tell", "()I", ()).await?;
-                assert_eq!(after_data_output_write, 3);
-                let _: () = jvm.invoke_virtual(&data_output, "close", "()V", ()).await?;
-
-                let _: () = jvm.invoke_virtual(&file, "seek", "(I)V", (0,)).await?;
-                let data_input: ClassInstanceRef<DataInputStream> = jvm
-                    .invoke_virtual(&file, "openDataInputStream", "()Ljava/io/DataInputStream;", ())
+                let _: () = jvm
+                    .invoke_virtual(&data_output, "java/io/DataOutputStream", "writeByte", "(I)V", (0xcd,))
                     .await?;
-                let prefix: i32 = jvm.invoke_virtual(&data_input, "readUnsignedShort", "()I", ()).await?;
+                let after_data_output_write: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "tell", "()I", ()).await?;
+                assert_eq!(after_data_output_write, 3);
+                let _: () = jvm.invoke_virtual(&data_output, "java/io/DataOutputStream", "close", "()V", ()).await?;
+
+                let _: () = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "seek", "(I)V", (0,)).await?;
+                let data_input: ClassInstanceRef<DataInputStream> = jvm
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "openDataInputStream", "()Ljava/io/DataInputStream;", ())
+                    .await?;
+                let prefix: i32 = jvm
+                    .invoke_virtual(&data_input, "java/io/DataInputStream", "readUnsignedShort", "()I", ())
+                    .await?;
                 assert_eq!(prefix, 0xfeab);
-                let after_input_read: i32 = jvm.invoke_virtual(&file, "tell", "()I", ()).await?;
+                let after_input_read: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "tell", "()I", ()).await?;
                 assert_eq!(after_input_read, 2);
-                let trailing: i32 = jvm.invoke_virtual(&file, "read", "()I", ()).await?;
+                let trailing: i32 = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "read", "()I", ()).await?;
                 assert_eq!(trailing, 0xcd);
 
-                let reopened: ClassInstanceRef<OutputStream> = jvm.invoke_virtual(&file, "openOutputStream", "()Ljava/io/OutputStream;", ()).await?;
-                let _: () = jvm.invoke_virtual(&reopened, "close", "()V", ()).await?;
+                let reopened: ClassInstanceRef<OutputStream> = jvm
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "openOutputStream", "()Ljava/io/OutputStream;", ())
+                    .await?;
+                let _: () = jvm.invoke_virtual(&reopened, "java/io/OutputStream", "close", "()V", ()).await?;
 
-                let _: () = jvm.invoke_virtual(&file, "seek", "(I)V", (0,)).await?;
+                let _: () = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "seek", "(I)V", (0,)).await?;
                 let bytes = jvm.instantiate_array("B", 3).await?;
-                let read: i32 = jvm.invoke_virtual(&file, "read", "([B)I", (bytes.clone(),)).await?;
+                let read: i32 = jvm
+                    .invoke_virtual(&file, "org/kwis/msp/io/File", "read", "([B)I", (bytes.clone(),))
+                    .await?;
                 assert_eq!(read, 3);
                 assert_eq!(jvm.load_array::<i8>(&bytes, 0, 3).await?, [-2i8, -85, -51]);
-                let _: () = jvm.invoke_virtual(&file, "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&file, "org/kwis/msp/io/File", "close", "()V", ()).await?;
 
                 Ok(())
             },
@@ -456,22 +491,29 @@ mod test {
                     )
                     .await?
                     .into();
-                let _: i32 = jvm.invoke_virtual(&writable, "write", "(I)I", (1,)).await?;
-                let _: () = jvm.invoke_virtual(&writable, "close", "()V", ()).await?;
+                let _: i32 = jvm.invoke_virtual(&writable, "org/kwis/msp/io/File", "write", "(I)I", (1,)).await?;
+                let _: () = jvm.invoke_virtual(&writable, "org/kwis/msp/io/File", "close", "()V", ()).await?;
 
                 let read_only: ClassInstanceRef<File> = jvm
                     .new_class("org/kwis/msp/io/File", "(Ljava/lang/String;I)V", (filename, Mode::READ_ONLY as i32))
                     .await?
                     .into();
-                let output: JvmResult<ClassInstanceRef<OutputStream>> =
-                    jvm.invoke_virtual(&read_only, "openOutputStream", "()Ljava/io/OutputStream;", ()).await;
+                let output: JvmResult<ClassInstanceRef<OutputStream>> = jvm
+                    .invoke_virtual(&read_only, "org/kwis/msp/io/File", "openOutputStream", "()Ljava/io/OutputStream;", ())
+                    .await;
                 let Err(JavaError::JavaException(exception)) = output else {
                     panic!("read-only file opened an output stream");
                 };
                 assert!(jvm.is_instance(&*exception, "java/io/IOException"));
 
                 let data_output: JvmResult<ClassInstanceRef<DataOutputStream>> = jvm
-                    .invoke_virtual(&read_only, "openDataOutputStream", "()Ljava/io/DataOutputStream;", ())
+                    .invoke_virtual(
+                        &read_only,
+                        "org/kwis/msp/io/File",
+                        "openDataOutputStream",
+                        "()Ljava/io/DataOutputStream;",
+                        (),
+                    )
                     .await;
                 let Err(JavaError::JavaException(exception)) = data_output else {
                     panic!("read-only file opened a data output stream");
@@ -483,11 +525,12 @@ mod test {
                     .new_class("org/kwis/msp/io/File", "(Ljava/lang/String;I)V", (filename, Mode::WRITE_TRUNC as i32))
                     .await?
                     .into();
-                let _: () = jvm.invoke_virtual(&closed, "close", "()V", ()).await?;
-                let _: () = jvm.invoke_virtual(&closed, "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&closed, "org/kwis/msp/io/File", "close", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&closed, "org/kwis/msp/io/File", "close", "()V", ()).await?;
 
-                let output: JvmResult<ClassInstanceRef<OutputStream>> =
-                    jvm.invoke_virtual(&closed, "openOutputStream", "()Ljava/io/OutputStream;", ()).await;
+                let output: JvmResult<ClassInstanceRef<OutputStream>> = jvm
+                    .invoke_virtual(&closed, "org/kwis/msp/io/File", "openOutputStream", "()Ljava/io/OutputStream;", ())
+                    .await;
                 let Err(JavaError::JavaException(exception)) = output else {
                     panic!("closed file opened an output stream");
                 };

--- a/wie_wipi_java/src/classes/org/kwis/msp/io/file_system.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/io/file_system.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::{io::File as JavaFile, lang::String, util::Vector};
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -17,61 +17,131 @@ impl FileSystem {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("isFile", "(Ljava/lang/String;)Z", Self::is_file, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("isDirectory", "(Ljava/lang/String;I)Z", Self::is_directory, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("exists", "(Ljava/lang/String;)Z", Self::exists, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("exists", "(Ljava/lang/String;I)Z", Self::exists_with_flag, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("mkdir", "(Ljava/lang/String;I)V", Self::mkdir, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("available", "()I", Self::available, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getMaxFilenameLength", "()I", Self::get_max_filename_length, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("list", "(Ljava/lang/String;)Ljava/util/Vector;", Self::list, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "isFile",
+                    "(Ljava/lang/String;)Z",
+                    Self::is_file,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "isDirectory",
+                    "(Ljava/lang/String;I)Z",
+                    Self::is_directory,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "exists",
+                    "(Ljava/lang/String;)Z",
+                    Self::exists,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "exists",
+                    "(Ljava/lang/String;I)Z",
+                    Self::exists_with_flag,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "mkdir",
+                    "(Ljava/lang/String;I)V",
+                    Self::mkdir,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("available", "()I", Self::available, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "getMaxFilenameLength",
+                    "()I",
+                    Self::get_max_filename_length,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "list",
+                    "(Ljava/lang/String;)Ljava/util/Vector;",
+                    Self::list,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
                 JavaMethodProto::new(
                     "list",
                     "(Ljava/lang/String;I)Ljava/util/Vector;",
                     Self::list_with_flag,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("remove", "(Ljava/lang/String;)V", Self::remove, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("remove", "(Ljava/lang/String;I)V", Self::remove_with_flag, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("mkdir", "(Ljava/lang/String;)V", Self::mkdir_without_flag, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("rmdir", "(Ljava/lang/String;)V", Self::rmdir, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("rmdir", "(Ljava/lang/String;I)V", Self::rmdir_with_flag, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("toCString", "(Ljava/lang/String;)[B", Self::to_c_string, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("isFile", "(Ljava/lang/String;I)Z", Self::is_file_with_flag, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "remove",
+                    "(Ljava/lang/String;)V",
+                    Self::remove,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "remove",
+                    "(Ljava/lang/String;I)V",
+                    Self::remove_with_flag,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "mkdir",
+                    "(Ljava/lang/String;)V",
+                    Self::mkdir_without_flag,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "rmdir",
+                    "(Ljava/lang/String;)V",
+                    Self::rmdir,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "rmdir",
+                    "(Ljava/lang/String;I)V",
+                    Self::rmdir_with_flag,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "toCString",
+                    "(Ljava/lang/String;)[B",
+                    Self::to_c_string,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "isFile",
+                    "(Ljava/lang/String;I)Z",
+                    Self::is_file_with_flag,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
                 JavaMethodProto::new(
                     "isDirectory",
                     "(Ljava/lang/String;)Z",
                     Self::is_directory_without_flag,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "getCreationTime",
                     "(Ljava/lang/String;)I",
                     Self::get_creation_time,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "getCreationTime",
                     "(Ljava/lang/String;I)I",
                     Self::get_creation_time_with_flag,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "rename",
                     "(Ljava/lang/String;Ljava/lang/String;)V",
                     Self::rename,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "rename",
                     "(Ljava/lang/String;Ljava/lang/String;I)V",
                     Self::rename_with_flag,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -85,7 +155,7 @@ impl FileSystem {
         tracing::debug!("org.kwis.msp.io.FileSystem::is_file({name:?})");
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let is_file = jvm.invoke_virtual(&file, "isFile", "()Z", ()).await?;
+        let is_file = jvm.invoke_virtual(&file, "java/io/File", "isFile", "()Z", ()).await?;
 
         Ok(is_file)
     }
@@ -94,7 +164,7 @@ impl FileSystem {
         tracing::debug!("org.kwis.msp.io.FileSystem::isDirectory({name:?}, {flag:?})");
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let is_directory = jvm.invoke_virtual(&file, "isDirectory", "()Z", ()).await?;
+        let is_directory = jvm.invoke_virtual(&file, "java/io/File", "isDirectory", "()Z", ()).await?;
 
         Ok(is_directory)
     }
@@ -110,7 +180,7 @@ impl FileSystem {
         tracing::debug!("org.kwis.msp.io.FileSystem::exists({name:?}, {flag:?})");
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
-        let exists = jvm.invoke_virtual(&file, "exists", "()Z", ()).await?;
+        let exists = jvm.invoke_virtual(&file, "java/io/File", "exists", "()Z", ()).await?;
 
         Ok(exists)
     }
@@ -191,7 +261,7 @@ impl FileSystem {
         tracing::debug!("org.kwis.msp.io.FileSystem::isDirectory({name:?})");
 
         let file: ClassInstanceRef<JavaFile> = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?.into();
-        jvm.invoke_virtual(&file, "isDirectory", "()Z", ()).await
+        jvm.invoke_virtual(&file, "java/io/File", "isDirectory", "()Z", ()).await
     }
 
     async fn get_creation_time(_: &Jvm, _: &mut WieJvmContext, name: ClassInstanceRef<String>) -> JvmResult<i32> {

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/card.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/card.rs
@@ -1,7 +1,7 @@
 use alloc::{format, vec};
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{ClassAccessFlags, MethodAccessFlags};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -19,51 +19,70 @@ impl Card {
             parent_class: Some("java/lang/Object"),
             interfaces: vec!["org/kwis/msp/lcdui/JletEventListener"],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(I)V", Self::init_int, Default::default()),
-                JavaMethodProto::new("<init>", "(Z)V", Self::init_transparent, Default::default()),
-                JavaMethodProto::new("<init>", "(IIII)V", Self::init_with_bounds, Default::default()),
-                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Display;)V", Self::init_with_display, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(I)V", Self::init_int, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Z)V", Self::init_transparent, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(IIII)V", Self::init_with_bounds, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Lorg/kwis/msp/lcdui/Display;)V",
+                    Self::init_with_display,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new(
                     "<init>",
                     "(Lorg/kwis/msp/lcdui/Display;IIII)V",
                     Self::init_with_display_and_bounds,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "<init>",
                     "(Lorg/kwis/msp/lcdui/Display;IIIIZ)V",
                     Self::init_with_display_bounds_and_transparency,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
-                JavaMethodProto::new("move", "(II)V", Self::move_card, Default::default()),
-                JavaMethodProto::new("resize", "(II)V", Self::resize, Default::default()),
-                JavaMethodProto::new("getX", "()I", Self::get_x, Default::default()),
-                JavaMethodProto::new("getY", "()I", Self::get_y, Default::default()),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("move", "(II)V", Self::move_card, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("resize", "(II)V", Self::resize, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getX", "()I", Self::get_x, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getY", "()I", Self::get_y, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("pointerNotify", "(III)Z", Self::pointer_notify, MethodAccessFlags::PROTECTED),
-                JavaMethodProto::new("getDisplay", "()Lorg/kwis/msp/lcdui/Display;", Self::get_display, Default::default()),
-                JavaMethodProto::new("isShown", "()Z", Self::is_shown, Default::default()),
-                JavaMethodProto::new("repaint", "(IIII)V", Self::repaint_with_area, Default::default()),
-                JavaMethodProto::new("repaint", "()V", Self::repaint, Default::default()),
-                JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, Default::default()),
-                JavaMethodProto::new("showNotify", "(Z)V", Self::show_notify, Default::default()),
-                JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, Default::default()),
-                JavaMethodProto::new_abstract("paint", "(Lorg/kwis/msp/lcdui/Graphics;)V", Default::default()),
+                JavaMethodProto::new(
+                    "getDisplay",
+                    "()Lorg/kwis/msp/lcdui/Display;",
+                    Self::get_display,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("isShown", "()Z", Self::is_shown, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("repaint", "(IIII)V", Self::repaint_with_area, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("repaint", "()V", Self::repaint, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("showNotify", "(Z)V", Self::show_notify, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new_abstract(
+                    "paint",
+                    "(Lorg/kwis/msp/lcdui/Graphics;)V",
+                    MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT,
+                ),
                 // wie private
-                JavaMethodProto::new("setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", Self::set_canvas, Default::default()),
+                JavaMethodProto::new(
+                    "setCanvas",
+                    "(Ljavax/microedition/lcdui/Canvas;)V",
+                    Self::set_canvas,
+                    MethodAccessFlags::PRIVATE,
+                ),
             ],
             fields: vec![
-                JavaFieldProto::new("canvas", "Ljavax/microedition/lcdui/Canvas;", Default::default()),
-                JavaFieldProto::new("display", "Lorg/kwis/msp/lcdui/Display;", Default::default()),
-                JavaFieldProto::new("x", "I", Default::default()),
-                JavaFieldProto::new("y", "I", Default::default()),
-                JavaFieldProto::new("w", "I", Default::default()),
-                JavaFieldProto::new("h", "I", Default::default()),
-                JavaFieldProto::new("transparent", "Z", Default::default()),
+                JavaFieldProto::new("canvas", "Ljavax/microedition/lcdui/Canvas;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("display", "Lorg/kwis/msp/lcdui/Display;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("x", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("y", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("w", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("h", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("transparent", "Z", FieldAccessFlags::PROTECTED),
             ],
-            access_flags: ClassAccessFlags::ABSTRACT,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 
@@ -106,8 +125,8 @@ impl Card {
             return Err(jvm.exception("java/lang/NullPointerException", "display is null").await);
         }
 
-        let width: i32 = jvm.invoke_virtual(&display, "getWidth", "()I", []).await?;
-        let height: i32 = jvm.invoke_virtual(&display, "getHeight", "()I", []).await?;
+        let width: i32 = jvm.invoke_virtual(&display, "org/kwis/msp/lcdui/Display", "getWidth", "()I", []).await?;
+        let height: i32 = jvm.invoke_virtual(&display, "org/kwis/msp/lcdui/Display", "getHeight", "()I", []).await?;
         let _: () = jvm
             .invoke_special(
                 &this,
@@ -156,8 +175,8 @@ impl Card {
             return Err(jvm.exception("java/lang/NullPointerException", "display is null").await);
         }
 
-        let width: i32 = jvm.invoke_virtual(&display, "getWidth", "()I", []).await?;
-        let height: i32 = jvm.invoke_virtual(&display, "getHeight", "()I", []).await?;
+        let width: i32 = jvm.invoke_virtual(&display, "org/kwis/msp/lcdui/Display", "getWidth", "()I", []).await?;
+        let height: i32 = jvm.invoke_virtual(&display, "org/kwis/msp/lcdui/Display", "getHeight", "()I", []).await?;
         let _: () = jvm
             .invoke_special(
                 &this,
@@ -302,7 +321,9 @@ impl Card {
         let width: i32 = jvm.get_field(&this, "w", "I").await?;
         let height: i32 = jvm.get_field(&this, "h", "I").await?;
 
-        let _: () = jvm.invoke_virtual(&this, "repaint", "(IIII)V", (0, 0, width, height)).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "org/kwis/msp/lcdui/Card", "repaint", "(IIII)V", (0, 0, width, height))
+            .await?;
 
         Ok(())
     }
@@ -339,6 +360,7 @@ impl Card {
         let _: () = jvm
             .invoke_virtual(
                 &canvas,
+                "javax/microedition/lcdui/Canvas",
                 "repaint",
                 "(IIII)V",
                 (
@@ -358,7 +380,9 @@ impl Card {
 
         let canvas: ClassInstanceRef<Canvas> = jvm.get_field(&this, "canvas", "Ljavax/microedition/lcdui/Canvas;").await?;
         if !canvas.is_null() {
-            let _: () = jvm.invoke_virtual(&canvas, "serviceRepaints", "()V", ()).await?;
+            let _: () = jvm
+                .invoke_virtual(&canvas, "javax/microedition/lcdui/Canvas", "serviceRepaints", "()V", ())
+                .await?;
         }
 
         Ok(())
@@ -388,6 +412,7 @@ mod test {
     use alloc::{boxed::Box, vec, vec::Vec};
 
     use java_class_proto::{JavaFieldProto, JavaMethodProto};
+    use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
     use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
     use test_utils::run_jvm_test;
     use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -409,21 +434,26 @@ mod test {
                 parent_class: Some("org/kwis/msp/lcdui/Card"),
                 interfaces: vec![],
                 methods: vec![
-                    JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Display;IIIIZ)V", Self::init, Default::default()),
-                    JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Display;)V", Self::init_with_display, Default::default()),
-                    JavaMethodProto::new("paint", "(Lorg/kwis/msp/lcdui/Graphics;)V", Self::paint, Default::default()),
-                    JavaMethodProto::new("showNotify", "(Z)V", Self::show_notify, Default::default()),
-                    JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, Default::default()),
-                    JavaMethodProto::new("notifyEvent", "(III)V", Self::notify_event, Default::default()),
+                    JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Display;IIIIZ)V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "<init>",
+                        "(Lorg/kwis/msp/lcdui/Display;)V",
+                        Self::init_with_display,
+                        MethodAccessFlags::PUBLIC,
+                    ),
+                    JavaMethodProto::new("paint", "(Lorg/kwis/msp/lcdui/Graphics;)V", Self::paint, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("showNotify", "(Z)V", Self::show_notify, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("notifyEvent", "(III)V", Self::notify_event, MethodAccessFlags::PUBLIC),
                 ],
                 fields: vec![
-                    JavaFieldProto::new("showCount", "I", Default::default()),
-                    JavaFieldProto::new("hideCount", "I", Default::default()),
-                    JavaFieldProto::new("keyCount", "I", Default::default()),
-                    JavaFieldProto::new("notifyCount", "I", Default::default()),
-                    JavaFieldProto::new("paintCount", "I", Default::default()),
+                    JavaFieldProto::new("showCount", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("hideCount", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("keyCount", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("notifyCount", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("paintCount", "I", FieldAccessFlags::PRIVATE),
                 ],
-                access_flags: Default::default(),
+                access_flags: ClassAccessFlags::PUBLIC,
             }
         }
 
@@ -467,25 +497,66 @@ mod test {
             let y: i32 = jvm.get_field(&this, "y", "I").await?;
             let width: i32 = jvm.get_field(&this, "w", "I").await?;
             let height: i32 = jvm.get_field(&this, "h", "I").await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getTranslateX", "()I", ()).await?, x);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getTranslateY", "()I", ()).await?, y);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getColor", "()I", ()).await?, 0);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getAlpha", "()I", ()).await?, 255);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getStrokeStyle", "()I", ()).await?, 0);
-            assert!(!jvm.invoke_virtual::<_, bool>(&graphics, "isXORMode", "()Z", ()).await?);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getTranslateX", "()I", ())
+                    .await?,
+                x
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getTranslateY", "()I", ())
+                    .await?,
+                y
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getColor", "()I", ())
+                    .await?,
+                0
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getAlpha", "()I", ())
+                    .await?,
+                255
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getStrokeStyle", "()I", ())
+                    .await?,
+                0
+            );
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&graphics, "org/kwis/msp/lcdui/Graphics", "isXORMode", "()Z", ())
+                    .await?
+            );
 
             let transparent: bool = jvm.get_field(&this, "transparent", "Z").await?;
             let _: () = jvm
-                .invoke_virtual(&graphics, "setColor", "(I)V", (if transparent { 0xff0000 } else { 0x00ff00 },))
+                .invoke_virtual(
+                    &graphics,
+                    "org/kwis/msp/lcdui/Graphics",
+                    "setColor",
+                    "(I)V",
+                    (if transparent { 0xff0000 } else { 0x00ff00 },),
+                )
                 .await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, width, height)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, width, height))
+                .await?;
 
             if transparent {
-                let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (7, 8)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (0, 0, 1, 1)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setAlpha", "(I)V", (0,)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setStrokeStyle", "(I)V", (1,)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setXORMode", "(Z)V", (true,)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "translate", "(II)V", (7, 8))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setClip", "(IIII)V", (0, 0, 1, 1))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setAlpha", "(I)V", (0,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setStrokeStyle", "(I)V", (1,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setXORMode", "(Z)V", (true,))
+                    .await?;
             }
 
             Ok(())
@@ -521,18 +592,23 @@ mod test {
                 parent_class: Some("javax/microedition/lcdui/Canvas"),
                 interfaces: vec![],
                 methods: vec![
-                    JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                    JavaMethodProto::new("paint", "(Ljavax/microedition/lcdui/Graphics;)V", Self::paint, Default::default()),
-                    JavaMethodProto::new("repaint", "(IIII)V", Self::repaint, Default::default()),
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "paint",
+                        "(Ljavax/microedition/lcdui/Graphics;)V",
+                        Self::paint,
+                        MethodAccessFlags::PROTECTED,
+                    ),
+                    JavaMethodProto::new("repaint", "(IIII)V", Self::repaint, MethodAccessFlags::PUBLIC),
                 ],
                 fields: vec![
-                    JavaFieldProto::new("repaintX", "I", Default::default()),
-                    JavaFieldProto::new("repaintY", "I", Default::default()),
-                    JavaFieldProto::new("repaintWidth", "I", Default::default()),
-                    JavaFieldProto::new("repaintHeight", "I", Default::default()),
-                    JavaFieldProto::new("repaintCount", "I", Default::default()),
+                    JavaFieldProto::new("repaintX", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("repaintY", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("repaintWidth", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("repaintHeight", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("repaintCount", "I", FieldAccessFlags::PRIVATE),
                 ],
-                access_flags: Default::default(),
+                access_flags: ClassAccessFlags::PUBLIC,
             }
         }
 
@@ -578,28 +654,75 @@ mod test {
                     .await?
                     .into();
 
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getX", "()I", ()).await?, 3);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getY", "()I", ()).await?, 4);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getWidth", "()I", ()).await?, 20);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getHeight", "()I", ()).await?, 30);
-
-                let returned_display: ClassInstanceRef<Display> =
-                    jvm.invoke_virtual(&card, "getDisplay", "()Lorg/kwis/msp/lcdui/Display;", ()).await?;
-                assert!(
-                    jvm.invoke_virtual::<_, bool>(&returned_display, "equals", "(Ljava/lang/Object;)Z", (display.clone(),))
-                        .await?
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getX", "()I", ()).await?,
+                    3
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getY", "()I", ()).await?,
+                    4
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getWidth", "()I", ())
+                        .await?,
+                    20
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getHeight", "()I", ())
+                        .await?,
+                    30
                 );
 
-                let _: () = jvm.invoke_virtual(&card, "move", "(II)V", (-5, 7)).await?;
-                let _: () = jvm.invoke_virtual(&card, "resize", "(II)V", (40, 50)).await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getX", "()I", ()).await?, -5);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getY", "()I", ()).await?, 7);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getWidth", "()I", ()).await?, 40);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getHeight", "()I", ()).await?, 50);
+                let returned_display: ClassInstanceRef<Display> = jvm
+                    .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "getDisplay", "()Lorg/kwis/msp/lcdui/Display;", ())
+                    .await?;
+                assert!(
+                    jvm.invoke_virtual::<_, bool>(
+                        &returned_display,
+                        "org/kwis/msp/lcdui/Display",
+                        "equals",
+                        "(Ljava/lang/Object;)Z",
+                        (display.clone(),)
+                    )
+                    .await?
+                );
 
-                assert!(jvm.invoke_virtual::<_, ()>(&card, "resize", "(II)V", (0, 10)).await.is_err());
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getWidth", "()I", ()).await?, 40);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&card, "getHeight", "()I", ()).await?, 50);
+                let _: () = jvm.invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "move", "(II)V", (-5, 7)).await?;
+                let _: () = jvm.invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "resize", "(II)V", (40, 50)).await?;
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getX", "()I", ()).await?,
+                    -5
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getY", "()I", ()).await?,
+                    7
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getWidth", "()I", ())
+                        .await?,
+                    40
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getHeight", "()I", ())
+                        .await?,
+                    50
+                );
+
+                assert!(
+                    jvm.invoke_virtual::<_, ()>(&card, "org/kwis/msp/lcdui/Card", "resize", "(II)V", (0, 10))
+                        .await
+                        .is_err()
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getWidth", "()I", ())
+                        .await?,
+                    40
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&card, "org/kwis/msp/lcdui/Card", "getHeight", "()I", ())
+                        .await?,
+                    50
+                );
 
                 let invalid_size: JvmResult<ClassInstanceRef<TestCard>> = jvm
                     .new_class(
@@ -633,6 +756,7 @@ mod test {
                 let _: () = jvm
                     .invoke_virtual(
                         &midp_display,
+                        "javax/microedition/lcdui/Display",
                         "setCurrent",
                         "(Ljavax/microedition/lcdui/Displayable;)V",
                         (canvas.clone(),),
@@ -653,79 +777,171 @@ mod test {
                     .into();
 
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", [None.into()])
+                    .invoke_virtual(&canvas, "net/wie/CardCanvas", "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", [None.into()])
                     .await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&canvas, "countCard", "()I", ()).await?, 0);
-                assert!(!jvm.invoke_virtual::<_, bool>(&first, "isShown", "()Z", ()).await?);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&canvas, "net/wie/CardCanvas", "countCard", "()I", ())
+                        .await?,
+                    0
+                );
+                assert!(
+                    !jvm.invoke_virtual::<_, bool>(&first, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
 
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (first.clone(),))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (first.clone(),),
+                    )
                     .await?;
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (first.clone(),))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (first.clone(),),
+                    )
                     .await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&canvas, "countCard", "()I", ()).await?, 1);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&canvas, "net/wie/CardCanvas", "countCard", "()I", ())
+                        .await?,
+                    1
+                );
                 assert_eq!(jvm.get_field::<i32>(&first, "showCount", "I").await?, 1);
-                assert!(jvm.invoke_virtual::<_, bool>(&first, "isShown", "()Z", ()).await?);
+                assert!(
+                    jvm.invoke_virtual::<_, bool>(&first, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
                 let paint_count: i32 = jvm.get_field(&first, "paintCount", "I").await?;
-                let _: () = jvm.invoke_virtual(&first, "serviceRepaints", "()V", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&first, "org/kwis/msp/lcdui/Card", "serviceRepaints", "()V", ())
+                    .await?;
                 assert_eq!(jvm.get_field::<i32>(&first, "paintCount", "I").await?, paint_count + 1);
 
                 let other_canvas: ClassInstanceRef<CardCanvas> = jvm.new_class("net/wie/CardCanvas", "()V", ()).await?.into();
                 let _: () = jvm
-                    .invoke_virtual(&other_canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (first.clone(),))
+                    .invoke_virtual(
+                        &other_canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (first.clone(),),
+                    )
                     .await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&other_canvas, "countCard", "()I", ()).await?, 0);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&other_canvas, "net/wie/CardCanvas", "countCard", "()I", ())
+                        .await?,
+                    0
+                );
 
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (second.clone(),))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (second.clone(),),
+                    )
                     .await?;
-                let _: () = jvm.invoke_virtual(&canvas, "keyPressed", "(I)V", (42,)).await?;
-                let _: () = jvm.invoke_virtual(&canvas, "handleNotifyEvent", "(III)V", (1, 2, 3)).await?;
+                let _: () = jvm.invoke_virtual(&canvas, "net/wie/CardCanvas", "keyPressed", "(I)V", (42,)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&canvas, "net/wie/CardCanvas", "handleNotifyEvent", "(III)V", (1, 2, 3))
+                    .await?;
                 assert_eq!(jvm.get_field::<i32>(&first, "keyCount", "I").await?, 0);
                 assert_eq!(jvm.get_field::<i32>(&first, "notifyCount", "I").await?, 0);
                 assert_eq!(jvm.get_field::<i32>(&second, "keyCount", "I").await?, 1);
                 assert_eq!(jvm.get_field::<i32>(&second, "notifyCount", "I").await?, 1);
-                let popped: ClassInstanceRef<TestCard> = jvm.invoke_virtual(&canvas, "popCard", "()Lorg/kwis/msp/lcdui/Card;", ()).await?;
+                let popped: ClassInstanceRef<TestCard> = jvm
+                    .invoke_virtual(&canvas, "net/wie/CardCanvas", "popCard", "()Lorg/kwis/msp/lcdui/Card;", ())
+                    .await?;
                 assert!(
-                    jvm.invoke_virtual::<_, bool>(&popped, "equals", "(Ljava/lang/Object;)Z", (second.clone(),))
+                    jvm.invoke_virtual::<_, bool>(&popped, "org/kwis/msp/lcdui/Card", "equals", "(Ljava/lang/Object;)Z", (second.clone(),))
                         .await?
                 );
-                assert!(!jvm.invoke_virtual::<_, bool>(&second, "isShown", "()Z", ()).await?);
+                assert!(
+                    !jvm.invoke_virtual::<_, bool>(&second, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
                 assert_eq!(jvm.get_field::<i32>(&second, "hideCount", "I").await?, 1);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&canvas, "countCard", "()I", ()).await?, 1);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&canvas, "net/wie/CardCanvas", "countCard", "()I", ())
+                        .await?,
+                    1
+                );
 
                 assert!(
-                    !jvm.invoke_virtual::<_, bool>(&canvas, "removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", [None.into()])
+                    !jvm.invoke_virtual::<_, bool>(&canvas, "net/wie/CardCanvas", "removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", [None.into()])
                         .await?
                 );
                 assert!(
-                    !jvm.invoke_virtual::<_, bool>(&canvas, "removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", (second.clone(),),)
-                        .await?
+                    !jvm.invoke_virtual::<_, bool>(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "removeCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)Z",
+                        (second.clone(),),
+                    )
+                    .await?
                 );
                 assert!(
-                    jvm.invoke_virtual::<_, bool>(&canvas, "removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", (first.clone(),))
+                    jvm.invoke_virtual::<_, bool>(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "removeCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)Z",
+                        (first.clone(),)
+                    )
+                    .await?
+                );
+                assert!(
+                    !jvm.invoke_virtual::<_, bool>(&first, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
                         .await?
                 );
-                assert!(!jvm.invoke_virtual::<_, bool>(&first, "isShown", "()Z", ()).await?);
                 assert_eq!(jvm.get_field::<i32>(&first, "hideCount", "I").await?, 1);
 
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (first.clone(),))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (first.clone(),),
+                    )
                     .await?;
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (second.clone(),))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (second.clone(),),
+                    )
                     .await?;
-                let _: () = jvm.invoke_virtual(&canvas, "removeAllCards", "()V", ()).await?;
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&canvas, "countCard", "()I", ()).await?, 0);
-                assert!(!jvm.invoke_virtual::<_, bool>(&first, "isShown", "()Z", ()).await?);
-                assert!(!jvm.invoke_virtual::<_, bool>(&second, "isShown", "()Z", ()).await?);
+                let _: () = jvm.invoke_virtual(&canvas, "net/wie/CardCanvas", "removeAllCards", "()V", ()).await?;
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&canvas, "net/wie/CardCanvas", "countCard", "()I", ())
+                        .await?,
+                    0
+                );
+                assert!(
+                    !jvm.invoke_virtual::<_, bool>(&first, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
+                assert!(
+                    !jvm.invoke_virtual::<_, bool>(&second, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
                 assert_eq!(jvm.get_field::<i32>(&first, "showCount", "I").await?, 2);
                 assert_eq!(jvm.get_field::<i32>(&first, "hideCount", "I").await?, 2);
                 assert_eq!(jvm.get_field::<i32>(&second, "showCount", "I").await?, 2);
                 assert_eq!(jvm.get_field::<i32>(&second, "hideCount", "I").await?, 2);
                 assert!(
-                    jvm.invoke_virtual::<_, ClassInstanceRef<TestCard>>(&canvas, "popCard", "()Lorg/kwis/msp/lcdui/Card;", ())
+                    jvm.invoke_virtual::<_, ClassInstanceRef<TestCard>>(&canvas, "net/wie/CardCanvas", "popCard", "()Lorg/kwis/msp/lcdui/Card;", (),)
                         .await?
                         .is_null()
                 );
@@ -748,22 +964,37 @@ mod test {
                     .into();
                 let canvas: ClassInstanceRef<TestCanvas> = jvm.new_class("test/TestCanvas", "()V", ()).await?.into();
                 let _: () = jvm
-                    .invoke_virtual(&card, "setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", (canvas.clone(),))
+                    .invoke_virtual(
+                        &card,
+                        "org/kwis/msp/lcdui/Card",
+                        "setCanvas",
+                        "(Ljavax/microedition/lcdui/Canvas;)V",
+                        (canvas.clone(),),
+                    )
                     .await?;
-                assert!(jvm.invoke_virtual::<_, bool>(&card, "isShown", "()Z", ()).await?);
+                assert!(
+                    jvm.invoke_virtual::<_, bool>(&card, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
 
-                let _: () = jvm.invoke_virtual(&card, "repaint", "(IIII)V", (-5, 5, 20, 50)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "repaint", "(IIII)V", (-5, 5, 20, 50))
+                    .await?;
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintX", "I").await?, 10);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintY", "I").await?, 25);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintWidth", "I").await?, 15);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintHeight", "I").await?, 35);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintCount", "I").await?, 1);
 
-                let _: () = jvm.invoke_virtual(&card, "repaint", "(IIII)V", (40, 0, 5, 5)).await?;
-                let _: () = jvm.invoke_virtual(&card, "repaint", "(IIII)V", (0, 0, -1, 5)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "repaint", "(IIII)V", (40, 0, 5, 5))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "repaint", "(IIII)V", (0, 0, -1, 5))
+                    .await?;
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintCount", "I").await?, 1);
 
-                let _: () = jvm.invoke_virtual(&card, "repaint", "()V", ()).await?;
+                let _: () = jvm.invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "repaint", "()V", ()).await?;
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintX", "I").await?, 10);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintY", "I").await?, 20);
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintWidth", "I").await?, 30);
@@ -771,10 +1002,19 @@ mod test {
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintCount", "I").await?, 2);
 
                 let _: () = jvm
-                    .invoke_virtual(&card, "setCanvas", "(Ljavax/microedition/lcdui/Canvas;)V", (None,))
+                    .invoke_virtual(
+                        &card,
+                        "org/kwis/msp/lcdui/Card",
+                        "setCanvas",
+                        "(Ljavax/microedition/lcdui/Canvas;)V",
+                        (None,),
+                    )
                     .await?;
-                let _: () = jvm.invoke_virtual(&card, "repaint", "()V", ()).await?;
-                assert!(!jvm.invoke_virtual::<_, bool>(&card, "isShown", "()Z", ()).await?);
+                let _: () = jvm.invoke_virtual(&card, "org/kwis/msp/lcdui/Card", "repaint", "()V", ()).await?;
+                assert!(
+                    !jvm.invoke_virtual::<_, bool>(&card, "org/kwis/msp/lcdui/Card", "isShown", "()Z", ())
+                        .await?
+                );
                 assert_eq!(jvm.get_field::<i32>(&canvas, "repaintCount", "I").await?, 2);
 
                 Ok(())
@@ -793,6 +1033,7 @@ mod test {
                 let _: () = jvm
                     .invoke_virtual(
                         &midp_display,
+                        "javax/microedition/lcdui/Display",
                         "setCurrent",
                         "(Ljavax/microedition/lcdui/Displayable;)V",
                         (canvas.clone(),),
@@ -812,10 +1053,16 @@ mod test {
                     .await?
                     .into();
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (mutating_card,))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "pushCard",
+                        "(Lorg/kwis/msp/lcdui/Card;)V",
+                        (mutating_card,),
+                    )
                     .await?;
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (drawing_card,))
+                    .invoke_virtual(&canvas, "net/wie/CardCanvas", "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (drawing_card,))
                     .await?;
 
                 let image: ClassInstanceRef<MidpImage> = jvm
@@ -827,23 +1074,69 @@ mod test {
                     )
                     .await?;
                 let graphics: ClassInstanceRef<MidpGraphics> = jvm
-                    .invoke_virtual(&image, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+                    .invoke_virtual(
+                        &image,
+                        "javax/microedition/lcdui/Image",
+                        "getGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
                     .await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x0000ff,)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (4, 4)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "setClip", "(IIII)V", (-2, -3, 4, 3)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x0000ff,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (4, 4))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setClip", "(IIII)V", (-2, -3, 4, 3))
+                    .await?;
 
                 let _: () = jvm
-                    .invoke_virtual(&canvas, "paint", "(Ljavax/microedition/lcdui/Graphics;)V", (graphics.clone(),))
+                    .invoke_virtual(
+                        &canvas,
+                        "net/wie/CardCanvas",
+                        "paint",
+                        "(Ljavax/microedition/lcdui/Graphics;)V",
+                        (graphics.clone(),),
+                    )
                     .await?;
 
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getTranslateX", "()I", ()).await?, 0);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getTranslateY", "()I", ()).await?, 0);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipX", "()I", ()).await?, 0);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipY", "()I", ()).await?, 0);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipWidth", "()I", ()).await?, 10);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getClipHeight", "()I", ()).await?, 10);
-                assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getColor", "()I", ()).await?, 0);
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getTranslateX", "()I", ())
+                        .await?,
+                    0
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getTranslateY", "()I", ())
+                        .await?,
+                    0
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+                        .await?,
+                    0
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+                        .await?,
+                    0
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+                        .await?,
+                    10
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+                        .await?,
+                    10
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getColor", "()I", ())
+                        .await?,
+                    0
+                );
 
                 let backend_image = MidpImage::image(&jvm, &image).await?;
                 let outside = backend_image.get_pixel(0, 0);

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/display.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/display.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::{Object, Runnable, String};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -28,88 +28,133 @@ impl Display {
                     "<init>",
                     "(Lorg/kwis/msp/lcdui/Jlet;Lorg/kwis/msp/lcdui/DisplayProxy;)V",
                     Self::init,
-                    Default::default(),
+                    MethodAccessFlags::PRIVATE,
                 ),
                 JavaMethodProto::new(
                     "getDisplay",
                     "(Ljava/lang/String;)Lorg/kwis/msp/lcdui/Display;",
                     Self::get_display,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC | MethodAccessFlags::FINAL,
                 ),
                 JavaMethodProto::new(
                     "getDefaultDisplay",
                     "()Lorg/kwis/msp/lcdui/Display;",
                     Self::get_default_display,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("isDoubleBuffered", "()Z", Self::is_double_buffered, Default::default()),
-                JavaMethodProto::new("getDockedCard", "()Lorg/kwis/msp/lcdui/Card;", Self::get_docked_card, Default::default()),
+                JavaMethodProto::new("isDoubleBuffered", "()Z", Self::is_double_buffered, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "getDockedCard",
+                    "()Lorg/kwis/msp/lcdui/Card;",
+                    Self::get_docked_card,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new(
                     "setDockedCard",
                     "(Lorg/kwis/msp/lcdui/Card;I)V",
                     Self::set_docked_card,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", Self::push_card, Default::default()),
-                JavaMethodProto::new("popCard", "()Lorg/kwis/msp/lcdui/Card;", Self::pop_card, Default::default()),
-                JavaMethodProto::new("removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", Self::remove_card, Default::default()),
-                JavaMethodProto::new("countCard", "()I", Self::count_card, Default::default()),
-                JavaMethodProto::new("removeAllCards", "()V", Self::remove_all_cards, Default::default()),
+                JavaMethodProto::new(
+                    "pushCard",
+                    "(Lorg/kwis/msp/lcdui/Card;)V",
+                    Self::push_card,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new(
+                    "popCard",
+                    "()Lorg/kwis/msp/lcdui/Card;",
+                    Self::pop_card,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new(
+                    "removeCard",
+                    "(Lorg/kwis/msp/lcdui/Card;)Z",
+                    Self::remove_card,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new("countCard", "()I", Self::count_card, MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL),
+                JavaMethodProto::new("removeAllCards", "()V", Self::remove_all_cards, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "addJletEventListener",
                     "(Lorg/kwis/msp/lcdui/JletEventListener;)V",
                     Self::add_jlet_event_listener,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
-                JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, Default::default()),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL),
+                JavaMethodProto::new(
+                    "callSerially",
+                    "(Ljava/lang/Runnable;)V",
+                    Self::call_serially,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
                 JavaMethodProto::new(
                     "callSerially",
                     "(Ljava/lang/Runnable;I)V",
                     Self::call_serially_with_timeout,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
                 ),
-                JavaMethodProto::new("isColor", "()Z", Self::is_color, Default::default()),
-                JavaMethodProto::new("numColors", "()I", Self::num_colors, Default::default()),
-                JavaMethodProto::new("hasPointerEvents", "()Z", Self::has_pointer_events, Default::default()),
-                JavaMethodProto::new("hasPointerMotionEvents", "()Z", Self::has_pointer_motion_events, Default::default()),
-                JavaMethodProto::new("hasRepeatEvents", "()Z", Self::has_repeat_events, Default::default()),
-                JavaMethodProto::new("getKeyName", "(I)Ljava/lang/String;", Self::get_key_name, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getBitsPerPixel", "()I", Self::get_bits_per_pixel, Default::default()),
-                JavaMethodProto::new("flush", "()V", Self::flush, Default::default()),
+                JavaMethodProto::new("isColor", "()Z", Self::is_color, MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL),
+                JavaMethodProto::new("numColors", "()I", Self::num_colors, MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL),
+                JavaMethodProto::new(
+                    "hasPointerEvents",
+                    "()Z",
+                    Self::has_pointer_events,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new(
+                    "hasPointerMotionEvents",
+                    "()Z",
+                    Self::has_pointer_motion_events,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new(
+                    "hasRepeatEvents",
+                    "()Z",
+                    Self::has_repeat_events,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new(
+                    "getKeyName",
+                    "(I)Ljava/lang/String;",
+                    Self::get_key_name,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("getBitsPerPixel", "()I", Self::get_bits_per_pixel, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("flush", "()V", Self::flush, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "removeJletEventListener",
                     "(Lorg/kwis/msp/lcdui/JletEventListener;)V",
                     Self::remove_jlet_event_listener,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
                     "grabKey",
                     "(ILorg/kwis/msp/lcdui/JletEventListener;)V",
                     Self::grab_key,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("ungrabKey", "(I)V", Self::ungrab_key, Default::default()),
+                JavaMethodProto::new("ungrabKey", "(I)V", Self::ungrab_key, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getGameAction",
                     "(I)I",
                     Self::get_game_action,
-                    MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "getKeyCode",
                     "(I)I",
                     Self::get_key_code,
-                    MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("midpDisplay", "Ljavax/microedition/lcdui/Display;", Default::default()),
-                JavaFieldProto::new("cardCanvas", "Lnet/wie/CardCanvas;", Default::default()),
-                JavaFieldProto::new("dockedCard", "Lorg/kwis/msp/lcdui/Card;", Default::default()),
+                JavaFieldProto::new("midpDisplay", "Ljavax/microedition/lcdui/Display;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("cardCanvas", "Lnet/wie/CardCanvas;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("dockedCard", "Lorg/kwis/msp/lcdui/Card;", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -141,7 +186,13 @@ impl Display {
             .await?;
 
         let _: () = jvm
-            .invoke_virtual(&midp_display, "setCurrent", "(Ljavax/microedition/lcdui/Displayable;)V", (card_canvas,))
+            .invoke_virtual(
+                &midp_display,
+                "javax/microedition/lcdui/Display",
+                "setCurrent",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (card_canvas,),
+            )
             .await?;
 
         Ok(())
@@ -197,14 +248,17 @@ impl Display {
 
         let canvas = jvm.get_field(&this, "cardCanvas", "Lnet/wie/CardCanvas;").await?;
 
-        jvm.invoke_virtual(&canvas, "isDoubleBuffered", "()Z", ()).await
+        jvm.invoke_virtual(&canvas, "javax/microedition/lcdui/Canvas", "isDoubleBuffered", "()Z", ())
+            .await
     }
 
     async fn push_card(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>, c: ClassInstanceRef<Card>) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Display::pushCard({this:?}, {c:?})");
 
         let card_canvas = jvm.get_field(&this, "cardCanvas", "Lnet/wie/CardCanvas;").await?;
-        let _: () = jvm.invoke_virtual(&card_canvas, "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (c,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&card_canvas, "net/wie/CardCanvas", "pushCard", "(Lorg/kwis/msp/lcdui/Card;)V", (c,))
+            .await?;
 
         Ok(())
     }
@@ -213,14 +267,15 @@ impl Display {
         tracing::debug!("org.kwis.msp.lcdui.Display::popCard({this:?})");
 
         let card_canvas = jvm.get_field(&this, "cardCanvas", "Lnet/wie/CardCanvas;").await?;
-        jvm.invoke_virtual(&card_canvas, "popCard", "()Lorg/kwis/msp/lcdui/Card;", ()).await
+        jvm.invoke_virtual(&card_canvas, "net/wie/CardCanvas", "popCard", "()Lorg/kwis/msp/lcdui/Card;", ())
+            .await
     }
 
     async fn remove_card(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>, card: ClassInstanceRef<Card>) -> JvmResult<bool> {
         tracing::debug!("org.kwis.msp.lcdui.Display::removeCard({this:?}, {card:?})");
 
         let card_canvas = jvm.get_field(&this, "cardCanvas", "Lnet/wie/CardCanvas;").await?;
-        jvm.invoke_virtual(&card_canvas, "removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", (card,))
+        jvm.invoke_virtual(&card_canvas, "net/wie/CardCanvas", "removeCard", "(Lorg/kwis/msp/lcdui/Card;)Z", (card,))
             .await
     }
 
@@ -228,14 +283,16 @@ impl Display {
         tracing::debug!("org.kwis.msp.lcdui.Display::countCard({this:?})");
 
         let card_canvas = jvm.get_field(&this, "cardCanvas", "Lnet/wie/CardCanvas;").await?;
-        jvm.invoke_virtual(&card_canvas, "countCard", "()I", ()).await
+        jvm.invoke_virtual(&card_canvas, "net/wie/CardCanvas", "countCard", "()I", ()).await
     }
 
     async fn remove_all_cards(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Display::removeAllCards({this:?})");
 
         let card_canvas = jvm.get_field(&this, "cardCanvas", "Lnet/wie/CardCanvas;").await?;
-        let _: () = jvm.invoke_virtual(&card_canvas, "removeAllCards", "()V", ()).await?;
+        let _: () = jvm
+            .invoke_virtual(&card_canvas, "net/wie/CardCanvas", "removeAllCards", "()V", ())
+            .await?;
 
         Ok(())
     }
@@ -255,7 +312,9 @@ impl Display {
         tracing::debug!("org.kwis.msp.lcdui.Display::getWidth({this:?})");
 
         let midp_display: ClassInstanceRef<MidpDisplay> = jvm.get_field(&this, "midpDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let width: i32 = jvm.invoke_virtual(&midp_display, "getWidth", "()I", ()).await?;
+        let width: i32 = jvm
+            .invoke_virtual(&midp_display, "javax/microedition/lcdui/Display", "getWidth", "()I", ())
+            .await?;
 
         Ok(width)
     }
@@ -264,7 +323,9 @@ impl Display {
         tracing::debug!("org.kwis.msp.lcdui.Display::getHeight({this:?})");
 
         let midp_display: ClassInstanceRef<MidpDisplay> = jvm.get_field(&this, "midpDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let height: i32 = jvm.invoke_virtual(&midp_display, "getHeight", "()I", ()).await?;
+        let height: i32 = jvm
+            .invoke_virtual(&midp_display, "javax/microedition/lcdui/Display", "getHeight", "()I", ())
+            .await?;
 
         Ok(height)
     }
@@ -273,7 +334,15 @@ impl Display {
         tracing::debug!("org.kwis.msp.lcdui.Display::callSerially({this:?}, {r:?})");
 
         let midp_display: ClassInstanceRef<MidpDisplay> = jvm.get_field(&this, "midpDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let _: () = jvm.invoke_virtual(&midp_display, "callSerially", "(Ljava/lang/Runnable;)V", (r,)).await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &midp_display,
+                "javax/microedition/lcdui/Display",
+                "callSerially",
+                "(Ljava/lang/Runnable;)V",
+                (r,),
+            )
+            .await?;
 
         Ok(())
     }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/display.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/display.rs
@@ -28,7 +28,7 @@ impl Display {
                     "<init>",
                     "(Lorg/kwis/msp/lcdui/Jlet;Lorg/kwis/msp/lcdui/DisplayProxy;)V",
                     Self::init,
-                    MethodAccessFlags::PRIVATE,
+                    MethodAccessFlags::empty(),
                 ),
                 JavaMethodProto::new(
                     "getDisplay",

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/event_queue.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/event_queue.rs
@@ -19,7 +19,7 @@ impl EventQueue {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Jlet;)V", Self::init, MethodAccessFlags::PRIVATE),
+                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Jlet;)V", Self::init, MethodAccessFlags::empty()),
                 JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("postEvent", "([I)Z", Self::post_event, MethodAccessFlags::PUBLIC),

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/event_queue.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/event_queue.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -19,14 +19,19 @@ impl EventQueue {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Jlet;)V", Self::init, Default::default()),
-                JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, Default::default()),
-                JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, Default::default()),
-                JavaMethodProto::new("postEvent", "([I)Z", Self::post_event, Default::default()),
-                JavaMethodProto::new("postEvent", "(I[I)V", Self::post_event_static, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Jlet;)V", Self::init, MethodAccessFlags::PRIVATE),
+                JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("postEvent", "([I)Z", Self::post_event, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "postEvent",
+                    "(I[I)V",
+                    Self::post_event_static,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
             ],
-            fields: vec![JavaFieldProto::new("wieEventQueue", "Lnet/wie/EventQueue;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new("wieEventQueue", "Lnet/wie/EventQueue;", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -52,7 +57,9 @@ impl EventQueue {
         tracing::debug!("org.kwis.msp.lcdui.EventQueue::getNextEvent({this:?}, {event:?})");
 
         let wie_event_queue = jvm.get_field(&this, "wieEventQueue", "Lnet/wie/EventQueue;").await?;
-        let _: () = jvm.invoke_virtual(&wie_event_queue, "getNextEvent", "([I)V", (event,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&wie_event_queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event,))
+            .await?;
 
         Ok(())
     }
@@ -66,7 +73,9 @@ impl EventQueue {
         tracing::debug!("org.kwis.msp.lcdui.EventQueue::dispatchEvent({this:?}, {event:?})");
 
         let wie_event_queue = jvm.get_field(&this, "wieEventQueue", "Lnet/wie/EventQueue;").await?;
-        let _: () = jvm.invoke_virtual(&wie_event_queue, "dispatchEvent", "([I)V", (event,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&wie_event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event,))
+            .await?;
 
         Ok(())
     }
@@ -103,7 +112,10 @@ mod test {
                 .into();
             let event = jvm.instantiate_array("I", 4).await?;
 
-            assert!(!jvm.invoke_virtual::<_, bool>(&queue, "postEvent", "([I)Z", (event.clone(),)).await?);
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&queue, "org/kwis/msp/lcdui/EventQueue", "postEvent", "([I)Z", (event.clone(),))
+                    .await?
+            );
             let _: () = jvm
                 .invoke_static("org/kwis/msp/lcdui/EventQueue", "postEvent", "(I[I)V", (1, event))
                 .await?;

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/font.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/font.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::{FieldAccessFlags, MethodAccessFlags};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, JavaChar, Jvm, Result as JvmResult};
 
@@ -19,45 +19,55 @@ impl Font {
             interfaces: vec![],
             methods: vec![
                 JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Font;)V", Self::init, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
-                JavaMethodProto::new("getBaselinePosition", "()I", Self::get_baseline_position, Default::default()),
-                JavaMethodProto::new("getFace", "()I", Self::get_face, Default::default()),
-                JavaMethodProto::new("getSize", "()I", Self::get_size, Default::default()),
-                JavaMethodProto::new("getStyle", "()I", Self::get_style, Default::default()),
-                JavaMethodProto::new("isBold", "()Z", Self::is_bold, Default::default()),
-                JavaMethodProto::new("isItalic", "()Z", Self::is_italic, Default::default()),
-                JavaMethodProto::new("isPlain", "()Z", Self::is_plain, Default::default()),
-                JavaMethodProto::new("isUnderlined", "()Z", Self::is_underlined, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Font;)V", Self::init, MethodAccessFlags::PRIVATE),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getBaselinePosition", "()I", Self::get_baseline_position, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getFace", "()I", Self::get_face, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getSize", "()I", Self::get_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getStyle", "()I", Self::get_style, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isBold", "()Z", Self::is_bold, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isItalic", "()Z", Self::is_italic, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isPlain", "()Z", Self::is_plain, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isUnderlined", "()Z", Self::is_underlined, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getDefaultFont",
                     "()Lorg/kwis/msp/lcdui/Font;",
                     Self::get_default_font,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("getFont", "(III)Lorg/kwis/msp/lcdui/Font;", Self::get_font, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("stringWidth", "(Ljava/lang/String;)I", Self::string_width, Default::default()),
-                JavaMethodProto::new("substringWidth", "(Ljava/lang/String;II)I", Self::substring_width, Default::default()),
-                JavaMethodProto::new("charWidth", "(C)I", Self::char_width, Default::default()),
-                JavaMethodProto::new("charsWidth", "([CII)I", Self::chars_width, Default::default()),
+                JavaMethodProto::new(
+                    "getFont",
+                    "(III)Lorg/kwis/msp/lcdui/Font;",
+                    Self::get_font,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("stringWidth", "(Ljava/lang/String;)I", Self::string_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "substringWidth",
+                    "(Ljava/lang/String;II)I",
+                    Self::substring_width,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("charWidth", "(C)I", Self::char_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("charsWidth", "([CII)I", Self::chars_width, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("midpFont", "Ljavax/microedition/lcdui/Font;", Default::default()),
-                JavaFieldProto::new("face", "I", Default::default()),
-                JavaFieldProto::new("style", "I", Default::default()),
-                JavaFieldProto::new("size", "I", Default::default()),
-                JavaFieldProto::new("FACE_SYSTEM", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("FACE_PROPORTIONAL", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_PLAIN", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_BOLD", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_ITALIC", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("STYLE_UNDERLINED", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("SIZE_SMALL", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("SIZE_MEDIUM", "I", FieldAccessFlags::STATIC),
-                JavaFieldProto::new("SIZE_LARGE", "I", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("midpFont", "Ljavax/microedition/lcdui/Font;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("face", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("style", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("size", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("FACE_SYSTEM", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("FACE_MONOSPACE", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("FACE_PROPORTIONAL", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_PLAIN", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_BOLD", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_ITALIC", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("STYLE_UNDERLINED", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_SMALL", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_MEDIUM", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
+                JavaFieldProto::new("SIZE_LARGE", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -107,7 +117,8 @@ impl Font {
         tracing::debug!("org.kwis.msp.lcdui.Font::getHeight");
 
         let midp_font = jvm.get_field(&this, "midpFont", "Ljavax/microedition/lcdui/Font;").await?;
-        jvm.invoke_virtual(&midp_font, "getHeight", "()I", ()).await
+        jvm.invoke_virtual(&midp_font, "javax/microedition/lcdui/Font", "getHeight", "()I", ())
+            .await
     }
 
     async fn get_baseline_position(_: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -202,7 +213,14 @@ impl Font {
         tracing::debug!("org.kwis.msp.lcdui.Font::stringWidth({string:?})");
 
         let midp_font = jvm.get_field(&this, "midpFont", "Ljavax/microedition/lcdui/Font;").await?;
-        jvm.invoke_virtual(&midp_font, "stringWidth", "(Ljava/lang/String;)I", (string,)).await
+        jvm.invoke_virtual(
+            &midp_font,
+            "javax/microedition/lcdui/Font",
+            "stringWidth",
+            "(Ljava/lang/String;)I",
+            (string,),
+        )
+        .await
     }
 
     async fn substring_width(
@@ -216,15 +234,22 @@ impl Font {
         tracing::debug!("org.kwis.msp.lcdui.Font::substringWidth({string:?}, {offset:?}, {len:?})");
 
         let midp_font = jvm.get_field(&this, "midpFont", "Ljavax/microedition/lcdui/Font;").await?;
-        jvm.invoke_virtual(&midp_font, "substringWidth", "(Ljava/lang/String;II)I", (string, offset, len))
-            .await
+        jvm.invoke_virtual(
+            &midp_font,
+            "javax/microedition/lcdui/Font",
+            "substringWidth",
+            "(Ljava/lang/String;II)I",
+            (string, offset, len),
+        )
+        .await
     }
 
     async fn char_width(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>, char: JavaChar) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Font::charWidth({char:?})");
 
         let midp_font = jvm.get_field(&this, "midpFont", "Ljavax/microedition/lcdui/Font;").await?;
-        jvm.invoke_virtual(&midp_font, "charWidth", "(C)I", (char,)).await
+        jvm.invoke_virtual(&midp_font, "javax/microedition/lcdui/Font", "charWidth", "(C)I", (char,))
+            .await
     }
 
     async fn chars_width(
@@ -238,7 +263,8 @@ impl Font {
         tracing::debug!("org.kwis.msp.lcdui.Font::charsWidth({chars:?}, {offset:?}, {len:?})");
 
         let midp_font = jvm.get_field(&this, "midpFont", "Ljavax/microedition/lcdui/Font;").await?;
-        jvm.invoke_virtual(&midp_font, "charsWidth", "([CII)I", (chars, offset, len)).await
+        jvm.invoke_virtual(&midp_font, "javax/microedition/lcdui/Font", "charsWidth", "([CII)I", (chars, offset, len))
+            .await
     }
 
     pub async fn midp_font(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<MidpFont>> {
@@ -268,14 +294,42 @@ mod test {
                 )
                 .await?;
 
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&font, "getFace", "()I", ()).await?, 32);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&font, "getStyle", "()I", ()).await?, 7);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&font, "getSize", "()I", ()).await?, 16);
-            assert!(jvm.invoke_virtual::<_, bool>(&font, "isBold", "()Z", ()).await?);
-            assert!(jvm.invoke_virtual::<_, bool>(&font, "isItalic", "()Z", ()).await?);
-            assert!(jvm.invoke_virtual::<_, bool>(&font, "isUnderlined", "()Z", ()).await?);
-            assert!(!jvm.invoke_virtual::<_, bool>(&font, "isPlain", "()Z", ()).await?);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&font, "getBaselinePosition", "()I", ()).await?, 0);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&font, "org/kwis/msp/lcdui/Font", "getFace", "()I", ())
+                    .await?,
+                32
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&font, "org/kwis/msp/lcdui/Font", "getStyle", "()I", ())
+                    .await?,
+                7
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&font, "org/kwis/msp/lcdui/Font", "getSize", "()I", ())
+                    .await?,
+                16
+            );
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&font, "org/kwis/msp/lcdui/Font", "isBold", "()Z", ())
+                    .await?
+            );
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&font, "org/kwis/msp/lcdui/Font", "isItalic", "()Z", ())
+                    .await?
+            );
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&font, "org/kwis/msp/lcdui/Font", "isUnderlined", "()Z", ())
+                    .await?
+            );
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&font, "org/kwis/msp/lcdui/Font", "isPlain", "()Z", ())
+                    .await?
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&font, "org/kwis/msp/lcdui/Font", "getBaselinePosition", "()I", ())
+                    .await?,
+                0
+            );
 
             Ok(())
         })

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/graphics.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/graphics.rs
@@ -3,6 +3,7 @@ use alloc::vec;
 use jvm::{Array, ClassInstanceRef, JavaChar, Jvm, Result as JvmResult};
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -21,69 +22,79 @@ impl Graphics {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Display;)V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "(Lorg/kwis/msp/lcdui/Display;)V", Self::init, MethodAccessFlags::PRIVATE),
                 JavaMethodProto::new(
                     "<init>",
                     "(Ljavax/microedition/lcdui/Graphics;)V",
                     Self::init_with_midp_graphics,
-                    Default::default(),
+                    MethodAccessFlags::PRIVATE,
                 ),
-                JavaMethodProto::new("getFont", "()Lorg/kwis/msp/lcdui/Font;", Self::get_font, Default::default()),
-                JavaMethodProto::new("copyArea", "(IIIIII)V", Self::copy_area, Default::default()),
-                JavaMethodProto::new("setColor", "(I)V", Self::set_color, Default::default()),
-                JavaMethodProto::new("setColor", "(III)V", Self::set_color_by_rgb, Default::default()),
-                JavaMethodProto::new("setFont", "(Lorg/kwis/msp/lcdui/Font;)V", Self::set_font, Default::default()),
-                JavaMethodProto::new("setAlpha", "(I)V", Self::set_alpha, Default::default()),
-                JavaMethodProto::new("fillRect", "(IIII)V", Self::fill_rect, Default::default()),
-                JavaMethodProto::new("fillRoundRect", "(IIIIII)V", Self::fill_round_rect, Default::default()),
-                JavaMethodProto::new("fillArc", "(IIIIII)V", Self::fill_arc, Default::default()),
-                JavaMethodProto::new("fillPolygon", "([I[I)V", Self::fill_polygon, Default::default()),
-                JavaMethodProto::new("drawLine", "(IIII)V", Self::draw_line, Default::default()),
-                JavaMethodProto::new("drawRect", "(IIII)V", Self::draw_rect, Default::default()),
-                JavaMethodProto::new("drawRoundRect", "(IIIIII)V", Self::draw_round_rect, Default::default()),
-                JavaMethodProto::new("drawArc", "(IIIIII)V", Self::draw_arc, Default::default()),
-                JavaMethodProto::new("drawPolygon", "([I[I)V", Self::draw_polygon, Default::default()),
-                JavaMethodProto::new("drawChar", "(CIII)V", Self::draw_char, Default::default()),
-                JavaMethodProto::new("drawChars", "([CIIIII)V", Self::draw_chars, Default::default()),
-                JavaMethodProto::new("drawString", "(Ljava/lang/String;III)V", Self::draw_string, Default::default()),
-                JavaMethodProto::new("drawSubstring", "(Ljava/lang/String;IIIII)V", Self::draw_substring, Default::default()),
-                JavaMethodProto::new("drawImage", "(Lorg/kwis/msp/lcdui/Image;III)V", Self::draw_image, Default::default()),
-                JavaMethodProto::new("setClip", "(IIII)V", Self::set_clip, Default::default()),
-                JavaMethodProto::new("clipRect", "(IIII)V", Self::clip_rect, Default::default()),
-                JavaMethodProto::new("getColor", "()I", Self::get_color, Default::default()),
-                JavaMethodProto::new("getBlueComponent", "()I", Self::get_blue_component, Default::default()),
-                JavaMethodProto::new("getGrayScale", "()I", Self::get_gray_scale, Default::default()),
-                JavaMethodProto::new("getGreenComponent", "()I", Self::get_green_component, Default::default()),
-                JavaMethodProto::new("getRedComponent", "()I", Self::get_red_component, Default::default()),
-                JavaMethodProto::new("getStrokeStyle", "()I", Self::get_stroke_style, Default::default()),
-                JavaMethodProto::new("setStrokeStyle", "(I)V", Self::set_stroke_style, Default::default()),
-                JavaMethodProto::new("getClipX", "()I", Self::get_clip_x, Default::default()),
-                JavaMethodProto::new("getClipY", "()I", Self::get_clip_y, Default::default()),
-                JavaMethodProto::new("getClipWidth", "()I", Self::get_clip_width, Default::default()),
-                JavaMethodProto::new("getClipHeight", "()I", Self::get_clip_height, Default::default()),
-                JavaMethodProto::new("getTranslateX", "()I", Self::get_translate_x, Default::default()),
-                JavaMethodProto::new("getTranslateY", "()I", Self::get_translate_y, Default::default()),
-                JavaMethodProto::new("translate", "(II)V", Self::translate, Default::default()),
-                JavaMethodProto::new("setPixel", "(II)V", Self::set_pixel, Default::default()),
-                JavaMethodProto::new("setRGBPixels", "(IIII[III)V", Self::set_rgb_pixels, Default::default()),
-                JavaMethodProto::new("setGrayScale", "(I)V", Self::set_gray_scale, Default::default()),
-                JavaMethodProto::new("setXORMode", "(Z)V", Self::set_xor_mode, Default::default()),
-                JavaMethodProto::new("getPixel", "(II)I", Self::get_pixel, Default::default()),
-                JavaMethodProto::new("getPixels", "(IIII[BII)V", Self::get_pixels, Default::default()),
-                JavaMethodProto::new("setPixels", "(IIII[BII)V", Self::set_pixels, Default::default()),
-                JavaMethodProto::new("reset", "()V", Self::reset, Default::default()),
-                JavaMethodProto::new("getAlpha", "()I", Self::get_alpha, Default::default()),
-                JavaMethodProto::new("isXORMode", "()Z", Self::is_xor_mode, Default::default()),
-                JavaMethodProto::new("encodeImage", "(IIII)[B", Self::encode_image, Default::default()),
-                JavaMethodProto::new("getRGBPixels", "(IIII[III)V", Self::get_rgb_pixels, Default::default()),
+                JavaMethodProto::new("getFont", "()Lorg/kwis/msp/lcdui/Font;", Self::get_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("copyArea", "(IIIIII)V", Self::copy_area, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setColor", "(I)V", Self::set_color, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setColor", "(III)V", Self::set_color_by_rgb, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setFont", "(Lorg/kwis/msp/lcdui/Font;)V", Self::set_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setAlpha", "(I)V", Self::set_alpha, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillRect", "(IIII)V", Self::fill_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillRoundRect", "(IIIIII)V", Self::fill_round_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillArc", "(IIIIII)V", Self::fill_arc, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("fillPolygon", "([I[I)V", Self::fill_polygon, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawLine", "(IIII)V", Self::draw_line, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawRect", "(IIII)V", Self::draw_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawRoundRect", "(IIIIII)V", Self::draw_round_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawArc", "(IIIIII)V", Self::draw_arc, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawPolygon", "([I[I)V", Self::draw_polygon, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawChar", "(CIII)V", Self::draw_char, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawChars", "([CIIIII)V", Self::draw_chars, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("drawString", "(Ljava/lang/String;III)V", Self::draw_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "drawSubstring",
+                    "(Ljava/lang/String;IIIII)V",
+                    Self::draw_substring,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "drawImage",
+                    "(Lorg/kwis/msp/lcdui/Image;III)V",
+                    Self::draw_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("setClip", "(IIII)V", Self::set_clip, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("clipRect", "(IIII)V", Self::clip_rect, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getColor", "()I", Self::get_color, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getBlueComponent", "()I", Self::get_blue_component, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getGrayScale", "()I", Self::get_gray_scale, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getGreenComponent", "()I", Self::get_green_component, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getRedComponent", "()I", Self::get_red_component, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getStrokeStyle", "()I", Self::get_stroke_style, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setStrokeStyle", "(I)V", Self::set_stroke_style, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipX", "()I", Self::get_clip_x, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipY", "()I", Self::get_clip_y, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipWidth", "()I", Self::get_clip_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getClipHeight", "()I", Self::get_clip_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getTranslateX", "()I", Self::get_translate_x, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getTranslateY", "()I", Self::get_translate_y, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("translate", "(II)V", Self::translate, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setPixel", "(II)V", Self::set_pixel, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setRGBPixels", "(IIII[III)V", Self::set_rgb_pixels, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setGrayScale", "(I)V", Self::set_gray_scale, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setXORMode", "(Z)V", Self::set_xor_mode, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getPixel", "(II)I", Self::get_pixel, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getPixels", "(IIII[BII)V", Self::get_pixels, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setPixels", "(IIII[BII)V", Self::set_pixels, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("reset", "()V", Self::reset, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getAlpha", "()I", Self::get_alpha, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isXORMode", "()Z", Self::is_xor_mode, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("encodeImage", "(IIII)[B", Self::encode_image, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getRGBPixels", "(IIII[III)V", Self::get_rgb_pixels, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("midpGraphics", "Ljavax/microedition/lcdui/Graphics;", Default::default()),
-                JavaFieldProto::new("alpha", "I", Default::default()),
-                JavaFieldProto::new("strokeStyle", "I", Default::default()),
-                JavaFieldProto::new("xorMode", "Z", Default::default()),
+                JavaFieldProto::new("midpGraphics", "Ljavax/microedition/lcdui/Graphics;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("alpha", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("strokeStyle", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("xorMode", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -130,7 +141,13 @@ impl Graphics {
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
         let midp_font: ClassInstanceRef<MidpFont> = jvm
-            .invoke_virtual(&midp_graphics, "getFont", "()Ljavax/microedition/lcdui/Font;", ())
+            .invoke_virtual(
+                &midp_graphics,
+                "javax/microedition/lcdui/Graphics",
+                "getFont",
+                "()Ljavax/microedition/lcdui/Font;",
+                (),
+            )
             .await?;
 
         Ok(jvm
@@ -160,8 +177,12 @@ impl Graphics {
         let image = MidpGraphics::image(jvm, &mut midp_graphics).await?;
         let mut canvas = MidpImage::canvas(jvm, &image).await?;
 
-        let translate_x: i32 = jvm.invoke_virtual(&midp_graphics, "getTranslateX", "()I", ()).await?;
-        let translate_y: i32 = jvm.invoke_virtual(&midp_graphics, "getTranslateY", "()I", ()).await?;
+        let translate_x: i32 = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getTranslateX", "()I", ())
+            .await?;
+        let translate_y: i32 = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getTranslateY", "()I", ())
+            .await?;
         let clip = MidpGraphics::clip(jvm, &midp_graphics).await?;
 
         canvas.copy_area(
@@ -180,14 +201,16 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::setColor({this:?}, {color})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "setColor", "(I)V", (color,)).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+            .await
     }
 
     async fn set_color_by_rgb(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, r: i32, g: i32, b: i32) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::setColor({this:?}, {r}, {g}, {b})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "setColor", "(III)V", (r, g, b)).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "setColor", "(III)V", (r, g, b))
+            .await
     }
 
     async fn set_font(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, font: ClassInstanceRef<Font>) -> JvmResult<()> {
@@ -196,15 +219,23 @@ impl Graphics {
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
         let midp_font = Font::midp_font(jvm, &font).await?;
 
-        jvm.invoke_virtual(&midp_graphics, "setFont", "(Ljavax/microedition/lcdui/Font;)V", (midp_font,))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "setFont",
+            "(Ljavax/microedition/lcdui/Font;)V",
+            (midp_font,),
+        )
+        .await
     }
 
     async fn set_alpha(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, alpha: i32) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::setAlpha({this:?}, {alpha})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        let _: () = jvm.invoke_virtual(&midp_graphics, "setXORMode", "(Z)V", (false,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "setXORMode", "(Z)V", (false,))
+            .await?;
         jvm.put_field(&mut this, "alpha", "I", if alpha == 0 { 0 } else { 255 }).await?;
         jvm.put_field(&mut this, "xorMode", "Z", false).await?;
 
@@ -223,7 +254,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::fillRect({this:?}, {x}, {y}, {width}, {height})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "fillRect", "(IIII)V", (x, y, width, height)).await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "fillRect",
+            "(IIII)V",
+            (x, y, width, height),
+        )
+        .await
     }
 
     async fn fill_round_rect(
@@ -240,8 +278,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::fillRoundRect({this:?}, {x}, {y}, {width}, {height}, {arc_width}, {arc_height})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "fillRoundRect", "(IIIIII)V", (x, y, width, height, arc_width, arc_height))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "fillRoundRect",
+            "(IIIIII)V",
+            (x, y, width, height, arc_width, arc_height),
+        )
+        .await
     }
 
     async fn fill_arc(
@@ -258,8 +302,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::fillArc({this:?}, {x}, {y}, {width}, {height}, {start_angle}, {arc_angle})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "fillArc", "(IIIIII)V", (x, y, width, height, start_angle, arc_angle))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "fillArc",
+            "(IIIIII)V",
+            (x, y, width, height, start_angle, arc_angle),
+        )
+        .await
     }
 
     async fn fill_polygon(
@@ -278,7 +328,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::drawLine({this:?}, {x1}, {y1}, {x2}, {y2})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawLine", "(IIII)V", (x1, y1, x2, y2)).await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawLine",
+            "(IIII)V",
+            (x1, y1, x2, y2),
+        )
+        .await
     }
 
     async fn draw_rect(
@@ -293,7 +350,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::drawRect({this:?}, {x}, {y}, {width}, {height})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawRect", "(IIII)V", (x, y, width, height)).await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawRect",
+            "(IIII)V",
+            (x, y, width, height),
+        )
+        .await
     }
 
     async fn draw_round_rect(
@@ -310,8 +374,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::drawRoundRect({this:?}, {x}, {y}, {width}, {height}, {arc_width}, {arc_height})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawRoundRect", "(IIIIII)V", (x, y, width, height, arc_width, arc_height))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawRoundRect",
+            "(IIIIII)V",
+            (x, y, width, height, arc_width, arc_height),
+        )
+        .await
     }
 
     async fn draw_arc(
@@ -328,8 +398,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::drawArc({this:?}, {x}, {y}, {width}, {height}, {start_angle}, {arc_angle})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawArc", "(IIIIII)V", (x, y, width, height, start_angle, arc_angle))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawArc",
+            "(IIIIII)V",
+            (x, y, width, height, start_angle, arc_angle),
+        )
+        .await
     }
 
     async fn draw_polygon(
@@ -356,7 +432,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::drawChar({this:?}, {ch:?}, {x}, {y}, {anchor})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawChar", "(CIII)V", (ch, x, y, anchor)).await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawChar",
+            "(CIII)V",
+            (ch, x, y, anchor),
+        )
+        .await
     }
 
     async fn draw_chars(
@@ -373,8 +456,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::drawChars({this:?}, {chars:?}, {offset}, {length}, {x}, {y}, {anchor})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawChars", "([CIIIII)V", (chars, offset, length, x, y, anchor))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawChars",
+            "([CIIIII)V",
+            (chars, offset, length, x, y, anchor),
+        )
+        .await
     }
 
     async fn draw_string(
@@ -394,8 +483,14 @@ impl Graphics {
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
 
-        jvm.invoke_virtual(&midp_graphics, "drawString", "(Ljava/lang/String;III)V", (string, x, y, anchor))
-            .await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawString",
+            "(Ljava/lang/String;III)V",
+            (string, x, y, anchor),
+        )
+        .await
     }
 
     async fn draw_substring(
@@ -415,6 +510,7 @@ impl Graphics {
 
         jvm.invoke_virtual(
             &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
             "drawSubstring",
             "(Ljava/lang/String;IIIII)V",
             (string, offset, len, x, y, anchor),
@@ -442,6 +538,7 @@ impl Graphics {
 
         jvm.invoke_virtual(
             &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
             "drawImage",
             "(Ljavax/microedition/lcdui/Image;III)V",
             (midp_image, x, y, anchor),
@@ -461,7 +558,14 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::setClip({this:?}, {x}, {y}, {width}, {height})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "setClip", "(IIII)V", (x, y, width, height)).await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "setClip",
+            "(IIII)V",
+            (x, y, width, height),
+        )
+        .await
     }
 
     async fn clip_rect(
@@ -476,41 +580,49 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::clipRect({this:?}, {x}, {y}, {width}, {height})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "clipRect", "(IIII)V", (x, y, width, height)).await
+        jvm.invoke_virtual(
+            &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
+            "clipRect",
+            "(IIII)V",
+            (x, y, width, height),
+        )
+        .await
     }
 
     async fn get_color(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getColor({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getColor", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getColor", "()I", ())
+            .await
     }
 
     async fn get_blue_component(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getBlueComponent({this:?})");
 
-        let color: i32 = jvm.invoke_virtual(&this, "getColor", "()I", ()).await?;
+        let color: i32 = jvm.invoke_virtual(&this, "org/kwis/msp/lcdui/Graphics", "getColor", "()I", ()).await?;
         Ok(color & 0xff)
     }
 
     async fn get_gray_scale(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getGrayScale({this:?})");
 
-        let color: i32 = jvm.invoke_virtual(&this, "getColor", "()I", ()).await?;
+        let color: i32 = jvm.invoke_virtual(&this, "org/kwis/msp/lcdui/Graphics", "getColor", "()I", ()).await?;
         Ok((((color >> 16) & 0xff) + ((color >> 8) & 0xff) + (color & 0xff)) / 3)
     }
 
     async fn get_green_component(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getGreenComponent({this:?})");
 
-        let color: i32 = jvm.invoke_virtual(&this, "getColor", "()I", ()).await?;
+        let color: i32 = jvm.invoke_virtual(&this, "org/kwis/msp/lcdui/Graphics", "getColor", "()I", ()).await?;
         Ok((color >> 8) & 0xff)
     }
 
     async fn get_red_component(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getRedComponent({this:?})");
 
-        let color: i32 = jvm.invoke_virtual(&this, "getColor", "()I", ()).await?;
+        let color: i32 = jvm.invoke_virtual(&this, "org/kwis/msp/lcdui/Graphics", "getColor", "()I", ()).await?;
         Ok((color >> 16) & 0xff)
     }
 
@@ -534,56 +646,64 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getClipX({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getClipX", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+            .await
     }
 
     async fn get_clip_y(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getClipY({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getClipY", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+            .await
     }
 
     async fn get_clip_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getClipWidth({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getClipWidth", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+            .await
     }
 
     async fn get_clip_height(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getClipHeight({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getClipHeight", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+            .await
     }
 
     async fn get_translate_x(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getTranslateX({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getTranslateX", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getTranslateX", "()I", ())
+            .await
     }
 
     async fn get_translate_y(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::getTranslateY({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "getTranslateY", "()I", ()).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getTranslateY", "()I", ())
+            .await
     }
 
     async fn translate(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::translate({this:?}, {x}, {y})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "translate", "(II)V", (x, y)).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "translate", "(II)V", (x, y))
+            .await
     }
 
     async fn set_pixel(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, x: i32, y: i32) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::setPixel({this:?}, {x}, {y})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "drawLine", "(IIII)V", (x, y, x, y)).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "drawLine", "(IIII)V", (x, y, x, y))
+            .await
     }
 
     async fn set_rgb_pixels(
@@ -604,6 +724,7 @@ impl Graphics {
 
         jvm.invoke_virtual(
             &midp_graphics,
+            "javax/microedition/lcdui/Graphics",
             "drawRGB",
             "([IIIIIIIZ)V",
             (rgb_pixels, offset, bpl, x, y, width, height, true),
@@ -615,14 +736,17 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::SetGrayScale({this:?}, {value})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        jvm.invoke_virtual(&midp_graphics, "setGrayScale", "(I)V", (value,)).await
+        jvm.invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "setGrayScale", "(I)V", (value,))
+            .await
     }
 
     async fn set_xor_mode(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, xor_mode: bool) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::setXORMode({this:?}, {xor_mode})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        let _: () = jvm.invoke_virtual(&midp_graphics, "setXORMode", "(Z)V", (xor_mode,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "setXORMode", "(Z)V", (xor_mode,))
+            .await?;
         jvm.put_field(&mut this, "xorMode", "Z", xor_mode).await
     }
 
@@ -632,8 +756,12 @@ impl Graphics {
         let mut midp_graphics: ClassInstanceRef<MidpGraphics> = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
         let image = MidpGraphics::image(jvm, &mut midp_graphics).await?;
         let backend_image = MidpImage::image(jvm, &image).await?;
-        let translate_x: i32 = jvm.invoke_virtual(&midp_graphics, "getTranslateX", "()I", ()).await?;
-        let translate_y: i32 = jvm.invoke_virtual(&midp_graphics, "getTranslateY", "()I", ()).await?;
+        let translate_x: i32 = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getTranslateX", "()I", ())
+            .await?;
+        let translate_y: i32 = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "getTranslateY", "()I", ())
+            .await?;
         let Some(x) = x.checked_add(translate_x) else {
             return Ok(0);
         };
@@ -686,7 +814,9 @@ impl Graphics {
         tracing::debug!("org.kwis.msp.lcdui.Graphics::reset({this:?})");
 
         let midp_graphics = jvm.get_field(&this, "midpGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
-        let _: () = jvm.invoke_virtual(&midp_graphics, "reset", "()V", ()).await?;
+        let _: () = jvm
+            .invoke_virtual(&midp_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
+            .await?;
         jvm.put_field(&mut this, "alpha", "I", 255).await?;
         jvm.put_field(&mut this, "strokeStyle", "I", 0).await?;
         jvm.put_field(&mut this, "xorMode", "Z", false).await?;
@@ -800,15 +930,23 @@ mod test {
                 .invoke_static("org/kwis/msp/lcdui/Image", "createImage", "(II)Lorg/kwis/msp/lcdui/Image;", (4, 1))
                 .await?;
 
-            let graphics: ClassInstanceRef<Graphics> = jvm.invoke_virtual(&image, "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ()).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(&image, "org/kwis/msp/lcdui/Image", "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ())
+                .await?;
 
             let colors = [0xff0000, 0x00ff00, 0x0000ff, 0x000000];
             for (x, color) in colors.into_iter().enumerate() {
-                let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (color,)).await?;
-                let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (x as i32, 0, 1, 1)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setColor", "(I)V", (color,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "fillRect", "(IIII)V", (x as i32, 0, 1, 1))
+                    .await?;
             }
 
-            let _: () = jvm.invoke_virtual(&graphics, "copyArea", "(IIIIII)V", (1, 0, 0, 0, 3, 1)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "copyArea", "(IIIIII)V", (1, 0, 0, 0, 3, 1))
+                .await?;
 
             let midp_image = Image::midp_image(&jvm, &image).await?;
             let backend_image = MidpImage::image(&jvm, &midp_image).await?;
@@ -833,14 +971,32 @@ mod test {
             let image: ClassInstanceRef<Image> = jvm
                 .invoke_static("org/kwis/msp/lcdui/Image", "createImage", "(II)Lorg/kwis/msp/lcdui/Image;", (2, 1))
                 .await?;
-            let graphics: ClassInstanceRef<Graphics> = jvm.invoke_virtual(&image, "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ()).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(&image, "org/kwis/msp/lcdui/Image", "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ())
+                .await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x123456,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setColor", "(I)V", (0x123456,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await?;
 
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getPixel", "(II)I", (0, 0)).await?, 0x123456);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getPixel", "(II)I", (-1, 0)).await?, 0);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getPixel", "(II)I", (2, 0)).await?, 0);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getPixel", "(II)I", (0, 0))
+                    .await?,
+                0x123456
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getPixel", "(II)I", (-1, 0))
+                    .await?,
+                0
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getPixel", "(II)I", (2, 0))
+                    .await?,
+                0
+            );
 
             Ok(())
         })
@@ -852,17 +1008,37 @@ mod test {
             let image: ClassInstanceRef<Image> = jvm
                 .invoke_static("org/kwis/msp/lcdui/Image", "createImage", "(II)Lorg/kwis/msp/lcdui/Image;", (2, 1))
                 .await?;
-            let graphics: ClassInstanceRef<Graphics> = jvm.invoke_virtual(&image, "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ()).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(&image, "org/kwis/msp/lcdui/Image", "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ())
+                .await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x123456,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x654321,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (1, 0, 1, 1)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setColor", "(I)V", (0x123456,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setColor", "(I)V", (0x654321,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "fillRect", "(IIII)V", (1, 0, 1, 1))
+                .await?;
 
-            let _: () = jvm.invoke_virtual(&graphics, "translate", "(II)V", (1, 0)).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "translate", "(II)V", (1, 0))
+                .await?;
 
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getPixel", "(II)I", (0, 0)).await?, 0x654321);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getPixel", "(II)I", (1, 0)).await?, 0);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getPixel", "(II)I", (0, 0))
+                    .await?,
+                0x654321
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getPixel", "(II)I", (1, 0))
+                    .await?,
+                0
+            );
 
             Ok(())
         })
@@ -874,13 +1050,21 @@ mod test {
             let image: ClassInstanceRef<Image> = jvm
                 .invoke_static("org/kwis/msp/lcdui/Image", "createImage", "(II)Lorg/kwis/msp/lcdui/Image;", (1, 1))
                 .await?;
-            let graphics: ClassInstanceRef<Graphics> = jvm.invoke_virtual(&image, "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ()).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(&image, "org/kwis/msp/lcdui/Image", "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ())
+                .await?;
             let string: ClassInstanceRef<String> = None.into();
 
             assert!(
-                jvm.invoke_virtual::<_, ()>(&graphics, "drawString", "(Ljava/lang/String;III)V", (string, 0, 0, 0))
-                    .await
-                    .is_err()
+                jvm.invoke_virtual::<_, ()>(
+                    &graphics,
+                    "org/kwis/msp/lcdui/Graphics",
+                    "drawString",
+                    "(Ljava/lang/String;III)V",
+                    (string, 0, 0, 0)
+                )
+                .await
+                .is_err()
             );
 
             Ok(())
@@ -893,37 +1077,119 @@ mod test {
             let image: ClassInstanceRef<Image> = jvm
                 .invoke_static("org/kwis/msp/lcdui/Image", "createImage", "(II)Lorg/kwis/msp/lcdui/Image;", (2, 2))
                 .await?;
-            let graphics: ClassInstanceRef<Graphics> = jvm.invoke_virtual(&image, "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ()).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(&image, "org/kwis/msp/lcdui/Image", "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ())
+                .await?;
 
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getAlpha", "()I", ()).await?, 255);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getStrokeStyle", "()I", ()).await?, 0);
-            assert!(!jvm.invoke_virtual::<_, bool>(&graphics, "isXORMode", "()Z", ()).await?);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getAlpha", "()I", ())
+                    .await?,
+                255
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getStrokeStyle", "()I", ())
+                    .await?,
+                0
+            );
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&graphics, "org/kwis/msp/lcdui/Graphics", "isXORMode", "()Z", ())
+                    .await?
+            );
 
-            let _: () = jvm.invoke_virtual(&graphics, "setStrokeStyle", "(I)V", (1,)).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getStrokeStyle", "()I", ()).await?, 1);
-            assert!(jvm.invoke_virtual::<_, ()>(&graphics, "setStrokeStyle", "(I)V", (2,)).await.is_err());
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getStrokeStyle", "()I", ()).await?, 1);
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setStrokeStyle", "(I)V", (1,))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getStrokeStyle", "()I", ())
+                    .await?,
+                1
+            );
+            assert!(
+                jvm.invoke_virtual::<_, ()>(&graphics, "org/kwis/msp/lcdui/Graphics", "setStrokeStyle", "(I)V", (2,))
+                    .await
+                    .is_err()
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getStrokeStyle", "()I", ())
+                    .await?,
+                1
+            );
 
-            let _: () = jvm.invoke_virtual(&graphics, "setXORMode", "(Z)V", (true,)).await?;
-            assert!(jvm.invoke_virtual::<_, bool>(&graphics, "isXORMode", "()Z", ()).await?);
-            let _: () = jvm.invoke_virtual(&graphics, "setAlpha", "(I)V", (0,)).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getAlpha", "()I", ()).await?, 0);
-            assert!(!jvm.invoke_virtual::<_, bool>(&graphics, "isXORMode", "()Z", ()).await?);
-            let _: () = jvm.invoke_virtual(&graphics, "setAlpha", "(I)V", (42,)).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getAlpha", "()I", ()).await?, 255);
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setXORMode", "(Z)V", (true,))
+                .await?;
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&graphics, "org/kwis/msp/lcdui/Graphics", "isXORMode", "()Z", ())
+                    .await?
+            );
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setAlpha", "(I)V", (0,))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getAlpha", "()I", ())
+                    .await?,
+                0
+            );
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&graphics, "org/kwis/msp/lcdui/Graphics", "isXORMode", "()Z", ())
+                    .await?
+            );
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setAlpha", "(I)V", (42,))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getAlpha", "()I", ())
+                    .await?,
+                255
+            );
 
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0x123456,)).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getRedComponent", "()I", ()).await?, 0x12);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getGreenComponent", "()I", ()).await?, 0x34);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getBlueComponent", "()I", ()).await?, 0x56);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getGrayScale", "()I", ()).await?, 0x34);
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setColor", "(I)V", (0x123456,))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getRedComponent", "()I", ())
+                    .await?,
+                0x12
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getGreenComponent", "()I", ())
+                    .await?,
+                0x34
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getBlueComponent", "()I", ())
+                    .await?,
+                0x56
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getGrayScale", "()I", ())
+                    .await?,
+                0x34
+            );
 
-            let _: () = jvm.invoke_virtual(&graphics, "setStrokeStyle", "(I)V", (1,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "reset", "()V", ()).await?;
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getColor", "()I", ()).await?, 0);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getAlpha", "()I", ()).await?, 255);
-            assert_eq!(jvm.invoke_virtual::<_, i32>(&graphics, "getStrokeStyle", "()I", ()).await?, 0);
-            assert!(!jvm.invoke_virtual::<_, bool>(&graphics, "isXORMode", "()Z", ()).await?);
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setStrokeStyle", "(I)V", (1,))
+                .await?;
+            let _: () = jvm.invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "reset", "()V", ()).await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getColor", "()I", ())
+                    .await?,
+                0
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getAlpha", "()I", ())
+                    .await?,
+                255
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "org/kwis/msp/lcdui/Graphics", "getStrokeStyle", "()I", ())
+                    .await?,
+                0
+            );
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&graphics, "org/kwis/msp/lcdui/Graphics", "isXORMode", "()Z", ())
+                    .await?
+            );
 
             Ok(())
         })

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/image.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/image.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -20,65 +20,75 @@ impl Image {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init_empty, MethodAccessFlags::PROTECTED),
-                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Image;)V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init_empty, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljavax/microedition/lcdui/Image;)V", Self::init, MethodAccessFlags::PRIVATE),
                 JavaMethodProto::new(
                     "loadImage",
                     "(Ljava/lang/String;Lorg/kwis/msp/lcdui/ImageObserver;)Lorg/kwis/msp/lcdui/Image;",
                     Self::load_image,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "(II)Lorg/kwis/msp/lcdui/Image;",
                     Self::create_image,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "(Ljava/lang/String;)Lorg/kwis/msp/lcdui/Image;",
                     Self::create_image_from_name,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "([BII)Lorg/kwis/msp/lcdui/Image;",
                     Self::create_image_from_data,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "createImage",
                     "(Lorg/kwis/msp/lcdui/Image;)Lorg/kwis/msp/lcdui/Image;",
                     Self::create_image_from_image,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", Self::get_graphics, Default::default()),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
-                JavaMethodProto::new("isMutable", "()Z", Self::is_mutable, Default::default()),
-                JavaMethodProto::new("isAnimated", "()Z", Self::is_animated, Default::default()),
-                JavaMethodProto::new("play", "(Lorg/kwis/msp/lcdui/ImageObserver;)V", Self::play, Default::default()),
-                JavaMethodProto::new("stop", "()V", Self::stop, Default::default()),
+                JavaMethodProto::new(
+                    "getGraphics",
+                    "()Lorg/kwis/msp/lcdui/Graphics;",
+                    Self::get_graphics,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isMutable", "()Z", Self::is_mutable, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isAnimated", "()Z", Self::is_animated, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("play", "(Lorg/kwis/msp/lcdui/ImageObserver;)V", Self::play, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("stop", "()V", Self::stop, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "stopImage",
                     "(Lorg/kwis/msp/lcdui/ImageObserver;)V",
                     Self::stop_image,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
-                JavaMethodProto::new("drawImage", "(Lorg/kwis/msp/lcdui/Image;IIIIIIII)V", Self::draw_image, Default::default()),
+                JavaMethodProto::new(
+                    "drawImage",
+                    "(Lorg/kwis/msp/lcdui/Image;IIIIIIII)V",
+                    Self::draw_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new(
                     "createSubImage",
                     "(IIIIZ)Lorg/kwis/msp/lcdui/Image;",
                     Self::create_sub_image,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("setTransparentColor", "(I)V", Self::set_transparent_color, Default::default()),
+                JavaMethodProto::new("setTransparentColor", "(I)V", Self::set_transparent_color, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("midpImage", "Ljavax/microedition/lcdui/Image;", Default::default()),
-                JavaFieldProto::new("mutable", "Z", Default::default()),
+                JavaFieldProto::new("midpImage", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("mutable", "Z", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -202,7 +212,13 @@ impl Image {
         let midp_image: ClassInstanceRef<MidpImage> = jvm.get_field(&this, "midpImage", "Ljavax/microedition/lcdui/Image;").await?;
 
         let midp_graphics: ClassInstanceRef<MidpGraphics> = jvm
-            .invoke_virtual(&midp_image, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+            .invoke_virtual(
+                &midp_image,
+                "javax/microedition/lcdui/Image",
+                "getGraphics",
+                "()Ljavax/microedition/lcdui/Graphics;",
+                (),
+            )
             .await?;
 
         let instance = jvm
@@ -217,7 +233,8 @@ impl Image {
 
         let midp_image: ClassInstanceRef<MidpImage> = jvm.get_field(&this, "midpImage", "Ljavax/microedition/lcdui/Image;").await?;
 
-        jvm.invoke_virtual(&midp_image, "getWidth", "()I", ()).await
+        jvm.invoke_virtual(&midp_image, "javax/microedition/lcdui/Image", "getWidth", "()I", ())
+            .await
     }
 
     async fn get_height(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Image>) -> JvmResult<i32> {
@@ -225,7 +242,8 @@ impl Image {
 
         let midp_image: ClassInstanceRef<MidpImage> = jvm.get_field(&this, "midpImage", "Ljavax/microedition/lcdui/Image;").await?;
 
-        jvm.invoke_virtual(&midp_image, "getHeight", "()I", ()).await
+        jvm.invoke_virtual(&midp_image, "javax/microedition/lcdui/Image", "getHeight", "()I", ())
+            .await
     }
 
     async fn is_mutable(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Image>) -> JvmResult<bool> {
@@ -284,10 +302,17 @@ impl Image {
         let target: ClassInstanceRef<MidpImage> = jvm.get_field(&this, "midpImage", "Ljavax/microedition/lcdui/Image;").await?;
         let source: ClassInstanceRef<MidpImage> = jvm.get_field(&image, "midpImage", "Ljavax/microedition/lcdui/Image;").await?;
         let graphics: ClassInstanceRef<MidpGraphics> = jvm
-            .invoke_virtual(&target, "getGraphics", "()Ljavax/microedition/lcdui/Graphics;", ())
+            .invoke_virtual(
+                &target,
+                "javax/microedition/lcdui/Image",
+                "getGraphics",
+                "()Ljavax/microedition/lcdui/Graphics;",
+                (),
+            )
             .await?;
         jvm.invoke_virtual(
             &graphics,
+            "javax/microedition/lcdui/Graphics",
             "drawRegion",
             "(Ljavax/microedition/lcdui/Image;IIIIIIII)V",
             [
@@ -355,7 +380,10 @@ mod test {
             let target: ClassInstanceRef<Image> = jvm
                 .invoke_static("org/kwis/msp/lcdui/Image", "createImage", "(II)Lorg/kwis/msp/lcdui/Image;", (2, 1))
                 .await?;
-            assert!(jvm.invoke_virtual::<_, bool>(&source, "isMutable", "()Z", ()).await?);
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&source, "org/kwis/msp/lcdui/Image", "isMutable", "()Z", ())
+                    .await?
+            );
 
             let clone: ClassInstanceRef<Image> = jvm
                 .invoke_static(
@@ -365,15 +393,28 @@ mod test {
                     (source.clone(),),
                 )
                 .await?;
-            assert!(!jvm.invoke_virtual::<_, bool>(&clone, "isMutable", "()Z", ()).await?);
-            assert!(!jvm.invoke_virtual::<_, bool>(&source, "isAnimated", "()Z", ()).await?);
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&clone, "org/kwis/msp/lcdui/Image", "isMutable", "()Z", ())
+                    .await?
+            );
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&source, "org/kwis/msp/lcdui/Image", "isAnimated", "()Z", ())
+                    .await?
+            );
 
-            let graphics: ClassInstanceRef<Graphics> = jvm.invoke_virtual(&source, "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ()).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "setColor", "(I)V", (0xff0000,)).await?;
-            let _: () = jvm.invoke_virtual(&graphics, "fillRect", "(IIII)V", (0, 0, 1, 1)).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(&source, "org/kwis/msp/lcdui/Image", "getGraphics", "()Lorg/kwis/msp/lcdui/Graphics;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "setColor", "(I)V", (0xff0000,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "org/kwis/msp/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await?;
             let _: () = jvm
                 .invoke_virtual(
                     &target,
+                    "org/kwis/msp/lcdui/Image",
                     "drawImage",
                     "(Lorg/kwis/msp/lcdui/Image;IIIIIIII)V",
                     [

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/image_observer.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/image_observer.rs
@@ -17,10 +17,10 @@ impl ImageObserver {
             methods: vec![JavaMethodProto::new_abstract(
                 "notify",
                 "(Lorg/kwis/msp/lcdui/Image;I)V",
-                MethodAccessFlags::ABSTRACT,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
             )],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/input_method_handler.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/input_method_handler.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -15,11 +16,11 @@ impl InputMethodHandler {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(I)V", Self::init, Default::default()),
-                JavaMethodProto::new("setCurrentMode", "(I)Z", Self::set_current_mode, Default::default()),
+                JavaMethodProto::new("<init>", "(I)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setCurrentMode", "(I)Z", Self::set_current_mode, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/jlet.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/jlet.rs
@@ -20,38 +20,51 @@ impl Jlet {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
                 JavaMethodProto::new(
                     "getActiveJlet",
                     "()Lorg/kwis/msp/lcdui/Jlet;",
                     Self::get_active_jlet,
-                    MethodAccessFlags::STATIC,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "getEventQueue",
                     "()Lorg/kwis/msp/lcdui/EventQueue;",
                     Self::get_event_queue,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
                 ),
                 JavaMethodProto::new(
                     "getAppProperty",
                     "(Ljava/lang/String;)Ljava/lang/String;",
                     Self::get_app_property,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
                 ),
-                JavaMethodProto::new("notifyDestroyed", "()V", Self::notify_destroyed, Default::default()),
-                JavaMethodProto::new_abstract("startApp", "([Ljava/lang/String;)V", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("pauseApp", "()V", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("resumeApp", "()V", MethodAccessFlags::ABSTRACT),
-                JavaMethodProto::new_abstract("destroyApp", "(Z)V", MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new(
+                    "notifyDestroyed",
+                    "()V",
+                    Self::notify_destroyed,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::FINAL,
+                ),
+                JavaMethodProto::new_abstract(
+                    "startApp",
+                    "([Ljava/lang/String;)V",
+                    MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract("pauseApp", "()V", MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("resumeApp", "()V", MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("destroyApp", "(Z)V", MethodAccessFlags::PROTECTED | MethodAccessFlags::ABSTRACT),
             ],
             fields: vec![
-                JavaFieldProto::new("wipiMidlet", "Lnet/wie/WIPIMIDlet;", Default::default()),
-                JavaFieldProto::new("dis", "Lorg/kwis/msp/lcdui/Display;", Default::default()),
-                JavaFieldProto::new("eq", "Lorg/kwis/msp/lcdui/EventQueue;", Default::default()),
-                JavaFieldProto::new("currentJlet", "Lorg/kwis/msp/lcdui/Jlet;", FieldAccessFlags::STATIC),
+                JavaFieldProto::new("wipiMidlet", "Lnet/wie/WIPIMIDlet;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("dis", "Lorg/kwis/msp/lcdui/Display;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("eq", "Lorg/kwis/msp/lcdui/EventQueue;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new(
+                    "currentJlet",
+                    "Lorg/kwis/msp/lcdui/Jlet;",
+                    FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC,
+                ),
             ],
-            access_flags: ClassAccessFlags::ABSTRACT,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 
@@ -65,7 +78,13 @@ impl Jlet {
             .await?;
         jvm.put_field(&mut this, "wipiMidlet", "Lnet/wie/WIPIMIDlet;", midlet.clone()).await?;
         let _: () = jvm
-            .invoke_virtual(&midlet, "setCurrentJlet", "(Lorg/kwis/msp/lcdui/Jlet;)V", (this.clone(),))
+            .invoke_virtual(
+                &midlet,
+                "net/wie/WIPIMIDlet",
+                "setCurrentJlet",
+                "(Lorg/kwis/msp/lcdui/Jlet;)V",
+                (this.clone(),),
+            )
             .await?;
 
         let display = jvm
@@ -118,7 +137,13 @@ impl Jlet {
 
         let midlet = jvm.get_field(&this, "wipiMidlet", "Lnet/wie/WIPIMIDlet;").await?;
         let value = jvm
-            .invoke_virtual(&midlet, "getAppProperty", "(Ljava/lang/String;)Ljava/lang/String;", (key,))
+            .invoke_virtual(
+                &midlet,
+                "net/wie/WIPIMIDlet",
+                "getAppProperty",
+                "(Ljava/lang/String;)Ljava/lang/String;",
+                (key,),
+            )
             .await?;
 
         Ok(value)
@@ -128,9 +153,11 @@ impl Jlet {
         tracing::debug!("org.kwis.msp.lcdui.Jlet::notifyDestroyed({this:?})");
 
         let midlet: ClassInstanceRef<MIDlet> = jvm.get_field(&this, "wipiMidlet", "Lnet/wie/WIPIMIDlet;").await?;
-        let _: () = jvm.invoke_virtual(&midlet, "notifyDestroyed", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&midlet, "net/wie/WIPIMIDlet", "notifyDestroyed", "()V", ()).await?;
 
-        let _: () = jvm.invoke_virtual(&this, "destroyApp", "(Z)V", (false,)).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "org/kwis/msp/lcdui/Jlet", "destroyApp", "(Z)V", (false,))
+            .await?;
 
         Ok(())
     }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/jlet_event_listener.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/jlet_event_listener.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::ClassAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use wie_jvm_support::WieJavaClassProto;
 
 // interface org.kwis.msp.lcdui.JletEventListener
@@ -13,9 +13,13 @@ impl JletEventListener {
             name: "org/kwis/msp/lcdui/JletEventListener",
             parent_class: None,
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new_abstract("notifyEvent", "(III)V", Default::default())],
+            methods: vec![JavaMethodProto::new_abstract(
+                "notifyEvent",
+                "(III)V",
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+            )],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/jlet_wrapper.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/jlet_wrapper.rs
@@ -15,7 +15,7 @@ impl JletWrapper {
             interfaces: vec![],
             methods: vec![],
             fields: vec![],
-            access_flags: ClassAccessFlags::ABSTRACT,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lcdui/main.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lcdui/main.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -20,10 +20,10 @@ impl Main {
                 "main",
                 "([Ljava/lang/String;)V",
                 Self::main,
-                MethodAccessFlags::STATIC,
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
             )],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/annunciator_component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/annunciator_component.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -15,11 +16,11 @@ impl AnnunciatorComponent {
             parent_class: Some("org/kwis/msp/lwc/ShellComponent"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Z)V", Self::init, Default::default()),
-                JavaMethodProto::new("show", "()V", Self::show, Default::default()),
+                JavaMethodProto::new("<init>", "(Z)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("show", "()V", Self::show, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/component.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -17,15 +17,15 @@ impl Component {
             interfaces: vec![],
             methods: vec![
                 JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
-                JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, Default::default()),
-                JavaMethodProto::new("focusNotify", "(Z)V", Self::focus_notify, Default::default()),
-                JavaMethodProto::new("showNotify", "(Z)V", Self::show_notify, Default::default()),
-                JavaMethodProto::new("configure", "(IIIII)V", Self::configure, Default::default()),
-                JavaMethodProto::new("setFocus", "()V", Self::set_focus, Default::default()),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, Default::default()),
+                JavaMethodProto::new("keyNotify", "(II)Z", Self::key_notify, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("focusNotify", "(Z)V", Self::focus_notify, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("showNotify", "(Z)V", Self::show_notify, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("configure", "(IIIII)V", Self::configure, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setFocus", "()V", Self::set_focus, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/container_component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/container_component.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -19,17 +19,22 @@ impl ContainerComponent {
             interfaces: vec![],
             methods: vec![
                 JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
-                JavaMethodProto::new("addComponent", "(Lorg/kwis/msp/lwc/Component;)I", Self::add_component, Default::default()),
-                JavaMethodProto::new("removeComponent", "(I)V", Self::remove_component_index, Default::default()),
+                JavaMethodProto::new(
+                    "addComponent",
+                    "(Lorg/kwis/msp/lwc/Component;)I",
+                    Self::add_component,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("removeComponent", "(I)V", Self::remove_component_index, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "removeComponent",
                     "(Lorg/kwis/msp/lwc/Component;)V",
                     Self::remove_component,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/event_listener.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/event_listener.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::ClassAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use wie_jvm_support::WieJavaClassProto;
 
 // interface org.kwis.msp.lwc.EventListener
@@ -16,10 +16,10 @@ impl EventListener {
             methods: vec![JavaMethodProto::new_abstract(
                 "eventNotify",
                 "(IIIILjava/lang/Object;)Z",
-                Default::default(),
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
             )],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/shell_component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/shell_component.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
@@ -16,19 +17,19 @@ impl ShellComponent {
             parent_class: Some("org/kwis/msp/lwc/ContainerComponent"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(IIII)V", Self::init_with_size, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(IIII)V", Self::init_with_size, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "setWorkComponent",
                     "(Lorg/kwis/msp/lwc/Component;)V",
                     Self::set_work_component,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("show", "()V", Self::show, Default::default()),
-                JavaMethodProto::new("hide", "()V", Self::hide, Default::default()),
+                JavaMethodProto::new("show", "()V", Self::show, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("hide", "()V", Self::hide, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/text_box_component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/text_box_component.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -15,9 +16,14 @@ impl TextBoxComponent {
             name: "org/kwis/msp/lwc/TextBoxComponent",
             parent_class: Some("org/kwis/msp/lwc/TextComponent"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, Default::default())],
+            methods: vec![JavaMethodProto::new(
+                "<init>",
+                "(Ljava/lang/String;I)V",
+                Self::init,
+                MethodAccessFlags::PUBLIC,
+            )],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/text_component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/text_component.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
@@ -16,16 +17,16 @@ impl TextComponent {
             parent_class: Some("org/kwis/msp/lwc/Component"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, Default::default()),
-                JavaMethodProto::new("setMaxLength", "(I)V", Self::set_max_length, Default::default()),
-                JavaMethodProto::new("getString", "()Ljava/lang/String;", Self::get_string, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setMaxLength", "(I)V", Self::set_max_length, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getString", "()Ljava/lang/String;", Self::get_string, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("m_cPos", "I", Default::default()),
-                JavaFieldProto::new("imHandler", "Lorg/kwis/msp/lcdui/InputMethodHandler;", Default::default()),
+                JavaFieldProto::new("m_cPos", "I", FieldAccessFlags::PROTECTED),
+                JavaFieldProto::new("imHandler", "Lorg/kwis/msp/lcdui/InputMethodHandler;", FieldAccessFlags::PROTECTED),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/lwc/text_field_component.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/lwc/text_field_component.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
@@ -16,12 +17,12 @@ impl TextFieldComponent {
             parent_class: Some("org/kwis/msp/lwc/TextComponent"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, Default::default()),
-                JavaMethodProto::new("insert", "([CIII)V", Self::insert, Default::default()),
-                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("insert", "([CIII)V", Self::insert, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/base_clip.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/base_clip.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -17,14 +18,18 @@ impl BaseClip {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, Default::default()),
-                JavaMethodProto::new("putData", "([BII)I", Self::put_data, Default::default()),
-                JavaMethodProto::new("setBuffer", "([BI)Z", Self::set_buffer, Default::default()),
-                JavaMethodProto::new("clearData", "()V", Self::clear_data, Default::default()),
-                JavaMethodProto::new("availableDataSize", "()I", Self::available_data_size, Default::default()),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("putData", "([BII)I", Self::put_data, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setBuffer", "([BI)Z", Self::set_buffer, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("clearData", "()V", Self::clear_data, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("availableDataSize", "()I", Self::available_data_size, MethodAccessFlags::PUBLIC),
             ],
-            fields: vec![JavaFieldProto::new("player", "Ljavax/microedition/media/Player;", Default::default())],
-            access_flags: Default::default(),
+            fields: vec![JavaFieldProto::new(
+                "player",
+                "Ljavax/microedition/media/Player;",
+                FieldAccessFlags::PRIVATE,
+            )],
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -77,7 +82,7 @@ impl BaseClip {
             return Ok(());
         }
 
-        let _: () = jvm.invoke_virtual(&player, "close", "()V", ()).await?;
+        let _: () = jvm.invoke_virtual(&player, "javax/microedition/media/Player", "close", "()V", ()).await?;
 
         jvm.put_field(&mut this, "player", "Ljavax/microedition/media/Player;", None).await?;
 
@@ -93,7 +98,9 @@ impl BaseClip {
     ) -> JvmResult<bool> {
         tracing::debug!("org.kwis.msp.media.BaseClip::setBuffer({this:?}, {buffer:?}, {size})");
 
-        let written: i32 = jvm.invoke_virtual(&this, "putData", "([BII)I", (buffer, 0, size)).await?;
+        let written: i32 = jvm
+            .invoke_virtual(&this, "org/kwis/msp/media/BaseClip", "putData", "([BII)I", (buffer, 0, size))
+            .await?;
 
         Ok(written == size)
     }

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/clip.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/clip.rs
@@ -3,6 +3,7 @@ use alloc::vec;
 use bytemuck::cast_vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
+use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaIoInputStream};
 
@@ -21,37 +22,37 @@ impl Clip {
             parent_class: Some("org/kwis/msp/media/BaseClip"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;[B)V", Self::init_with_data, Default::default()),
-                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init_with_data_size, Default::default()),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;[B)V", Self::init_with_data, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init_with_data_size, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "<init>",
                     "(Ljava/lang/String;Ljava/lang/String;)V",
                     Self::init_with_resource,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("setVolume", "(I)Z", Self::set_volume, Default::default()),
+                JavaMethodProto::new("setVolume", "(I)Z", Self::set_volume, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "setListener",
                     "(Lorg/kwis/msp/media/PlayListener;)V",
                     Self::set_listener,
-                    Default::default(),
+                    MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("setBuffer", "([BI)V", Self::set_buffer, Default::default()),
-                JavaMethodProto::new("getType", "()Ljava/lang/String;", Self::get_type, Default::default()),
-                JavaMethodProto::new("setPosition", "(I)Z", Self::set_position, Default::default()),
-                JavaMethodProto::new("getPosition", "()I", Self::get_position, Default::default()),
-                JavaMethodProto::new("setStopTime", "(I)Z", Self::set_stop_time, Default::default()),
-                JavaMethodProto::new("getStopTime", "()I", Self::get_stop_time, Default::default()),
-                JavaMethodProto::new("getVolume", "()I", Self::get_volume, Default::default()),
+                JavaMethodProto::new("setBuffer", "([BI)V", Self::set_buffer, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getType", "()Ljava/lang/String;", Self::get_type, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setPosition", "(I)Z", Self::set_position, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getPosition", "()I", Self::get_position, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setStopTime", "(I)Z", Self::set_stop_time, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getStopTime", "()I", Self::get_stop_time, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getVolume", "()I", Self::get_volume, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
-                JavaFieldProto::new("position", "I", Default::default()),
-                JavaFieldProto::new("stopTime", "I", Default::default()),
-                JavaFieldProto::new("type", "Ljava/lang/String;", Default::default()),
-                JavaFieldProto::new("volume", "I", Default::default()),
+                JavaFieldProto::new("position", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("stopTime", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("type", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("volume", "I", FieldAccessFlags::PRIVATE),
             ],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -73,10 +74,13 @@ impl Clip {
     ) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.media.Clip::<init>({this:?}, {type:?}, {resource_name:?})");
 
-        let class = jvm.invoke_virtual(&r#type, "getClass", "()Ljava/lang/Class;", ()).await?;
+        let class = jvm
+            .invoke_virtual(&r#type, "java/lang/String", "getClass", "()Ljava/lang/Class;", ())
+            .await?;
         let resource_stream = jvm
             .invoke_virtual(
                 &class,
+                "java/lang/Class",
                 "getResourceAsStream",
                 "(Ljava/lang/String;)Ljava/io/InputStream;",
                 (resource_name.clone(),),
@@ -114,7 +118,9 @@ impl Clip {
             .await?;
         let length = jvm.array_length(&data).await?;
 
-        let _: () = jvm.invoke_virtual(&this, "setBuffer", "([BI)V", (data, length as i32)).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "org/kwis/msp/media/Clip", "setBuffer", "([BI)V", (data, length as i32))
+            .await?;
 
         Ok(())
     }
@@ -164,7 +170,9 @@ impl Clip {
     ) -> JvmResult<()> {
         tracing::debug!("org.kwis.msp.media.Clip::setBuffer({this:?}, {buffer:?}, {size})");
 
-        let _: i32 = jvm.invoke_virtual(&this, "putData", "([BII)I", (buffer, 0, size)).await?;
+        let _: i32 = jvm
+            .invoke_virtual(&this, "org/kwis/msp/media/Clip", "putData", "([BII)I", (buffer, 0, size))
+            .await?;
 
         Ok(())
     }
@@ -231,12 +239,16 @@ mod test {
             let r#type = JavaLangString::from_rust_string(&jvm, "audio/test").await?;
             let clip: ClassInstanceRef<Clip> = jvm.new_class("org/kwis/msp/media/Clip", "(Ljava/lang/String;)V", (r#type,)).await?.into();
 
-            let initial_position: i32 = jvm.invoke_virtual(&clip, "getPosition", "()I", ()).await?;
-            let initial_stop_time: i32 = jvm.invoke_virtual(&clip, "getStopTime", "()I", ()).await?;
-            let position_set: bool = jvm.invoke_virtual(&clip, "setPosition", "(I)Z", (-17,)).await?;
-            let stop_time_set: bool = jvm.invoke_virtual(&clip, "setStopTime", "(I)Z", (i32::MAX,)).await?;
-            let position: i32 = jvm.invoke_virtual(&clip, "getPosition", "()I", ()).await?;
-            let stop_time: i32 = jvm.invoke_virtual(&clip, "getStopTime", "()I", ()).await?;
+            let initial_position: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getPosition", "()I", ()).await?;
+            let initial_stop_time: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getStopTime", "()I", ()).await?;
+            let position_set: bool = jvm
+                .invoke_virtual(&clip, "org/kwis/msp/media/Clip", "setPosition", "(I)Z", (-17,))
+                .await?;
+            let stop_time_set: bool = jvm
+                .invoke_virtual(&clip, "org/kwis/msp/media/Clip", "setStopTime", "(I)Z", (i32::MAX,))
+                .await?;
+            let position: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getPosition", "()I", ()).await?;
+            let stop_time: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getStopTime", "()I", ()).await?;
 
             assert_eq!(initial_position, 0);
             assert_eq!(initial_stop_time, 0);
@@ -266,8 +278,12 @@ mod test {
                 .await?
                 .into();
 
-            let returned_string_type: ClassInstanceRef<String> = jvm.invoke_virtual(&string_clip, "getType", "()Ljava/lang/String;", ()).await?;
-            let returned_data_type: ClassInstanceRef<String> = jvm.invoke_virtual(&data_clip, "getType", "()Ljava/lang/String;", ()).await?;
+            let returned_string_type: ClassInstanceRef<String> = jvm
+                .invoke_virtual(&string_clip, "org/kwis/msp/media/Clip", "getType", "()Ljava/lang/String;", ())
+                .await?;
+            let returned_data_type: ClassInstanceRef<String> = jvm
+                .invoke_virtual(&data_clip, "org/kwis/msp/media/Clip", "getType", "()Ljava/lang/String;", ())
+                .await?;
 
             assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_string_type).await?, "audio/string");
             assert_eq!(JavaLangString::to_rust_string(&jvm, &returned_data_type).await?, "audio/data");
@@ -287,17 +303,21 @@ mod test {
                 .await?
                 .into();
 
-            let second_initial_volume: i32 = jvm.invoke_virtual(&second_clip, "getVolume", "()I", ()).await?;
+            let second_initial_volume: i32 = jvm
+                .invoke_virtual(&second_clip, "org/kwis/msp/media/Clip", "getVolume", "()I", ())
+                .await?;
 
-            let minimum_set: bool = jvm.invoke_virtual(&clip, "setVolume", "(I)Z", (0,)).await?;
-            let minimum_volume: i32 = jvm.invoke_virtual(&clip, "getVolume", "()I", ()).await?;
-            let maximum_set: bool = jvm.invoke_virtual(&clip, "setVolume", "(I)Z", (100,)).await?;
-            let maximum_volume: i32 = jvm.invoke_virtual(&clip, "getVolume", "()I", ()).await?;
-            let below_minimum_set: bool = jvm.invoke_virtual(&clip, "setVolume", "(I)Z", (-1,)).await?;
-            let volume_after_below_minimum: i32 = jvm.invoke_virtual(&clip, "getVolume", "()I", ()).await?;
-            let above_maximum_set: bool = jvm.invoke_virtual(&clip, "setVolume", "(I)Z", (101,)).await?;
-            let volume_after_above_maximum: i32 = jvm.invoke_virtual(&clip, "getVolume", "()I", ()).await?;
-            let second_final_volume: i32 = jvm.invoke_virtual(&second_clip, "getVolume", "()I", ()).await?;
+            let minimum_set: bool = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "setVolume", "(I)Z", (0,)).await?;
+            let minimum_volume: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getVolume", "()I", ()).await?;
+            let maximum_set: bool = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "setVolume", "(I)Z", (100,)).await?;
+            let maximum_volume: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getVolume", "()I", ()).await?;
+            let below_minimum_set: bool = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "setVolume", "(I)Z", (-1,)).await?;
+            let volume_after_below_minimum: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getVolume", "()I", ()).await?;
+            let above_maximum_set: bool = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "setVolume", "(I)Z", (101,)).await?;
+            let volume_after_above_maximum: i32 = jvm.invoke_virtual(&clip, "org/kwis/msp/media/Clip", "getVolume", "()I", ()).await?;
+            let second_final_volume: i32 = jvm
+                .invoke_virtual(&second_clip, "org/kwis/msp/media/Clip", "getVolume", "()I", ())
+                .await?;
 
             assert_eq!(second_initial_volume, 0);
             assert!(minimum_set);

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/play_listener.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/play_listener.rs
@@ -14,7 +14,7 @@ impl PlayListener {
             interfaces: vec![],
             methods: vec![],
             fields: vec![],
-            access_flags: ClassAccessFlags::INTERFACE,
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }
 }

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/player.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/player.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -18,16 +18,51 @@ impl Player {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("pause", "(Lorg/kwis/msp/media/BaseClip;)Z", Self::pause, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("stop", "(Lorg/kwis/msp/media/BaseClip;)Z", Self::stop, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("resume", "(Lorg/kwis/msp/media/BaseClip;)Z", Self::resume, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("play", "(Lorg/kwis/msp/media/BaseClip;Z)Z", Self::play, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("record", "(Lorg/kwis/msp/media/BaseClip;)Z", Self::record, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("play", "(Lorg/kwis/msp/media/Clip;Z)Z", Self::play_clip, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("stop", "(Lorg/kwis/msp/media/Clip;)Z", Self::stop_clip, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "pause",
+                    "(Lorg/kwis/msp/media/BaseClip;)Z",
+                    Self::pause,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "stop",
+                    "(Lorg/kwis/msp/media/BaseClip;)Z",
+                    Self::stop,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "resume",
+                    "(Lorg/kwis/msp/media/BaseClip;)Z",
+                    Self::resume,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "play",
+                    "(Lorg/kwis/msp/media/BaseClip;Z)Z",
+                    Self::play,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "record",
+                    "(Lorg/kwis/msp/media/BaseClip;)Z",
+                    Self::record,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "play",
+                    "(Lorg/kwis/msp/media/Clip;Z)Z",
+                    Self::play_clip,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "stop",
+                    "(Lorg/kwis/msp/media/Clip;)Z",
+                    Self::stop_clip,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 
@@ -67,7 +102,9 @@ impl Player {
         let player = Clip::player(jvm, &clip).await?;
 
         if !player.is_null() {
-            let _: () = jvm.invoke_virtual(&player, "start", "(Z)V", (repeat,)).await?;
+            let _: () = jvm
+                .invoke_virtual(&player, "javax/microedition/media/Player", "start", "(Z)V", (repeat,))
+                .await?;
 
             Ok(true)
         } else {
@@ -81,7 +118,7 @@ impl Player {
         let player = Clip::player(jvm, &clip).await?;
 
         if !player.is_null() {
-            let _: () = jvm.invoke_virtual(&player, "stop", "()V", ()).await?;
+            let _: () = jvm.invoke_virtual(&player, "javax/microedition/media/Player", "stop", "()V", ()).await?;
 
             return Ok(true);
         }

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/player.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/player.rs
@@ -102,9 +102,7 @@ impl Player {
         let player = Clip::player(jvm, &clip).await?;
 
         if !player.is_null() {
-            let _: () = jvm
-                .invoke_virtual(&player, "javax/microedition/media/Player", "start", "(Z)V", (repeat,))
-                .await?;
+            let _: () = jvm.invoke_virtual(&player, "net/wie/SmafPlayer", "start", "(Z)V", (repeat,)).await?;
 
             Ok(true)
         } else {
@@ -178,25 +176,24 @@ mod test {
     }
 
     #[test]
-    fn test_clip_compatibility_overloads_remain() -> Result<()> {
+    fn test_clip_playback_uses_repeat_overload() -> Result<()> {
         run_jvm_test(Box::new([wie_midp::get_protos().into(), get_protos().into()]), |jvm| async move {
             let r#type: ClassInstanceRef<String> = JavaLangString::from_rust_string(&jvm, "audio/test").await?.into();
-            let clip: ClassInstanceRef<Clip> = jvm.new_class("org/kwis/msp/media/Clip", "(Ljava/lang/String;)V", (r#type,)).await?.into();
+            let data = jvm.instantiate_array("B", 0).await?;
+            let clip: ClassInstanceRef<Clip> = jvm
+                .new_class("org/kwis/msp/media/Clip", "(Ljava/lang/String;[B)V", (r#type, data))
+                .await?
+                .into();
 
             let played: bool = jvm
-                .invoke_static(
-                    "org/kwis/msp/media/Player",
-                    "play",
-                    "(Lorg/kwis/msp/media/Clip;Z)Z",
-                    (clip.clone(), false),
-                )
+                .invoke_static("org/kwis/msp/media/Player", "play", "(Lorg/kwis/msp/media/Clip;Z)Z", (clip.clone(), true))
                 .await?;
             let stopped: bool = jvm
                 .invoke_static("org/kwis/msp/media/Player", "stop", "(Lorg/kwis/msp/media/Clip;)Z", (clip,))
                 .await?;
 
-            assert!(!played);
-            assert!(!stopped);
+            assert!(played);
+            assert!(stopped);
 
             Ok(())
         })

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/vibrator.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/vibrator.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -16,11 +16,16 @@ impl Vibrator {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("on", "(II)V", Self::on, MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC),
-                JavaMethodProto::new("off", "()V", Self::off, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "on",
+                    "(II)V",
+                    Self::on,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("off", "()V", Self::off, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 

--- a/wie_wipi_java/src/classes/org/kwis/msp/media/volume.rs
+++ b/wie_wipi_java/src/classes/org/kwis/msp/media/volume.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 
 use java_class_proto::JavaMethodProto;
-use java_constants::MethodAccessFlags;
+use java_constants::{ClassAccessFlags, MethodAccessFlags};
 use jvm::{Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -16,15 +16,35 @@ impl Volume {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("set", "(I)V", Self::set, MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC),
-                JavaMethodProto::new("get", "()I", Self::get, MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC),
-                JavaMethodProto::new("setMute", "(IZ)V", Self::set_mute, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getMute", "(I)Z", Self::get_mute, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("setDefaultVolume", "(II)Z", Self::set_default_volume, MethodAccessFlags::STATIC),
-                JavaMethodProto::new("getDefaultVolume", "(I)I", Self::get_default_volume, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "set",
+                    "(I)V",
+                    Self::set,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "get",
+                    "()I",
+                    Self::get,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::NATIVE | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new("setMute", "(IZ)V", Self::set_mute, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new("getMute", "(I)Z", Self::get_mute, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "setDefaultVolume",
+                    "(II)Z",
+                    Self::set_default_volume,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
+                JavaMethodProto::new(
+                    "getDefaultVolume",
+                    "(I)I",
+                    Self::get_default_volume,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                ),
             ],
             fields: vec![],
-            access_flags: Default::default(),
+            access_flags: ClassAccessFlags::PUBLIC,
         }
     }
 


### PR DESCRIPTION
## Summary

- Update the RustJava dependency and pass each call's symbolic owner to `invoke_virtual`.
- Replace implicit Java prototype access flags with explicit modifiers based on the KTF WIPI and MIDP API references.
- Align protected overrides and public interface methods across MIDP, WIPI, SKVM, KTF, and LGT runtime classes.

## Why

RustJava now resolves virtual calls from the symbolic owner and applies Java access rules when selecting overrides. Prototype members that implicitly remained package-private could therefore hide valid cross-package overrides or produce inconsistent dispatch.

## Validation

- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test --workspace`
