### PR TITLE
Fix LGT graphics and runtime compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "wipi_types"
 version = "0.0.1"
-source = "git+https://github.com/dlunch/wipi.git#5c744444d139e669e0ddaf5599f441971a71bbc1"
+source = "git+https://github.com/dlunch/wipi.git#4e3d8d3366aa0993f7c6667d3c6b0f4770c8f5ae"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/wie_backend/src/system.rs
+++ b/wie_backend/src/system.rs
@@ -33,6 +33,7 @@ pub struct System {
     event_queue: Arc<RwLock<EventQueue>>,
     audio: Arc<RwLock<Audio>>,
     task_runner: Arc<dyn TaskRunner>,
+    random_state: Arc<RwLock<u32>>,
 }
 
 impl System {
@@ -52,6 +53,7 @@ impl System {
             event_queue: Arc::new(RwLock::new(EventQueue::new())),
             audio: Arc::new(RwLock::new(Audio::new(audio_sink))),
             task_runner: Arc::new(task_runner),
+            random_state: Arc::new(RwLock::new(1)),
         }
     }
 
@@ -93,6 +95,14 @@ impl System {
 
     pub fn aid(&self) -> &str {
         &self.aid
+    }
+
+    pub fn random_state(&self) -> u32 {
+        *self.random_state.read()
+    }
+
+    pub fn set_random_state(&self, random_state: u32) {
+        *self.random_state.write() = random_state;
     }
 
     pub fn platform(&self) -> &dyn Platform {

--- a/wie_ktf/src/emulator.rs
+++ b/wie_ktf/src/emulator.rs
@@ -18,6 +18,10 @@ use crate::{
 
 pub const IMAGE_BASE: u32 = 0x100000;
 
+fn is_clet_mode(main_class_name: &str) -> bool {
+    main_class_name == "Clet"
+}
+
 struct KtfTaskRunner {
     core: ArmCore,
 }
@@ -118,7 +122,6 @@ impl KtfEmulator {
         let mut core_clone = core.clone();
         let mut system_clone = system.clone();
         let jar_filename_clone = jar_filename.to_owned();
-
         system.spawn(async move || Self::start(&mut core_clone, &mut system_clone, jar_filename_clone, main_class_name).await);
 
         Ok(Self { core, system })
@@ -127,6 +130,7 @@ impl KtfEmulator {
     #[tracing::instrument(name = "start", skip_all)]
     async fn start(core: &mut ArmCore, system: &mut System, jar_filename: String, main_class_name: Option<String>) -> Result<()> {
         let (jvm, class_loader) = KtfJvmSupport::init(core, system, Some(&jar_filename)).await?;
+        let clet_mode = main_class_name.as_deref().is_some_and(is_clet_mode);
 
         let main_class_name = if let Some(x) = main_class_name {
             x
@@ -155,6 +159,10 @@ impl KtfEmulator {
             .await;
 
         if let Err(x) = result {
+            return Err(JvmSupport::to_wie_err(&jvm, x).await);
+        }
+
+        if clet_mode && let Err(x) = KtfJvmSupport::disable_midp_paint(&jvm).await {
             return Err(JvmSupport::to_wie_err(&jvm, x).await);
         }
 
@@ -189,6 +197,13 @@ mod tests {
     use wie_util::{Result, WieError};
 
     use super::{KtfJvmSupport, KtfTaskRunner};
+
+    #[test]
+    fn clet_mode_is_selected_from_adf_mclass() {
+        assert!(super::is_clet_mode("Clet"));
+        assert!(!super::is_clet_mode("MIDlet"));
+        assert!(!super::is_clet_mode(""));
+    }
 
     #[test]
     fn switches_jvm_thread_context_between_tasks() -> Result<()> {

--- a/wie_ktf/src/runtime/java/jvm_support.rs
+++ b/wie_ktf/src/runtime/java/jvm_support.rs
@@ -17,11 +17,12 @@ use jvm_implementation::KtfJvmImplementation;
 use bytemuck::{Pod, Zeroable};
 
 use java_runtime::classes::java::util::{Enumeration, jar::JarEntry};
-use jvm::{ClassDefinition, ClassInstance, ClassInstanceRef, Jvm, runtime::JavaLangString};
+use jvm::{ClassDefinition, ClassInstance, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 
 use wie_backend::System;
 use wie_core_arm::{Allocator, ArmCore};
 use wie_jvm_support::JvmSupport;
+use wie_midp::classes::javax::microedition::midlet::MIDlet;
 use wie_util::{Result, WieError, read_generic, read_null_terminated_table, write_generic};
 
 use wipi_types::ktf::InitParam2;
@@ -159,6 +160,16 @@ impl KtfJvmSupport {
         Ok((jvm, class_loader))
     }
 
+    pub(crate) async fn disable_midp_paint(jvm: &Jvm) -> JvmResult<()> {
+        let midlet: ClassInstanceRef<MIDlet> = jvm
+            .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+            .await?;
+        let display = MIDlet::display(jvm, &midlet).await?;
+
+        jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "disablePaint", "()V", ())
+            .await
+    }
+
     pub fn class_definition_raw(definition: &dyn ClassDefinition) -> Result<u32> {
         Ok(if let Some(x) = definition.as_any().downcast_ref::<JavaClassDefinition>() {
             x.ptr_raw
@@ -239,10 +250,11 @@ mod test {
 
     use bytemuck::Zeroable;
     use java_constants::ClassAccessFlags;
-    use jvm::{Jvm, runtime::JavaLangString};
+    use jvm::{ClassInstanceRef, Jvm, runtime::JavaLangString};
 
     use wie_backend::{DefaultTaskRunner, System};
     use wie_core_arm::{Allocator, ArmCore};
+    use wie_midp::classes::javax::microedition::{lcdui::Display as MidpDisplay, midlet::MIDlet};
     use wie_util::{Result, WieError, write_generic};
 
     use super::{JavaArrayClassInstance, JavaClassDefinition, JavaMethod, KtfJvmSupport, KtfJvmThreadContext};
@@ -277,6 +289,16 @@ mod test {
         let mut system_clone = system.clone();
         system.spawn(async move || {
             let (jvm, _core) = init_jvm(&mut system_clone).await?;
+
+            let midlet: ClassInstanceRef<MIDlet> = jvm.new_class("net/wie/WIPIMIDlet", "()V", ()).await.unwrap().into();
+            let display: ClassInstanceRef<MidpDisplay> = MIDlet::display(&jvm, &midlet).await.unwrap();
+            let paint_disabled: bool = jvm.get_field(&display, "paintDisabled", "Z").await.unwrap();
+            assert!(!paint_disabled);
+
+            KtfJvmSupport::disable_midp_paint(&jvm).await.unwrap();
+
+            let paint_disabled: bool = jvm.get_field(&display, "paintDisabled", "Z").await.unwrap();
+            assert!(paint_disabled);
 
             let string1 = JavaLangString::from_rust_string(&jvm, "test1").await.unwrap();
             let string2 = JavaLangString::from_rust_string(&jvm, "test2").await.unwrap();

--- a/wie_ktf/src/runtime/wipi_c/method_table.rs
+++ b/wie_ktf/src/runtime/wipi_c/method_table.rs
@@ -363,12 +363,7 @@ pub fn get_method_body(table_id: WIPICTableId, function_id: u16) -> Option<WIPIC
     match table_id {
         WIPICTableId::Kernel => match WIPICKernelMethodId::try_from(function_id).ok()? {
             WIPICKernelMethodId::Printk => Some(kernel::printk.into_body()),
-            WIPICKernelMethodId::Sprintk => Some(
-                (|context: &mut dyn WIPICContext, dest, ptr_format, a0, a1, a2, a3, a4, a5| {
-                    kernel::sprintk(context, dest, ptr_format, a0, a1, a2, a3, a4, a5)
-                })
-                .into_body(),
-            ),
+            WIPICKernelMethodId::Sprintk => Some(kernel::sprintk.into_body()),
             WIPICKernelMethodId::GetExecNames => Some(gen_stub(2, "MC_knlGetExecNames")),
             WIPICKernelMethodId::Execute => Some(gen_stub(3, "MC_knlExecute")),
             WIPICKernelMethodId::Mexecute => Some(gen_stub(4, "MC_knlMExecute")),

--- a/wie_ktf/src/runtime/wipi_c/method_table.rs
+++ b/wie_ktf/src/runtime/wipi_c/method_table.rs
@@ -363,7 +363,12 @@ pub fn get_method_body(table_id: WIPICTableId, function_id: u16) -> Option<WIPIC
     match table_id {
         WIPICTableId::Kernel => match WIPICKernelMethodId::try_from(function_id).ok()? {
             WIPICKernelMethodId::Printk => Some(kernel::printk.into_body()),
-            WIPICKernelMethodId::Sprintk => Some(kernel::sprintk.into_body()),
+            WIPICKernelMethodId::Sprintk => Some(
+                (|context: &mut dyn WIPICContext, dest, ptr_format, a0, a1, a2, a3, a4, a5| {
+                    kernel::sprintk(context, dest, ptr_format, a0, a1, a2, a3, a4, a5)
+                })
+                .into_body(),
+            ),
             WIPICKernelMethodId::GetExecNames => Some(gen_stub(2, "MC_knlGetExecNames")),
             WIPICKernelMethodId::Execute => Some(gen_stub(3, "MC_knlExecute")),
             WIPICKernelMethodId::Mexecute => Some(gen_stub(4, "MC_knlMExecute")),

--- a/wie_lgt/src/emulator.rs
+++ b/wie_lgt/src/emulator.rs
@@ -39,11 +39,14 @@ impl LgtEmulator {
 
         tracing::info!("Loading app {}, pid {}, mclass {}", app_info.aid, app_info.pid, app_info.mclass);
 
-        let jar_filename = format!("{}.jar", app_info.aid);
+        let jar_filename = files
+            .iter()
+            .find_map(|(filename, data)| (filename.ends_with(".jar") && Self::loadable_jar(data)).then_some(filename))
+            .ok_or_else(|| WieError::FatalError("Missing LGT application JAR containing binary.mod".into()))?;
 
         Self::load(
             platform,
-            &jar_filename,
+            jar_filename,
             &app_info.pid,
             &app_info.aid,
             Some(app_info.mclass),
@@ -113,13 +116,20 @@ impl LgtEmulator {
     async fn do_start(core: &mut ArmCore, system: &mut System, jar_filename: String, _main_class_name: Option<String>) -> Result<()> {
         let jvm = LgtJvmSupport::init(core, system, Some(&jar_filename)).await?;
 
-        let class_loader = JavaLangClassLoader::get_system_class_loader(&jvm).await.unwrap();
-        let stream = JavaLangClassLoader::get_resource_as_stream(&jvm, &class_loader, "binary.mod")
-            .await
-            .unwrap()
-            .unwrap();
+        let class_loader = match JavaLangClassLoader::get_system_class_loader(&jvm).await {
+            Ok(class_loader) => class_loader,
+            Err(error) => return Err(JvmSupport::to_wie_err(&jvm, error).await),
+        };
+        let stream = match JavaLangClassLoader::get_resource_as_stream(&jvm, &class_loader, "binary.mod").await {
+            Ok(Some(stream)) => stream,
+            Ok(None) => return Err(WieError::FatalError(format!("Missing binary.mod in {jar_filename}"))),
+            Err(error) => return Err(JvmSupport::to_wie_err(&jvm, error).await),
+        };
 
-        let binary_mod = JavaIoInputStream::read_until_end(&jvm, &stream).await.unwrap();
+        let binary_mod = match JavaIoInputStream::read_until_end(&jvm, &stream).await {
+            Ok(binary_mod) => binary_mod,
+            Err(error) => return Err(JvmSupport::to_wie_err(&jvm, error).await),
+        };
 
         if let Err(error) = load_native(core, system, &jvm, &jar_filename, &binary_mod).await {
             return Err(match error {

--- a/wie_lgt/src/runtime/init.rs
+++ b/wie_lgt/src/runtime/init.rs
@@ -25,12 +25,14 @@ fn register_init_svc_handler(core: &mut ArmCore, ptr_jar_path: u32) -> Result<()
 async fn handle_init_svc(core: &mut ArmCore, ptr_jar_path: &mut u32, id: SvcId) -> Result<JumpTo> {
     let (_, lr) = core.read_pc_lr()?;
     match InitSvcId::try_from(id)? {
-        InitSvcId::GetImportTable => EmulatedFunction::call(&get_import_table, core, &mut ()).await?.write(core, lr)?,
-        InitSvcId::GetImportFunction => get_import_function(core, core.read_param(0)?, core.read_param(1)?)
+        InitSvcId::ImportTable => EmulatedFunction::call(&get_import_table, core, &mut ()).await?.write(core, lr)?,
+        InitSvcId::ImportFunction => get_import_function(core, core.read_param(0)?, core.read_param(1)?)
             .await?
             .write(core, lr)?,
-        InitSvcId::Unk0 => EmulatedFunction::call(&unk0, core, &mut ()).await?.write(core, lr)?,
-        InitSvcId::GetApplicationJarPath => EmulatedFunction::call(&get_application_jar_path, core, ptr_jar_path)
+        InitSvcId::SetDisplayProperty => EmulatedFunction::call(&super::wipi_c::graphics::set_display_property, core, &mut ())
+            .await?
+            .write(core, lr)?,
+        InitSvcId::ApplicationJarPath => EmulatedFunction::call(&get_application_jar_path, core, ptr_jar_path)
             .await?
             .write(core, lr)?,
     }
@@ -61,8 +63,8 @@ pub async fn load_native(core: &mut ArmCore, system: &mut System, jvm: &Jvm, jar
     write_generic(core, ptr_init_param_1, init_param_1)?;
 
     let init_param_2 = InitParam2 {
-        fn_get_import_table: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::GetImportTable)?,
-        fn_get_import_function: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::GetImportFunction)?,
+        fn_get_import_table: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::ImportTable)?,
+        fn_get_import_function: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::ImportFunction)?,
         fn_unk3: 0,
         fn_unk4: 0,
     };
@@ -106,8 +108,8 @@ async fn get_import_function(core: &mut ArmCore, import_table: u32, function_ind
     }
 
     Ok(match (import_table, function_index) {
-        (0x1f8, 0x16) => core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::Unk0)?,
-        (0x1f8, 0x17) => core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::GetApplicationJarPath)?,
+        (0x1f8, 0x16) => core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::SetDisplayProperty)?,
+        (0x1f8, 0x17) => core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::ApplicationJarPath)?,
         (0x1fc, 0x03) => core.make_svc_stub(SVC_CATEGORY_JAVA_SYSTEM, JavaSystemSvcId::Unk1)?,
         (0x1ff, 0x03) => core.make_svc_stub(SVC_CATEGORY_JAVA_SYSTEM, JavaSystemSvcId::Unk2)?,
         (0x201, 0x03) => core.make_svc_stub(SVC_CATEGORY_JAVA_SYSTEM, JavaSystemSvcId::Unk3)?,
@@ -158,12 +160,6 @@ fn load_executable(core: &mut ArmCore, data: &[u8]) -> Result<u32> {
     tracing::debug!("Entrypoint: {:#x}", elf.ehdr.e_entry);
 
     Ok(elf.ehdr.e_entry as u32)
-}
-
-async fn unk0(_core: &mut ArmCore, _: &mut (), a0: u32, a1: u32, a2: u32, a3: u32) -> Result<()> {
-    tracing::warn!("clet_unk0({a0:#x}, {a1:#x}, {a2:#x}, {a3:#x})");
-
-    Ok(())
 }
 
 async fn get_application_jar_path(core: &mut ArmCore, ptr_jar_path: &mut u32, _a0: u32, _capacity: u32, path_output: u32) -> Result<u32> {

--- a/wie_lgt/src/runtime/java/classes/net/wie/clet_wrapper.rs
+++ b/wie_lgt/src/runtime/java/classes/net/wie/clet_wrapper.rs
@@ -6,6 +6,7 @@ use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use java_runtime::classes::java::lang::String;
 use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
 
+use wie_midp::classes::javax::microedition::lcdui::Display as MidpDisplay;
 use wie_wipi_java::classes::org::kwis::msp::lcdui::Display;
 
 use super::CletWrapperContext;
@@ -67,6 +68,10 @@ impl CletWrapper {
                 "(Lorg/kwis/msp/lcdui/Card;)V",
                 (clet_wrapper_card,),
             )
+            .await?;
+        let midp_display: ClassInstanceRef<MidpDisplay> = jvm.get_field(&display, "midpDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let _: () = jvm
+            .invoke_virtual(&midp_display, "javax/microedition/lcdui/Display", "disablePaint", "()V", ())
             .await?;
 
         context

--- a/wie_lgt/src/runtime/java/jvm_support.rs
+++ b/wie_lgt/src/runtime/java/jvm_support.rs
@@ -397,6 +397,14 @@ mod tests {
             let mut shorts = jvm.instantiate_array("S", 10).await.unwrap();
             jvm.store_array(&mut shorts, 0, (0..10i16).collect::<Vec<_>>()).await.unwrap();
             assert_eq!(jvm.load_array::<i16>(&shorts, 5, 4).await.unwrap(), vec![5, 6, 7, 8]);
+            let short_instance_raw = LgtJvmSupport::class_instance_raw(&*shorts);
+            let short_instance: RawJavaClassInstance = read_generic(&core, short_instance_raw)?;
+            let mut short_value = [0; 2];
+            core.read_bytes(short_instance.ptr_fields + 6, &mut short_value)?;
+            assert_eq!(short_value, 1i16.to_le_bytes());
+            let mut short_padding = [0; 4];
+            core.read_bytes(short_instance.ptr_fields + 24, &mut short_padding)?;
+            assert_eq!(short_padding, [0; 4]);
             let short_array_definition = shorts
                 .class_definition()
                 .as_any()
@@ -417,6 +425,14 @@ mod tests {
             let mut longs = jvm.instantiate_array("J", long_values.len()).await.unwrap();
             jvm.store_array(&mut longs, 0, long_values.clone()).await.unwrap();
             assert_eq!(jvm.load_array::<i64>(&longs, 0, long_values.len()).await.unwrap(), long_values);
+            let long_instance_raw = LgtJvmSupport::class_instance_raw(&*longs);
+            let long_instance: RawJavaClassInstance = read_generic(&core, long_instance_raw)?;
+            let mut long_padding = [0; 4];
+            core.read_bytes(long_instance.ptr_fields + 4, &mut long_padding)?;
+            assert_eq!(long_padding, [0; 4]);
+            let mut first_long = [0; 8];
+            core.read_bytes(long_instance.ptr_fields + 8, &mut first_long)?;
+            assert_eq!(first_long, i64::MIN.to_le_bytes());
             let mut raw_long = [0; 8];
             longs.as_array_instance().unwrap().raw_buffer().unwrap().read(2, &mut raw_long).unwrap();
             assert_eq!(raw_long, 0x12345678_9abcdef0u64.to_le_bytes());
@@ -427,6 +443,11 @@ mod tests {
             jvm.store_array(&mut references, 0, vec![object]).await.unwrap();
             let loaded: Vec<ClassInstanceRef<String>> = jvm.load_array(&references, 0, 1).await.unwrap();
             assert_eq!(loaded[0].identity(), expected_identity);
+            let references_instance_raw = LgtJvmSupport::class_instance_raw(&*references);
+            let references_instance: RawJavaClassInstance = read_generic(&core, references_instance_raw)?;
+            let mut reference_value = [0; 4];
+            core.read_bytes(references_instance.ptr_fields + 4, &mut reference_value)?;
+            assert_eq!(u32::from_le_bytes(reference_value), expected_identity as u32);
 
             let object_definition = jvm
                 .resolve_class("java/lang/Object")

--- a/wie_lgt/src/runtime/java/jvm_support/array_class_instance.rs
+++ b/wie_lgt/src/runtime/java/jvm_support/array_class_instance.rs
@@ -11,7 +11,24 @@ use wie_core_arm::ArmCore;
 use wie_jvm_support::native::{decode_array_values, encode_array_values};
 use wie_util::{ByteRead, ByteWrite, Result, read_generic, write_generic};
 
-use super::{JavaArrayClassDefinition, JavaClassInstance, value::JavaValueCodec};
+use super::{JavaArrayClassDefinition, JavaClassInstance, LgtJvmWord, value::JavaValueCodec};
+
+// LGT reserves an eight-byte array prefix. Narrow elements start after the
+// length word at +0x04, while long and double elements start at +0x08 for
+// their required alignment.
+const LGT_ARRAY_STORAGE_PREFIX_SIZE: usize = 8;
+
+fn array_storage_size(length: usize, element_size: usize) -> usize {
+    LGT_ARRAY_STORAGE_PREFIX_SIZE + length * element_size
+}
+
+fn array_data_offset(element_size: usize) -> usize {
+    if element_size == size_of::<u64>() {
+        LGT_ARRAY_STORAGE_PREFIX_SIZE
+    } else {
+        size_of::<LgtJvmWord>()
+    }
+}
 
 #[derive(Clone)]
 pub struct JavaArrayClassInstance {
@@ -28,7 +45,7 @@ impl JavaArrayClassInstance {
     }
 
     pub fn new(core: &mut ArmCore, class: &JavaArrayClassDefinition, length: usize) -> Result<Self> {
-        let storage_size = size_of::<u32>() + length * class.element_size();
+        let storage_size = array_storage_size(length, class.element_size());
         let class_instance = JavaClassInstance::instantiate(core, &class.class, storage_size)?;
         write_generic(core, class_instance.ptr_fields()?, length as u32)?;
 
@@ -36,7 +53,7 @@ impl JavaArrayClassInstance {
     }
 
     fn storage_size(&self) -> usize {
-        size_of::<u32>() + self.array_length() * self.element_size()
+        array_storage_size(self.array_length(), self.element_size())
     }
 
     fn array_length(&self) -> usize {
@@ -45,7 +62,7 @@ impl JavaArrayClassInstance {
     }
 
     fn base_address(&self) -> u32 {
-        self.class_instance.storage_address(size_of::<u32>()).unwrap()
+        self.class_instance.storage_address(array_data_offset(self.element_size())).unwrap()
     }
 
     fn element_size(&self) -> usize {
@@ -186,5 +203,27 @@ impl ArrayRawBufferMut for ArrayRawBufferImpl {
             .write_bytes(self.base_address + (offset * self.element_size) as u32, buffer)
             .unwrap();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem::size_of;
+
+    use super::{LGT_ARRAY_STORAGE_PREFIX_SIZE, array_data_offset, array_storage_size};
+
+    #[test]
+    fn storage_layout_matches_lgt_abi() {
+        assert_eq!(LGT_ARRAY_STORAGE_PREFIX_SIZE, 8);
+
+        assert_eq!(array_data_offset(1), 4);
+        assert_eq!(array_data_offset(2), 4);
+        assert_eq!(array_data_offset(4), 4);
+        assert_eq!(array_data_offset(size_of::<u64>()), 8);
+
+        assert_eq!(array_storage_size(3, 1), 11);
+        assert_eq!(array_storage_size(3, 2), 14);
+        assert_eq!(array_storage_size(3, 4), 20);
+        assert_eq!(array_storage_size(3, 8), 32);
     }
 }

--- a/wie_lgt/src/runtime/stdlib.rs
+++ b/wie_lgt/src/runtime/stdlib.rs
@@ -31,7 +31,44 @@ pub fn register_stdlib_svc_handler(core: &mut ArmCore, system: &System) -> Resul
         }
     }
 
-    core.register_svc_handler(SVC_CATEGORY_STDLIB, handle_stdlib_svc, system)
+    let ptr_random_state = Allocator::alloc(core, size_of::<u32>() as u32)?;
+    write_generic(core, ptr_random_state, 1u32)?;
+
+    core.register_svc_handler(
+        SVC_CATEGORY_STDLIB,
+        handle_stdlib_svc,
+        &StdlibContext {
+            system: system.clone(),
+            ptr_random_state,
+        },
+    )
+}
+
+async fn srand(core: &mut ArmCore, ptr_random_state: &mut u32, seed: u32) -> Result<()> {
+    tracing::debug!("srand({seed:#x})");
+
+    write_generic(core, *ptr_random_state, seed)
+}
+
+async fn rand(core: &mut ArmCore, ptr_random_state: &mut u32) -> Result<u32> {
+    tracing::debug!("rand()");
+
+    let state: u32 = read_generic(core, *ptr_random_state)?;
+    let state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+    write_generic(core, *ptr_random_state, state)?;
+
+    Ok((state >> 16) & 0x7fff)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn sprintf(core: &mut ArmCore, _: &mut (), ptr_dst: u32, ptr_format: u32, a0: u32, a1: u32, a2: u32, a3: u32, a4: u32, a5: u32) -> Result<u32> {
+    tracing::debug!("sprintf({ptr_dst:#x}, {ptr_format:#x}, {a0:#x}, {a1:#x}, {a2:#x}, {a3:#x}, {a4:#x}, {a5:#x})");
+
+    let format = read_null_terminated_string_bytes(core, ptr_format)?;
+    let result = kernel::sprintf(core, &format, &[a0, a1, a2, a3, a4, a5])?;
+    write_null_terminated_string_bytes(core, ptr_dst, &result)?;
+
+    Ok(result.len() as u32)
 }
 
 async fn strncpy(core: &mut ArmCore, _: &mut (), ptr_dst: u32, ptr_src: u32, size: u32) -> Result<()> {

--- a/wie_lgt/src/runtime/stdlib.rs
+++ b/wie_lgt/src/runtime/stdlib.rs
@@ -5,6 +5,7 @@ use core::cmp::min;
 use wie_backend::System;
 use wie_core_arm::{Allocator, ArmCore, EmulatedFunction, ResultWriter, SvcId, stdlib};
 use wie_util::{ByteWrite, Result, WieError, read_generic, read_null_terminated_string_bytes, write_generic, write_null_terminated_string_bytes};
+use wie_wipi_c::api::kernel;
 
 use crate::runtime::{SVC_CATEGORY_STDLIB, svc_ids::StdlibSvcId};
 
@@ -14,13 +15,16 @@ pub fn register_stdlib_svc_handler(core: &mut ArmCore, system: &System) -> Resul
 
         match id.0 {
             x if x == StdlibSvcId::Unk2 as u32 => EmulatedFunction::call(&unk2, core, &mut ()).await?.write(core, lr),
+            x if x == StdlibSvcId::Sprintf as u32 => EmulatedFunction::call(&sprintf, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Atoi as u32 => EmulatedFunction::call(&atoi, core, &mut ()).await?.write(core, lr),
+            x if x == StdlibSvcId::Rand as u32 => EmulatedFunction::call(&rand, core, system).await?.write(core, lr),
+            x if x == StdlibSvcId::Srand as u32 => EmulatedFunction::call(&srand, core, system).await?.write(core, lr),
             x if x == StdlibSvcId::Strcpy as u32 => EmulatedFunction::call(&stdlib::strcpy, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Strncpy as u32 => EmulatedFunction::call(&strncpy, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Strcat as u32 => EmulatedFunction::call(&strcat, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Strcmp as u32 => EmulatedFunction::call(&strcmp, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Unk4 as u32 => EmulatedFunction::call(&unk4, core, &mut ()).await?.write(core, lr),
-            x if x == StdlibSvcId::Unk5 as u32 => EmulatedFunction::call(&unk5, core, &mut ()).await?.write(core, lr),
+            x if x == StdlibSvcId::Strstr as u32 => EmulatedFunction::call(&strstr, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Strlen as u32 => EmulatedFunction::call(&stdlib::strlen, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Memcpy as u32 => EmulatedFunction::call(&stdlib::memcpy, core, &mut ()).await?.write(core, lr),
             x if x == StdlibSvcId::Memset as u32 => EmulatedFunction::call(&stdlib::memset, core, &mut ()).await?.write(core, lr),
@@ -31,31 +35,22 @@ pub fn register_stdlib_svc_handler(core: &mut ArmCore, system: &System) -> Resul
         }
     }
 
-    let ptr_random_state = Allocator::alloc(core, size_of::<u32>() as u32)?;
-    write_generic(core, ptr_random_state, 1u32)?;
-
-    core.register_svc_handler(
-        SVC_CATEGORY_STDLIB,
-        handle_stdlib_svc,
-        &StdlibContext {
-            system: system.clone(),
-            ptr_random_state,
-        },
-    )
+    core.register_svc_handler(SVC_CATEGORY_STDLIB, handle_stdlib_svc, system)
 }
 
-async fn srand(core: &mut ArmCore, ptr_random_state: &mut u32, seed: u32) -> Result<()> {
+async fn srand(_core: &mut ArmCore, system: &mut System, seed: u32) -> Result<()> {
     tracing::debug!("srand({seed:#x})");
 
-    write_generic(core, *ptr_random_state, seed)
+    system.set_random_state(seed);
+    Ok(())
 }
 
-async fn rand(core: &mut ArmCore, ptr_random_state: &mut u32) -> Result<u32> {
+async fn rand(_core: &mut ArmCore, system: &mut System) -> Result<u32> {
     tracing::debug!("rand()");
 
-    let state: u32 = read_generic(core, *ptr_random_state)?;
+    let state = system.random_state();
     let state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
-    write_generic(core, *ptr_random_state, state)?;
+    system.set_random_state(state);
 
     Ok((state >> 16) & 0x7fff)
 }
@@ -175,9 +170,49 @@ async fn unk4(_core: &mut ArmCore, _: &mut (), a0: u32, a1: u32, a2: u32, a3: u3
     Ok(())
 }
 
-async fn unk5(_core: &mut ArmCore, _: &mut (), a0: u32, a1: u32) -> Result<()> {
-    tracing::warn!("unk5({a0:#x}, {a1:#x})");
-    // strstr??
+async fn strstr(core: &mut ArmCore, _: &mut (), ptr_haystack: u32, ptr_needle: u32) -> Result<u32> {
+    tracing::debug!("strstr({ptr_haystack:#x}, {ptr_needle:#x})");
 
-    Ok(())
+    let haystack = read_null_terminated_string_bytes(core, ptr_haystack)?;
+    let needle = read_null_terminated_string_bytes(core, ptr_needle)?;
+    let position = if needle.is_empty() {
+        Some(0)
+    } else {
+        haystack.windows(needle.len()).position(|window| window == needle)
+    };
+
+    Ok(position.map_or(0, |position| ptr_haystack + position as u32))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use futures::FutureExt;
+
+    use test_utils::TestPlatform;
+    use wie_backend::{DefaultTaskRunner, System};
+    use wie_core_arm::ArmCore;
+    use wie_util::Result;
+
+    use super::{rand, srand};
+
+    #[test]
+    fn random_state_is_shared_by_system_clones_and_process_local() -> Result<()> {
+        let mut first = ArmCore::new(false, None)?;
+        let mut second = ArmCore::new(false, None)?;
+        let mut first_system = System::new(Box::new(TestPlatform::new()), "", "", DefaultTaskRunner);
+        let mut second_system = System::new(Box::new(TestPlatform::new()), "", "", DefaultTaskRunner);
+        let mut first_system_clone = first_system.clone();
+
+        srand(&mut first, &mut first_system_clone, 1).now_or_never().unwrap()?;
+        assert_eq!(rand(&mut first, &mut first_system).now_or_never().unwrap()?, 16_838);
+        assert_eq!(first_system.random_state(), 1_103_527_590);
+
+        assert_eq!(rand(&mut second, &mut second_system).now_or_never().unwrap()?, 16_838);
+        srand(&mut second, &mut second_system, 7).now_or_never().unwrap()?;
+        assert_eq!(rand(&mut first, &mut first_system).now_or_never().unwrap()?, 5_758);
+
+        Ok(())
+    }
 }

--- a/wie_lgt/src/runtime/svc_ids.rs
+++ b/wie_lgt/src/runtime/svc_ids.rs
@@ -3,10 +3,10 @@ use wie_core_arm::SvcId;
 #[derive(Copy, Clone)]
 #[repr(u32)]
 pub enum InitSvcId {
-    GetImportTable = 0,
-    GetImportFunction = 1,
-    Unk0 = 2,
-    GetApplicationJarPath = 3,
+    ImportTable = 0,
+    ImportFunction = 1,
+    SetDisplayProperty = 2,
+    ApplicationJarPath = 3,
 }
 
 impl TryFrom<SvcId> for InitSvcId {
@@ -14,10 +14,10 @@ impl TryFrom<SvcId> for InitSvcId {
 
     fn try_from(value: SvcId) -> Result<Self, Self::Error> {
         Ok(match value.0 {
-            0 => Self::GetImportTable,
-            1 => Self::GetImportFunction,
-            2 => Self::Unk0,
-            3 => Self::GetApplicationJarPath,
+            0 => Self::ImportTable,
+            1 => Self::ImportFunction,
+            2 => Self::SetDisplayProperty,
+            3 => Self::ApplicationJarPath,
             _ => return Err(wie_util::WieError::FatalError(alloc::format!("Unknown LGT init SVC id {}", value.0))),
         })
     }

--- a/wie_lgt/src/runtime/svc_ids.rs
+++ b/wie_lgt/src/runtime/svc_ids.rs
@@ -348,13 +348,16 @@ impl From<WIPICSvcId> for u32 {
 #[repr(u32)]
 pub enum StdlibSvcId {
     Unk2 = 0x3f6,
+    Sprintf = 0x3f7,
     Atoi = 0x3fb,
+    Rand = 0x403,
+    Srand = 0x404,
     Strcpy = 0x405,
     Strncpy = 0x406,
     Strcat = 0x407,
     Strcmp = 0x409,
     Unk4 = 0x40a,
-    Unk5 = 0x410,
+    Strstr = 0x410,
     Strlen = 0x411,
     Memcpy = 0x414,
     Memset = 0x418,

--- a/wie_lgt/src/runtime/wipi_c.rs
+++ b/wie_lgt/src/runtime/wipi_c.rs
@@ -1,6 +1,7 @@
 use alloc::{boxed::Box, string::ToString, vec};
 
 mod context;
+pub(super) mod graphics;
 
 use jvm::{Jvm, Result as JvmResult, runtime::JavaLangString};
 use wipi_types::lgt::CletFunctions;
@@ -12,7 +13,7 @@ use wie_jvm_support::JvmSupport;
 use wie_util::{Result, read_generic, write_generic, write_null_terminated_string_bytes};
 use wie_wipi_c::{
     MethodImpl, WIPICContext, WIPICMethodBody, WIPICResult,
-    api::{database, graphics, kernel, media, misc, net},
+    api::{database, graphics as shared_graphics, kernel, media, misc, net},
 };
 
 use context::LgtWIPICContext;
@@ -44,7 +45,9 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm),
     let (_, lr) = core.read_pc_lr()?;
     let method = match WIPICSvcId::try_from(id)? {
         WIPICSvcId::CletRegister => {
-            return EmulatedFunction::call(&clet_register, core, jvm).await?.write(core, lr);
+            return EmulatedFunction::call(&clet_register, core, &mut (system.clone(), jvm.clone()))
+                .await?
+                .write(core, lr);
         }
         WIPICSvcId::GetFramebufferPointer => graphics::get_framebuffer_pointer.into_body(),
         WIPICSvcId::GetFramebufferWidth => graphics::get_framebuffer_width.into_body(),
@@ -52,7 +55,10 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm),
         WIPICSvcId::GetFramebufferBpl => graphics::get_framebuffer_bpl.into_body(),
         WIPICSvcId::GetFramebufferBpp => graphics::get_framebuffer_bpp.into_body(),
         WIPICSvcId::Printk => kernel::printk.into_body(),
-        WIPICSvcId::Sprintk => kernel::sprintk.into_body(),
+        WIPICSvcId::Sprintk => (|context: &mut dyn WIPICContext, dest, ptr_format, a0, a1, a2, a3, a4, a5| {
+            kernel::sprintk(context, dest, ptr_format, a0, a1, a2, a3, a4, a5)
+        })
+        .into_body(),
         WIPICSvcId::Unk13 => unk13.into_body(),
         WIPICSvcId::Unk1 => unk1.into_body(),
         WIPICSvcId::Exit => kernel::exit.into_body(),
@@ -91,15 +97,15 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm),
         WIPICSvcId::GetRgbPixels => graphics::get_rgb_pixels.into_body(),
         WIPICSvcId::SetRgbPixels => graphics::set_rgb_pixels.into_body(),
         WIPICSvcId::FlushLcd => graphics::flush_lcd.into_body(),
-        WIPICSvcId::GetPixelFromRgb => graphics::get_pixel_from_rgb.into_body(),
-        WIPICSvcId::GetRgbFromPixel => graphics::get_rgb_from_pixel.into_body(),
+        WIPICSvcId::GetPixelFromRgb => shared_graphics::get_pixel_from_rgb.into_body(),
+        WIPICSvcId::GetRgbFromPixel => shared_graphics::get_rgb_from_pixel.into_body(),
         WIPICSvcId::GetDisplayInfo => graphics::get_display_info.into_body(),
-        WIPICSvcId::Repaint => graphics::repaint.into_body(),
-        WIPICSvcId::GetFont => graphics::get_font.into_body(),
-        WIPICSvcId::GetFontHeight => graphics::get_font_height.into_body(),
-        WIPICSvcId::GetFontAscent => graphics::get_font_ascent.into_body(),
-        WIPICSvcId::GetFontDescent => graphics::get_font_descent.into_body(),
-        WIPICSvcId::GetStringWidth => graphics::get_string_width.into_body(),
+        WIPICSvcId::Repaint => shared_graphics::repaint.into_body(),
+        WIPICSvcId::GetFont => shared_graphics::get_font.into_body(),
+        WIPICSvcId::GetFontHeight => shared_graphics::get_font_height.into_body(),
+        WIPICSvcId::GetFontAscent => shared_graphics::get_font_ascent.into_body(),
+        WIPICSvcId::GetFontDescent => shared_graphics::get_font_descent.into_body(),
+        WIPICSvcId::GetStringWidth => shared_graphics::get_string_width.into_body(),
         WIPICSvcId::CreateImage => graphics::create_image.into_body(),
         WIPICSvcId::Unk0 => unk0.into_body(),
         WIPICSvcId::Unk11 => unk11.into_body(),
@@ -184,9 +190,15 @@ pub fn register_wipic_svc_handler(core: &mut ArmCore, system: &System, jvm: &Jvm
     core.register_svc_handler(SVC_CATEGORY_WIPIC, handle_wipic_svc, &(system.clone(), jvm.clone()))
 }
 
-async fn clet_register(core: &mut ArmCore, jvm: &mut Jvm, function_table: u32, a1: u32) -> Result<()> {
+async fn clet_register(core: &mut ArmCore, (system, jvm): &mut (System, Jvm), function_table: u32, a1: u32) -> Result<()> {
     tracing::debug!("clet_register({function_table:#x}, {a1:#x})");
 
+    let (screen_width, screen_height) = {
+        let screen = system.platform().screen();
+        (screen.width(), screen.height())
+    };
+    graphics::init_process_state(core, screen_width, screen_height)?;
+    graphics::set_use_annunciator(core, a1)?;
     let functions: CletFunctions = read_generic(core, function_table)?;
 
     jvm.put_static_field("net/wie/CletWrapper", "startClet", "I", functions.start_clet as i32)

--- a/wie_lgt/src/runtime/wipi_c.rs
+++ b/wie_lgt/src/runtime/wipi_c.rs
@@ -55,10 +55,7 @@ async fn handle_wipic_svc(core: &mut ArmCore, (system, jvm): &mut (System, Jvm),
         WIPICSvcId::GetFramebufferBpl => graphics::get_framebuffer_bpl.into_body(),
         WIPICSvcId::GetFramebufferBpp => graphics::get_framebuffer_bpp.into_body(),
         WIPICSvcId::Printk => kernel::printk.into_body(),
-        WIPICSvcId::Sprintk => (|context: &mut dyn WIPICContext, dest, ptr_format, a0, a1, a2, a3, a4, a5| {
-            kernel::sprintk(context, dest, ptr_format, a0, a1, a2, a3, a4, a5)
-        })
-        .into_body(),
+        WIPICSvcId::Sprintk => kernel::sprintk.into_body(),
         WIPICSvcId::Unk13 => unk13.into_body(),
         WIPICSvcId::Unk1 => unk1.into_body(),
         WIPICSvcId::Exit => kernel::exit.into_body(),

--- a/wie_lgt/src/runtime/wipi_c/graphics.rs
+++ b/wie_lgt/src/runtime/wipi_c/graphics.rs
@@ -1,0 +1,1086 @@
+use alloc::vec;
+use core::mem::size_of;
+
+use bytemuck::{Pod, Zeroable};
+use wipi_types::{
+    lgt::wipic::{LgtFramebuffer, LgtGraphicsContext, LgtGraphicsView, LgtImage},
+    wipic::{WIPICDisplayInfo, WIPICFramebuffer, WIPICIndirectPtr, WIPICWord},
+};
+
+use wie_backend::canvas::{ArgbPixel, Clip, Color, Image, PixelType, VecImageBuffer};
+use wie_core_arm::{Allocator, ArmCore};
+use wie_util::{Result, WieError, read_generic, write_generic};
+use wie_wipi_c::{
+    WIPICContext,
+    api::graphics::{FrameBuffer, decode_image_framebuffer, primitives},
+};
+
+const GRAPHICS_STATE_ROOT: u32 = 0x7fff1008;
+const DISPLAY_PROPERTIES_ROOT: u32 = 0x7fff1010;
+const FRAMEBUFFER_DEPTH: u32 = 16;
+
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct LgtGraphicsState {
+    physical_width: u32,
+    physical_height: u32,
+    use_annunciator: u32,
+    application_view_active: u32,
+    ptr_screen_backing: u32,
+    ptr_screen_view: u32,
+    ptr_annunciator_view: u32,
+    ptr_screen_wrapper: u32,
+}
+
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct LgtDisplayProperties {
+    physical_width: u32,
+    physical_height: u32,
+    use_annunciator: u32,
+}
+
+const _: [(); 16] = [(); size_of::<LgtFramebuffer>()];
+const _: [(); 20] = [(); size_of::<LgtGraphicsView>()];
+const _: [(); 8] = [(); size_of::<LgtImage>()];
+const _: [(); 56] = [(); size_of::<LgtGraphicsContext>()];
+
+struct ResolvedFramebuffer {
+    framebuffer: FrameBuffer,
+    public: LgtFramebuffer,
+    view: LgtGraphicsView,
+}
+
+struct ResolvedContext {
+    clip: Clip,
+    translation_x: i32,
+    translation_y: i32,
+    foreground: u32,
+}
+
+pub fn init_process_state(core: &mut ArmCore, physical_width: u32, physical_height: u32) -> Result<()> {
+    let ptr_state: u32 = read_generic(core, GRAPHICS_STATE_ROOT)?;
+    if ptr_state != 0 {
+        return Ok(());
+    }
+
+    let properties: LgtDisplayProperties = read_generic(core, DISPLAY_PROPERTIES_ROOT)?;
+    let state = LgtGraphicsState {
+        physical_width: if properties.physical_width == 0 {
+            physical_width
+        } else {
+            properties.physical_width
+        },
+        physical_height: if properties.physical_height == 0 {
+            physical_height
+        } else {
+            properties.physical_height
+        },
+        use_annunciator: properties.use_annunciator,
+        application_view_active: 0,
+        ptr_screen_backing: 0,
+        ptr_screen_view: 0,
+        ptr_annunciator_view: 0,
+        ptr_screen_wrapper: 0,
+    };
+    let ptr_state = Allocator::alloc(core, size_of::<LgtGraphicsState>() as u32)?;
+    write_generic(core, ptr_state, state)?;
+    write_generic(core, GRAPHICS_STATE_ROOT, ptr_state)
+}
+
+#[derive(Clone, Copy)]
+#[repr(u32)]
+enum DisplayProperty {
+    Width = 0x64,
+    Height = 0x65,
+    UseAnnunciator = 0x7f,
+}
+
+impl TryFrom<u32> for DisplayProperty {
+    type Error = ();
+
+    fn try_from(value: u32) -> core::result::Result<Self, Self::Error> {
+        match value {
+            0x64 => Ok(Self::Width),
+            0x65 => Ok(Self::Height),
+            0x7f => Ok(Self::UseAnnunciator),
+            _ => Err(()),
+        }
+    }
+}
+
+pub async fn set_display_property(core: &mut ArmCore, _: &mut (), _ptr_display: u32, property: u32, value: u32, size: u32) -> Result<u32> {
+    if size != 0 {
+        return Ok(0);
+    }
+    let Ok(property) = DisplayProperty::try_from(property) else {
+        return Ok(0);
+    };
+
+    let mut properties: LgtDisplayProperties = read_generic(core, DISPLAY_PROPERTIES_ROOT)?;
+
+    match property {
+        DisplayProperty::Width => properties.physical_width = value,
+        DisplayProperty::Height => properties.physical_height = value,
+        DisplayProperty::UseAnnunciator => properties.use_annunciator = value,
+    }
+    write_generic(core, DISPLAY_PROPERTIES_ROOT, properties)?;
+
+    let ptr_state: u32 = read_generic(core, GRAPHICS_STATE_ROOT)?;
+    if ptr_state != 0 {
+        let mut state: LgtGraphicsState = read_generic(core, ptr_state)?;
+        match property {
+            DisplayProperty::Width => state.physical_width = value,
+            DisplayProperty::Height => state.physical_height = value,
+            DisplayProperty::UseAnnunciator => state.use_annunciator = value,
+        }
+        write_generic(core, ptr_state, state)?;
+    }
+
+    Ok(0)
+}
+
+pub fn set_use_annunciator(core: &mut ArmCore, value: u32) -> Result<()> {
+    let ptr_state: u32 = read_generic(core, GRAPHICS_STATE_ROOT)?;
+    let mut state: LgtGraphicsState = read_generic(core, ptr_state)?;
+    state.use_annunciator = value;
+    write_generic(core, ptr_state, state)
+}
+
+fn state(context: &dyn WIPICContext) -> Result<(u32, LgtGraphicsState)> {
+    let ptr_state: u32 = read_generic(context, GRAPHICS_STATE_ROOT)?;
+    if ptr_state == 0 {
+        return Err(WieError::FatalError("LGT graphics state is not initialized".into()));
+    }
+    Ok((ptr_state, read_generic(context, ptr_state)?))
+}
+
+fn annunciator_height(width: u32) -> u32 {
+    match width {
+        120 => 14,
+        176 | 220 => 20,
+        240 | 320 | 400 => 24,
+        _ => 0,
+    }
+}
+
+fn requested_application_y(state: &LgtGraphicsState) -> u32 {
+    if state.use_annunciator != 0 {
+        annunciator_height(state.physical_width)
+    } else {
+        0
+    }
+}
+
+fn application_y(state: &LgtGraphicsState) -> u32 {
+    if state.application_view_active != 0 {
+        requested_application_y(state)
+    } else {
+        0
+    }
+}
+
+fn resize_presentation(context: &mut dyn WIPICContext, width: u32, height: u32) -> Result<()> {
+    let screen = context.system().platform().screen();
+    if screen.width() != width || screen.height() != height {
+        screen.resize(width, height)?;
+    }
+    Ok(())
+}
+
+fn presentation_image(image: &dyn Image, view: LgtGraphicsView, width: u32, height: u32) -> Result<VecImageBuffer<ArgbPixel>> {
+    if view.x < 0
+        || view.y < 0
+        || i64::from(view.x) + i64::from(view.width) > i64::from(image.width())
+        || i64::from(view.y) + i64::from(view.height) > i64::from(image.height())
+        || view.width > width
+        || view.height > height
+    {
+        return Err(WieError::FatalError("LGT presentation view is outside its physical backing".into()));
+    }
+
+    let pixel_count = width.checked_mul(height).ok_or(WieError::AllocationFailure)? as usize;
+    let mut pixels = vec![ArgbPixel::from_color(Color { a: 0xff, r: 0, g: 0, b: 0 }); pixel_count];
+    let destination_x = (width - view.width) / 2;
+    let destination_y = (height - view.height) / 2;
+    for y in 0..view.height {
+        for x in 0..view.width {
+            let destination = ((destination_y + y) * width + destination_x + x) as usize;
+            pixels[destination] = ArgbPixel::from_color(image.get_pixel(view.x + x as i32, view.y + y as i32));
+        }
+    }
+    Ok(VecImageBuffer::<ArgbPixel>::from_raw(width, height, pixels))
+}
+
+fn alloc_record<T: Pod>(context: &mut dyn WIPICContext, value: T) -> Result<WIPICIndirectPtr> {
+    let handle = context.alloc(size_of::<T>() as u32)?;
+    let address = context.data_ptr(handle)?;
+    write_generic(context, address, value)?;
+    Ok(handle)
+}
+
+fn read_record<T: Pod>(context: &dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<T> {
+    let address = context.data_ptr(handle)?;
+    read_generic(context, address)
+}
+
+fn create_backing(context: &mut dyn WIPICContext, width: u32, height: u32) -> Result<WIPICIndirectPtr> {
+    let bpl = width.checked_mul(2).ok_or(WieError::AllocationFailure)?;
+    let size = bpl.checked_mul(height).ok_or(WieError::AllocationFailure)?;
+    let pixels = context.alloc(size)?;
+    let pixels_address = context.data_ptr(pixels)?;
+    context.write_bytes(pixels_address, &vec![0; size as usize])?;
+
+    alloc_record(
+        context,
+        WIPICFramebuffer {
+            width,
+            height,
+            bpl,
+            bpp: FRAMEBUFFER_DEPTH,
+            buf: pixels,
+        },
+    )
+}
+
+fn create_view(context: &mut dyn WIPICContext, ptr_backing: WIPICIndirectPtr, x: i32, y: i32, width: u32, height: u32) -> Result<WIPICIndirectPtr> {
+    alloc_record(
+        context,
+        LgtGraphicsView {
+            ptr_backing: ptr_backing.0,
+            x,
+            y,
+            width,
+            height,
+        },
+    )
+}
+
+fn resolve_framebuffer(context: &dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<ResolvedFramebuffer> {
+    let public: LgtFramebuffer = read_record(context, handle)?;
+    if public.ptr_graphics == 0 {
+        return Err(WieError::FatalError(alloc::format!(
+            "LGT framebuffer {:#x} has no graphics view",
+            handle.0
+        )));
+    }
+    let view: LgtGraphicsView = read_record(context, WIPICIndirectPtr(public.ptr_graphics))?;
+    if view.ptr_backing == 0 {
+        return Err(WieError::FatalError(alloc::format!(
+            "LGT graphics view {:#x} has no backing",
+            public.ptr_graphics
+        )));
+    }
+    let backing: WIPICFramebuffer = read_record(context, WIPICIndirectPtr(view.ptr_backing))?;
+
+    Ok(ResolvedFramebuffer {
+        framebuffer: FrameBuffer(backing),
+        public,
+        view,
+    })
+}
+
+fn resolve_context(context: &dyn WIPICContext, framebuffer: &ResolvedFramebuffer, ptr_context: WIPICWord) -> Result<ResolvedContext> {
+    let raw: LgtGraphicsContext = read_generic(context, ptr_context)?;
+    let (_, state) = state(context)?;
+    Ok(normalize_context(raw, framebuffer.public, framebuffer.view, state))
+}
+
+fn normalize_context(raw: LgtGraphicsContext, framebuffer: LgtFramebuffer, view: LgtGraphicsView, state: LgtGraphicsState) -> ResolvedContext {
+    let adjust_y = if framebuffer.owned_image == 0 && framebuffer.screen_kind != 1 {
+        application_y(&state) as i32
+    } else {
+        0
+    };
+    let width = (i64::from(raw.clip_x2) + 1 - i64::from(raw.clip_x1)).clamp(0, u32::MAX as i64) as u32;
+    let height = (i64::from(raw.clip_y2) + 1 - i64::from(raw.clip_y1)).clamp(0, u32::MAX as i64) as u32;
+    let context_clip = Clip {
+        x: raw.clip_x1,
+        y: raw.clip_y1.wrapping_add(adjust_y),
+        width,
+        height,
+    };
+    let view_clip = Clip {
+        x: view.x,
+        y: view.y,
+        width: view.width,
+        height: view.height,
+    };
+
+    ResolvedContext {
+        clip: context_clip.intersect(&view_clip),
+        translation_x: raw.offset_x,
+        translation_y: raw.offset_y.wrapping_add(adjust_y),
+        foreground: raw.foreground,
+    }
+}
+
+fn image_framebuffer(context: &dyn WIPICContext, ptr_image: WIPICIndirectPtr) -> Result<FrameBuffer> {
+    let image: LgtImage = read_record(context, ptr_image)?;
+    if image.ptr_image == 0 {
+        return Err(WieError::FatalError("LGT image has no native backing".into()));
+    }
+    Ok(FrameBuffer(read_record(context, WIPICIndirectPtr(image.ptr_image))?))
+}
+
+fn activate_application_view(context: &mut dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<()> {
+    let (ptr_state, mut state) = state(context)?;
+    if state.application_view_active != 0 || state.use_annunciator == 0 || state.ptr_screen_wrapper != handle.0 {
+        return Ok(());
+    }
+
+    let app_y = requested_application_y(&state);
+    let app_height = state.physical_height.checked_sub(app_y).ok_or_else(|| {
+        WieError::FatalError(alloc::format!(
+            "Invalid LGT display region: {}x{} with annunciator {app_y}",
+            state.physical_width,
+            state.physical_height
+        ))
+    })?;
+    let ptr_screen_view_handle = WIPICIndirectPtr(state.ptr_screen_view);
+    let mut screen_view: LgtGraphicsView = read_record(context, ptr_screen_view_handle)?;
+    screen_view.y = app_y as i32;
+    screen_view.height = app_height;
+    write_generic(context, context.data_ptr(ptr_screen_view_handle)?, screen_view)?;
+
+    let ptr_annunciator_view = create_view(context, WIPICIndirectPtr(state.ptr_screen_backing), 0, 0, state.physical_width, app_y)?;
+    state.application_view_active = 1;
+    state.ptr_annunciator_view = ptr_annunciator_view.0;
+    write_generic(context, ptr_state, state)
+}
+
+pub async fn get_screen_framebuffer(context: &mut dyn WIPICContext, kind: WIPICWord) -> Result<WIPICIndirectPtr> {
+    tracing::debug!("MC_grpGetScreenFrameBuffer({kind:#x})");
+    if kind != 0 {
+        return Err(WieError::FatalError(alloc::format!("Unsupported LGT screen kind {kind}")));
+    }
+
+    let (ptr_state, mut state) = state(context)?;
+    if state.ptr_screen_wrapper != 0 {
+        return Ok(WIPICIndirectPtr(state.ptr_screen_wrapper));
+    }
+
+    let ptr_backing = create_backing(context, state.physical_width, state.physical_height)?;
+    let ptr_screen_view = create_view(context, ptr_backing, 0, 0, state.physical_width, state.physical_height)?;
+    let ptr_wrapper = alloc_record(
+        context,
+        LgtFramebuffer {
+            owned_image: 0,
+            ptr_graphics: ptr_screen_view.0,
+            ptr_image: 0,
+            screen_kind: kind,
+        },
+    )?;
+
+    state.ptr_screen_backing = ptr_backing.0;
+    state.ptr_screen_view = ptr_screen_view.0;
+    state.ptr_annunciator_view = 0;
+    state.ptr_screen_wrapper = ptr_wrapper.0;
+    write_generic(context, ptr_state, state)?;
+    resize_presentation(context, state.physical_width, state.physical_height)?;
+
+    Ok(ptr_wrapper)
+}
+
+pub async fn create_offscreen_framebuffer(context: &mut dyn WIPICContext, width: i32, height: i32) -> Result<WIPICIndirectPtr> {
+    tracing::debug!("MC_grpCreateOffScreenFrameBuffer({width}, {height})");
+    if width <= 0 || height <= 0 {
+        return Err(WieError::AllocationFailure);
+    }
+
+    let ptr_backing = create_backing(context, width as u32, height as u32)?;
+    let ptr_view = create_view(context, ptr_backing, 0, 0, width as u32, height as u32)?;
+    alloc_record(
+        context,
+        LgtFramebuffer {
+            owned_image: 1,
+            ptr_graphics: ptr_view.0,
+            ptr_image: ptr_backing.0,
+            screen_kind: 0,
+        },
+    )
+}
+
+pub async fn destroy_offscreen_framebuffer(context: &mut dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<()> {
+    tracing::debug!("MC_grpDestroyOffScreenFrameBuffer({:#x})", handle.0);
+    let public: LgtFramebuffer = read_record(context, handle)?;
+    if public.owned_image == 0 || public.ptr_graphics == 0 || public.ptr_image == 0 {
+        return Err(WieError::FatalError(alloc::format!("Invalid LGT off-screen framebuffer {:#x}", handle.0)));
+    }
+    let backing: WIPICFramebuffer = read_record(context, WIPICIndirectPtr(public.ptr_image))?;
+
+    context.free(WIPICIndirectPtr(public.ptr_graphics))?;
+    context.free(backing.buf)?;
+    context.free(WIPICIndirectPtr(public.ptr_image))?;
+    context.free(handle)
+}
+
+pub async fn get_framebuffer_pointer(context: &mut dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<WIPICWord> {
+    tracing::debug!("MC_GRP_GET_FRAME_BUFFER_POINTER({:#x})", handle.0);
+    activate_application_view(context, handle)?;
+    Ok(resolve_framebuffer(context, handle)?.framebuffer.0.buf.0)
+}
+
+pub async fn get_framebuffer_width(context: &mut dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<i32> {
+    tracing::debug!("MC_GRP_GET_FRAME_BUFFER_WIDTH({:#x})", handle.0);
+    Ok(resolve_framebuffer(context, handle)?.view.width as i32)
+}
+
+pub async fn get_framebuffer_height(context: &mut dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<i32> {
+    tracing::debug!("MC_GRP_GET_FRAME_BUFFER_HEIGHT({:#x})", handle.0);
+    Ok(resolve_framebuffer(context, handle)?.view.height as i32)
+}
+
+pub async fn get_framebuffer_bpl(context: &mut dyn WIPICContext, handle: WIPICIndirectPtr) -> Result<i32> {
+    tracing::debug!("MC_GRP_GET_FRAME_BUFFER_BPL({:#x})", handle.0);
+    let resolved = resolve_framebuffer(context, handle)?;
+    if resolved.public.owned_image != 0 {
+        Ok(0)
+    } else {
+        Ok(resolved.framebuffer.0.bpl as i32)
+    }
+}
+
+pub async fn get_framebuffer_bpp(context: &mut dyn WIPICContext, _handle: WIPICIndirectPtr) -> Result<i32> {
+    // The native accessor ignores its argument and reads display property 0x6e,
+    // property 2.  The application consequently passes a non-framebuffer value
+    // here during screen initialization.
+    tracing::debug!("MC_GRP_GET_FRAME_BUFFER_BPP() -> {FRAMEBUFFER_DEPTH}");
+    let (_, state) = state(context)?;
+    if state.physical_width == 0 || state.physical_height == 0 {
+        return Err(WieError::FatalError("Invalid LGT display dimensions".into()));
+    }
+    Ok(FRAMEBUFFER_DEPTH as i32)
+}
+
+pub async fn init_context(context: &mut dyn WIPICContext, ptr_context: WIPICWord) -> Result<()> {
+    tracing::debug!("MC_grpInitContext({ptr_context:#x})");
+    write_generic(
+        context,
+        ptr_context,
+        LgtGraphicsContext {
+            clip_x1: 0,
+            clip_y1: 0,
+            clip_x2: 0x7fff,
+            clip_y2: 0x7fff,
+            foreground: 0,
+            background: 0x00ff_ffff,
+            alpha: 255,
+            pixel_op: 0,
+            pixel_param: 255,
+            font: 0,
+            style: 0,
+            xor_enabled: 0,
+            offset_x: 0,
+            offset_y: 0,
+        },
+    )
+}
+
+pub async fn set_context(context: &mut dyn WIPICContext, ptr_context: WIPICWord, operation: WIPICWord, value: WIPICWord) -> Result<()> {
+    tracing::debug!("MC_grpSetContext({ptr_context:#x}, {operation}, {value:#x})");
+    let mut graphics: LgtGraphicsContext = read_generic(context, ptr_context)?;
+    match operation {
+        0 if value != 0 => {
+            graphics.clip_x1 = read_generic(context, value)?;
+            graphics.clip_y1 = read_generic(context, value + 4)?;
+            graphics.clip_x2 = read_generic::<i32, _>(context, value + 8)?.wrapping_sub(1);
+            graphics.clip_y2 = read_generic::<i32, _>(context, value + 12)?.wrapping_sub(1);
+        }
+        1 => graphics.foreground = value,
+        2 => graphics.background = value,
+        3 => {}
+        4 if value <= 255 => graphics.alpha = value,
+        5 => graphics.pixel_op = value,
+        6 => graphics.pixel_param = value,
+        7 => graphics.font = value,
+        8 => graphics.style = value,
+        9 if value == 0 => {
+            graphics.pixel_op = 0;
+            graphics.xor_enabled = 0;
+        }
+        9 => {
+            graphics.alpha = 0;
+            graphics.pixel_op = 1;
+            graphics.xor_enabled = 1;
+        }
+        10 if value != 0 => {
+            graphics.offset_x = read_generic(context, value)?;
+            graphics.offset_y = read_generic(context, value + 4)?;
+        }
+        _ => {}
+    }
+    write_generic(context, ptr_context, graphics)
+}
+
+pub async fn put_pixel(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x: i32, y: i32, ptr_graphics: WIPICWord) -> Result<()> {
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::put_pixel(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        color,
+        graphics.clip,
+    )
+}
+
+pub async fn fill_rect(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::fill_rect(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width as u32,
+        height as u32,
+        color,
+        graphics.clip,
+    )
+}
+
+pub async fn draw_line(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::draw_line(
+        context,
+        &resolved.framebuffer,
+        x1.wrapping_add(graphics.translation_x),
+        y1.wrapping_add(graphics.translation_y),
+        x2.wrapping_add(graphics.translation_x),
+        y2.wrapping_add(graphics.translation_y),
+        color,
+        graphics.clip,
+    )
+}
+
+pub async fn draw_rect(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::draw_rect(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width.saturating_sub(1) as u32,
+        height.saturating_sub(1) as u32,
+        color,
+        graphics.clip,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn draw_arc(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    start_angle: i32,
+    end_angle: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::draw_arc(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width.saturating_sub(1) as u32,
+        height.saturating_sub(1) as u32,
+        start_angle,
+        end_angle.wrapping_sub(start_angle),
+        color,
+        graphics.clip,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn fill_arc(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    start_angle: i32,
+    end_angle: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::fill_arc(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width as u32,
+        height as u32,
+        start_angle,
+        end_angle.wrapping_sub(start_angle),
+        color,
+        graphics.clip,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn draw_image(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    ptr_image: WIPICIndirectPtr,
+    source_x: i32,
+    source_y: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let source = image_framebuffer(context, ptr_image)?.image(context)?;
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    primitives::draw_image(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width as u32,
+        height as u32,
+        &*source,
+        source_x,
+        source_y,
+        graphics.clip,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn copy_frame_buffer(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    source: WIPICIndirectPtr,
+    source_x: i32,
+    source_y: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let source = resolve_framebuffer(context, source)?.framebuffer.image(context)?;
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    primitives::draw_image(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width as u32,
+        height as u32,
+        &*source,
+        source_x,
+        source_y,
+        graphics.clip,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn copy_area(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    source_x: i32,
+    source_y: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let resolved = resolve_framebuffer(context, dst)?;
+    let source = resolved.framebuffer.image(context)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    primitives::draw_image(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width as u32,
+        height as u32,
+        &*source,
+        source_x.wrapping_add(graphics.translation_x),
+        source_y.wrapping_add(graphics.translation_y),
+        graphics.clip,
+    )
+}
+
+pub async fn draw_string(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    ptr_string: WIPICWord,
+    length: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    let Some(string) = primitives::read_text(context, ptr_string, length)? else {
+        return Ok(());
+    };
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    let color = resolved.framebuffer.pixel_to_color(graphics.foreground);
+    primitives::draw_text(
+        context,
+        &resolved.framebuffer,
+        &string,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        color,
+        graphics.clip,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn get_rgb_pixels(
+    context: &mut dyn WIPICContext,
+    source: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    destination: WIPICWord,
+    destination_bpl: i32,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let image = resolve_framebuffer(context, source)?.framebuffer.image(context)?;
+    primitives::get_rgb_pixels(context, &*image, x, y, width, height, destination, destination_bpl)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn set_rgb_pixels(
+    context: &mut dyn WIPICContext,
+    dst: WIPICIndirectPtr,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    source: WIPICWord,
+    source_bpl: i32,
+    ptr_graphics: WIPICWord,
+) -> Result<()> {
+    if width <= 0 || height <= 0 {
+        return Ok(());
+    }
+    let resolved = resolve_framebuffer(context, dst)?;
+    let graphics = resolve_context(context, &resolved, ptr_graphics)?;
+    primitives::set_rgb_pixels(
+        context,
+        &resolved.framebuffer,
+        x.wrapping_add(graphics.translation_x),
+        y.wrapping_add(graphics.translation_y),
+        width,
+        height,
+        source,
+        source_bpl,
+        graphics.clip,
+    )
+}
+
+pub async fn flush_lcd(
+    context: &mut dyn WIPICContext,
+    kind: WIPICWord,
+    source: WIPICIndirectPtr,
+    _x: WIPICWord,
+    _y: WIPICWord,
+    _width: WIPICWord,
+    _height: WIPICWord,
+) -> Result<()> {
+    tracing::debug!("MC_grpFlushLcd({kind}, {:#x})", source.0);
+    if kind != 0 {
+        return Err(WieError::FatalError(alloc::format!("Unsupported LGT display kind {kind}")));
+    }
+    let resolved = resolve_framebuffer(context, source)?;
+    let image = resolved.framebuffer.image(context)?;
+    let (_, state) = state(context)?;
+    let presented = presentation_image(&*image, resolved.view, state.physical_width, state.physical_height)?;
+    resize_presentation(context, state.physical_width, state.physical_height)?;
+    context.system().platform().screen().paint(&presented);
+    Ok(())
+}
+
+pub async fn get_display_info(context: &mut dyn WIPICContext, kind: WIPICWord, output: WIPICWord) -> Result<WIPICWord> {
+    tracing::debug!("MC_grpGetDisplayInfo({kind}, {output:#x})");
+    if kind != 0 {
+        return Err(WieError::FatalError(alloc::format!("Unsupported LGT display kind {kind}")));
+    }
+    let (_, state) = state(context)?;
+    let height = state
+        .physical_height
+        .checked_sub(application_y(&state))
+        .ok_or_else(|| WieError::FatalError("Invalid LGT logical display height".into()))?;
+    write_generic(
+        context,
+        output,
+        WIPICDisplayInfo {
+            bpp: FRAMEBUFFER_DEPTH,
+            depth: FRAMEBUFFER_DEPTH,
+            width: state.physical_width,
+            height,
+            bpl: state.physical_width * 2,
+            color_type: 1,
+            red_mask: 0xf800,
+            green_mask: 0x07e0,
+            blue_mask: 0x001f,
+        },
+    )?;
+    Ok(1)
+}
+
+pub async fn create_image(
+    context: &mut dyn WIPICContext,
+    output: WIPICWord,
+    encoded_data: WIPICIndirectPtr,
+    offset: WIPICWord,
+    length: WIPICWord,
+) -> Result<WIPICWord> {
+    let backing = decode_image_framebuffer(context, encoded_data, offset, length)?;
+    let width = backing.0.width;
+    let height = backing.0.height;
+    let ptr_backing = alloc_record(context, backing.0)?;
+    let ptr_view = create_view(context, ptr_backing, 0, 0, width, height)?;
+    let ptr_framebuffer = alloc_record(
+        context,
+        LgtFramebuffer {
+            owned_image: 1,
+            ptr_graphics: ptr_view.0,
+            ptr_image: ptr_backing.0,
+            screen_kind: 0,
+        },
+    )?;
+    let public = alloc_record(
+        context,
+        LgtImage {
+            ptr_image: ptr_backing.0,
+            ptr_framebuffer: ptr_framebuffer.0,
+        },
+    )?;
+    write_generic(context, output, public)?;
+    Ok(1)
+}
+
+pub async fn get_image_framebuffer(context: &mut dyn WIPICContext, ptr_image: WIPICIndirectPtr) -> Result<WIPICIndirectPtr> {
+    Ok(WIPICIndirectPtr(read_record::<LgtImage>(context, ptr_image)?.ptr_framebuffer))
+}
+
+pub async fn get_image_property(context: &mut dyn WIPICContext, ptr_image: WIPICIndirectPtr, property: i32) -> Result<i32> {
+    let backing = image_framebuffer(context, ptr_image)?;
+    Ok(match property {
+        4 => backing.0.width as i32,
+        5 => backing.0.height as i32,
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use futures::FutureExt;
+    use wie_core_arm::{Allocator, ArmCore};
+    use wie_util::{Result, read_generic};
+
+    use super::{
+        DISPLAY_PROPERTIES_ROOT, GRAPHICS_STATE_ROOT, LgtDisplayProperties, LgtFramebuffer, LgtGraphicsContext, LgtGraphicsState, LgtGraphicsView,
+        application_y, init_process_state, normalize_context, presentation_image, set_display_property,
+    };
+    use wie_backend::canvas::{ArgbPixel, Image, PixelType, VecImageBuffer};
+
+    #[test]
+    fn process_state_initializes_once_for_the_clet_lifecycle() -> Result<()> {
+        let mut core = ArmCore::new(false, None)?;
+        Allocator::init(&mut core)?;
+
+        init_process_state(&mut core, 240, 320)?;
+        let ptr_state: u32 = read_generic(&core, GRAPHICS_STATE_ROOT)?;
+        let state: LgtGraphicsState = read_generic(&core, ptr_state)?;
+        assert_eq!(state.physical_width, 240);
+        assert_eq!(state.physical_height, 320);
+
+        init_process_state(&mut core, 176, 220)?;
+        let ptr_state_after: u32 = read_generic(&core, GRAPHICS_STATE_ROOT)?;
+        let state_after: LgtGraphicsState = read_generic(&core, ptr_state_after)?;
+        assert_eq!(ptr_state_after, ptr_state);
+        assert_eq!(state_after.physical_width, 240);
+        assert_eq!(state_after.physical_height, 320);
+
+        Ok(())
+    }
+
+    #[test]
+    fn display_properties_update_physical_display_state() -> Result<()> {
+        let mut core = ArmCore::new(false, None)?;
+        Allocator::init(&mut core)?;
+
+        set_display_property(&mut core, &mut (), 0, 0x64, 240, 0).now_or_never().unwrap()?;
+        set_display_property(&mut core, &mut (), 0, 0x65, 320, 0).now_or_never().unwrap()?;
+        let properties: LgtDisplayProperties = read_generic(&core, DISPLAY_PROPERTIES_ROOT)?;
+        assert_eq!(properties.physical_width, 240);
+        init_process_state(&mut core, 176, 220)?;
+
+        let ptr_state: u32 = read_generic(&core, GRAPHICS_STATE_ROOT)?;
+        let state: LgtGraphicsState = read_generic(&core, ptr_state)?;
+        assert_eq!(state.physical_width, 240);
+        assert_eq!(state.physical_height, 320);
+
+        Ok(())
+    }
+
+    #[test]
+    fn presentation_centers_the_application_view_in_the_physical_display() {
+        let source = VecImageBuffer::<ArgbPixel>::from_raw(2, 3, vec![0xff000001, 0xff000002, 0xff000003, 0xff000004, 0xff000005, 0xff000006]);
+        let view = LgtGraphicsView {
+            ptr_backing: 0,
+            x: 0,
+            y: 1,
+            width: 2,
+            height: 2,
+        };
+
+        let presented = presentation_image(&source, view, 2, 4).unwrap();
+
+        assert_eq!(presented.width(), 2);
+        assert_eq!(presented.height(), 4);
+        assert_eq!(ArgbPixel::from_color(presented.get_pixel(0, 0)), 0xff000000);
+        assert_eq!(ArgbPixel::from_color(presented.get_pixel(0, 1)), 0xff000003);
+        assert_eq!(ArgbPixel::from_color(presented.get_pixel(1, 2)), 0xff000006);
+        assert_eq!(ArgbPixel::from_color(presented.get_pixel(1, 3)), 0xff000000);
+    }
+
+    #[test]
+    fn annunciator_request_only_changes_application_geometry_after_raw_screen_access() {
+        let mut state = LgtGraphicsState {
+            physical_width: 240,
+            physical_height: 320,
+            use_annunciator: 1,
+            application_view_active: 0,
+            ptr_screen_backing: 0,
+            ptr_screen_view: 0,
+            ptr_annunciator_view: 0,
+            ptr_screen_wrapper: 0,
+        };
+
+        assert_eq!(application_y(&state), 0);
+        state.application_view_active = 1;
+        assert_eq!(application_y(&state), 24);
+        state.use_annunciator = 0;
+        assert_eq!(application_y(&state), 0);
+    }
+
+    #[test]
+    fn context_normalization_applies_lgt_view_and_annunciator_coordinates() {
+        let state = LgtGraphicsState {
+            physical_width: 240,
+            physical_height: 320,
+            use_annunciator: 1,
+            application_view_active: 1,
+            ptr_screen_backing: 0,
+            ptr_screen_view: 0,
+            ptr_annunciator_view: 0,
+            ptr_screen_wrapper: 0,
+        };
+        let framebuffer = LgtFramebuffer {
+            owned_image: 0,
+            ptr_graphics: 0,
+            ptr_image: 0,
+            screen_kind: 0,
+        };
+        let view = LgtGraphicsView {
+            ptr_backing: 0,
+            x: 0,
+            y: 24,
+            width: 240,
+            height: 296,
+        };
+        let raw = LgtGraphicsContext {
+            clip_x1: 10,
+            clip_y1: 2,
+            clip_x2: 29,
+            clip_y2: 11,
+            foreground: 0xf800,
+            background: 0,
+            alpha: 255,
+            pixel_op: 0,
+            pixel_param: 0,
+            font: 0,
+            style: 0,
+            xor_enabled: 0,
+            offset_x: 3,
+            offset_y: 4,
+        };
+
+        let normalized = normalize_context(raw, framebuffer, view, state);
+
+        assert_eq!(normalized.clip.x, 10);
+        assert_eq!(normalized.clip.y, 26);
+        assert_eq!(normalized.clip.width, 20);
+        assert_eq!(normalized.clip.height, 10);
+        assert_eq!(normalized.translation_x, 3);
+        assert_eq!(normalized.translation_y, 28);
+        assert_eq!(normalized.foreground, 0xf800);
+    }
+}

--- a/wie_lgt/src/runtime/wipi_c/graphics.rs
+++ b/wie_lgt/src/runtime/wipi_c/graphics.rs
@@ -40,10 +40,19 @@ struct LgtDisplayProperties {
     use_annunciator: u32,
 }
 
-const _: [(); 16] = [(); size_of::<LgtFramebuffer>()];
-const _: [(); 20] = [(); size_of::<LgtGraphicsView>()];
-const _: [(); 8] = [(); size_of::<LgtImage>()];
-const _: [(); 56] = [(); size_of::<LgtGraphicsContext>()];
+// These records are read directly by the LGT native graphics code. Keep the
+// guest ABI sizes explicit so an accidental Rust layout change fails at build time.
+const LGT_FRAMEBUFFER_SIZE: usize = 16;
+const LGT_GRAPHICS_VIEW_SIZE: usize = 20;
+const LGT_IMAGE_SIZE: usize = 8;
+const LGT_GRAPHICS_CONTEXT_SIZE: usize = 56;
+
+const _: () = {
+    assert!(size_of::<LgtFramebuffer>() == LGT_FRAMEBUFFER_SIZE);
+    assert!(size_of::<LgtGraphicsView>() == LGT_GRAPHICS_VIEW_SIZE);
+    assert!(size_of::<LgtImage>() == LGT_IMAGE_SIZE);
+    assert!(size_of::<LgtGraphicsContext>() == LGT_GRAPHICS_CONTEXT_SIZE);
+};
 
 struct ResolvedFramebuffer {
     framebuffer: FrameBuffer,

--- a/wie_lgt/tests/test_helloworld.rs
+++ b/wie_lgt/tests/test_helloworld.rs
@@ -29,7 +29,9 @@ pub fn test_helloworld() -> Result<()> {
 
     let platform = Box::new(TestPlatform::with_event_handler(event_handler));
 
-    let archive = extract_zip(include_bytes!("../../test_data/helloworld_lgt.zip"))?;
+    let mut archive = extract_zip(include_bytes!("../../test_data/helloworld_lgt.zip"))?;
+    let jar = archive.remove("00000000.jar").unwrap();
+    archive.insert("application.jar".into(), jar);
     let mut emulator = LgtEmulator::from_archive(
         platform,
         archive,

--- a/wie_wipi_c/src/api/graphics.rs
+++ b/wie_wipi_c/src/api/graphics.rs
@@ -1,18 +1,18 @@
 mod framebuffer;
 mod grp_context;
 mod image;
+pub mod primitives;
 
 pub use framebuffer::FrameBuffer;
+pub use image::decode_image_framebuffer;
 
 use core::mem::size_of;
 
-use alloc::vec;
-
 use wie_backend::{
     Event,
-    canvas::{Clip, Color, PixelType, Rgb8Pixel, Rgb565Pixel, TextAlignment, string_width},
+    canvas::{Clip, Color, PixelType, Rgb565Pixel, string_width},
 };
-use wie_util::{Result, read_generic, read_null_terminated_string_bytes, write_generic};
+use wie_util::{Result, read_generic, write_generic};
 
 use wipi_types::wipic::{WIPICDisplayInfo, WIPICFramebuffer, WIPICGraphicsContext, WIPICImage, WIPICIndirectPtr, WIPICWord};
 
@@ -106,9 +106,10 @@ pub async fn put_pixel(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst_fb)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, p_gctx)?;
 
-    let mut canvas = framebuffer.canvas(context)?;
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.put_pixel(
+    primitives::put_pixel(
+        context,
+        &framebuffer,
         x as _,
         y as _,
         color,
@@ -118,10 +119,7 @@ pub async fn put_pixel(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
             width: framebuffer.0.width,
             height: framebuffer.0.height,
         },
-    );
-    canvas.flush()?;
-
-    Ok(())
+    )
 }
 
 pub async fn fill_rect(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr, x: i32, y: i32, w: i32, h: i32, p_gctx: WIPICWord) -> Result<()> {
@@ -133,8 +131,6 @@ pub async fn fill_rect(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst_fb)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, p_gctx)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: x as _,
         y: y as _,
@@ -143,10 +139,7 @@ pub async fn fill_rect(context: &mut dyn WIPICContext, dst_fb: WIPICIndirectPtr,
     };
 
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.fill_rect(x as _, y as _, w as _, h as _, color, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::fill_rect(context, &framebuffer, x, y, w as u32, h as u32, color, clip)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -169,8 +162,6 @@ pub async fn draw_arc(
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, p_gctx)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: x as _,
         y: y as _,
@@ -179,10 +170,7 @@ pub async fn draw_arc(
     };
 
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.draw_arc(x as _, y as _, w as _, h as _, start_angle, arc_angle, color, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::draw_arc(context, &framebuffer, x, y, w as u32, h as u32, start_angle, arc_angle, color, clip)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -205,8 +193,6 @@ pub async fn fill_arc(
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, p_gctx)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: x as _,
         y: y as _,
@@ -215,10 +201,7 @@ pub async fn fill_arc(
     };
 
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.fill_arc(x as _, y as _, w as _, h as _, start_angle, arc_angle, color, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::fill_arc(context, &framebuffer, x, y, w as u32, h as u32, start_angle, arc_angle, color, clip)
 }
 
 pub async fn create_image(
@@ -270,8 +253,6 @@ pub async fn draw_image(
     let image: WIPICImage = read_generic(context, context.data_ptr(image)?)?;
 
     let src_image = FrameBuffer(image.img).image(context)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: dx as _,
         y: dy as _,
@@ -279,10 +260,7 @@ pub async fn draw_image(
         height: h as _,
     };
 
-    canvas.draw(dx as _, dy as _, w as _, h as _, &*src_image, sx as _, sy as _, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::draw_image(context, &framebuffer, dx, dy, w as u32, h as u32, &*src_image, sx, sy, clip)
 }
 
 pub async fn flush_lcd(
@@ -382,9 +360,6 @@ pub async fn copy_area(
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
 
-    let image = framebuffer.image(context)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: dx as _,
         y: dy as _,
@@ -392,10 +367,7 @@ pub async fn copy_area(
         height: h as _,
     };
 
-    canvas.draw(dx as _, dy as _, w as _, h as _, &*image, x as _, y as _, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::copy_area(context, &framebuffer, dx, dy, w as u32, h as u32, x, y, clip)
 }
 
 pub async fn create_offscreen_framebuffer(context: &mut dyn WIPICContext, w: i32, h: i32) -> Result<WIPICIndirectPtr> {
@@ -439,9 +411,6 @@ pub async fn copy_frame_buffer(
     let src_framebuffer = FrameBuffer(read_generic(context, context.data_ptr(src)?)?);
     let dst_framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
 
-    let src_image = src_framebuffer.image(context)?;
-    let mut dst_canvas = dst_framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: dx as _,
         y: dy as _,
@@ -449,10 +418,7 @@ pub async fn copy_frame_buffer(
         height: h as _,
     };
 
-    dst_canvas.draw(dx as _, dy as _, w as _, h as _, &*src_image, sx as _, sy as _, clip);
-    dst_canvas.flush()?;
-
-    Ok(())
+    primitives::copy_framebuffer(context, &dst_framebuffer, dx, dy, w as u32, h as u32, &src_framebuffer, sx, sy, clip)
 }
 
 pub async fn get_font(_: &mut dyn WIPICContext, face: i32, size: i32, style: i32) -> Result<i32> {
@@ -482,18 +448,10 @@ pub async fn get_font_descent(_: &mut dyn WIPICContext, font: i32) -> Result<i32
 pub async fn get_string_width(context: &mut dyn WIPICContext, font: i32, ptr_string: WIPICWord, length: i32) -> Result<i32> {
     tracing::debug!("MC_grpGetStringWidth({font}, {ptr_string:#x}, {length})");
 
-    let bytes = if length == -1 {
-        read_null_terminated_string_bytes(context, ptr_string)?
-    } else {
-        let mut bytes = vec![0u8; length as usize];
-        context.read_bytes(ptr_string, &mut bytes)?;
-
-        bytes
+    let Some(string) = primitives::read_text(context, ptr_string, length)? else {
+        return Ok(0);
     };
-
-    let s = encoding_rs::EUC_KR.decode(&bytes).0;
-
-    Ok(string_width(&s, 10.0) as i32)
+    Ok(string_width(&string, 10.0) as i32)
 }
 
 pub async fn draw_string(
@@ -507,16 +465,9 @@ pub async fn draw_string(
 ) -> Result<()> {
     tracing::debug!("MC_grpDrawString({:#x}, {x}, {y}, {ptr_string:#x}, {length}, {pgc:#x})", dst.0);
 
-    let bytes = if length == -1 {
-        read_null_terminated_string_bytes(context, ptr_string)?
-    } else {
-        let mut bytes = vec![0u8; length as usize];
-        context.read_bytes(ptr_string, &mut bytes)?;
-
-        bytes
+    let Some(string) = primitives::read_text(context, ptr_string, length)? else {
+        return Ok(());
     };
-
-    let s = encoding_rs::EUC_KR.decode(&bytes).0;
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, pgc)?;
@@ -528,12 +479,8 @@ pub async fn draw_string(
         height: framebuffer.0.height,
     };
 
-    let mut canvas = framebuffer.canvas(context)?;
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.draw_text(&s, x, y, TextAlignment::Left, color, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::draw_text(context, &framebuffer, &string, x, y, color, clip)
 }
 
 pub async fn repaint(context: &mut dyn WIPICContext, lcd: i32, x: i32, y: i32, width: i32, height: i32) -> Result<()> {
@@ -558,52 +505,12 @@ pub async fn get_rgb_pixels(
     ipl: i32,
 ) -> Result<()> {
     tracing::debug!("MC_grpGetRGBPixels({:#x}, {x}, {y}, {w}, {h}, {pd:#x}, {ipl})", src.0);
-
-    let row_bytes = match (w as i64).checked_mul(4) {
-        Some(n) if w > 0 && h > 0 => n as i32,
-        _ => return Ok(()),
-    };
-    if ipl < row_bytes {
-        tracing::warn!("MC_grpGetRGBPixels: invalid ipl {ipl} (need >= {row_bytes})");
+    if w <= 0 || h <= 0 {
         return Ok(());
     }
-
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(src)?)?);
     let image = framebuffer.image(context)?;
-
-    let mut row = vec![0u8; row_bytes as usize];
-    for dy in 0..h {
-        for dx in 0..w {
-            let sx = x + dx;
-            let sy = y + dy;
-            let color = if sx < 0 || sy < 0 || sx >= image.width() as i32 || sy >= image.height() as i32 {
-                Color { a: 0, r: 0, g: 0, b: 0 }
-            } else {
-                image.get_pixel(sx, sy)
-            };
-            // WIPI spec: pixels are 0x00RRGGBB (top byte zero).
-            let rgb = Rgb8Pixel::from_color(color);
-            let off = (dx as usize) * 4;
-            row[off..off + 4].copy_from_slice(&rgb.to_le_bytes());
-        }
-        let row_offset = match (dy as u32).checked_mul(ipl as u32) {
-            Some(n) => n,
-            None => {
-                tracing::warn!("MC_grpGetRGBPixels: row offset overflow (dy={dy}, ipl={ipl})");
-                return Ok(());
-            }
-        };
-        let dst_addr = match pd.checked_add(row_offset) {
-            Some(n) => n,
-            None => {
-                tracing::warn!("MC_grpGetRGBPixels: destination address overflow (pd={pd:#x}, row_offset={row_offset})");
-                return Ok(());
-            }
-        };
-        context.write_bytes(dst_addr, &row)?;
-    }
-
-    Ok(())
+    primitives::get_rgb_pixels(context, &*image, x, y, w, h, pd, ipl)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -619,69 +526,18 @@ pub async fn set_rgb_pixels(
     _pgc: WIPICWord,
 ) -> Result<()> {
     tracing::debug!("MC_grpSetRGBPixels({:#x}, {x}, {y}, {w}, {h}, {psrc:#x}, {ibpl})", dst.0);
-
     if w <= 0 || h <= 0 {
         return Ok(());
     }
-    let row_bytes = match (w as usize).checked_mul(4) {
-        Some(n) => n,
-        None => {
-            tracing::warn!("MC_grpSetRGBPixels: row size overflow (w={w})");
-            return Ok(());
-        }
-    };
-    if ibpl < row_bytes as i32 {
-        tracing::warn!("MC_grpSetRGBPixels: invalid ibpl {ibpl} (need >= {row_bytes})");
-        return Ok(());
-    }
-    let total_bytes = match row_bytes.checked_mul(h as usize) {
-        Some(n) => n,
-        None => {
-            tracing::warn!("MC_grpSetRGBPixels: total size overflow (w={w}, h={h})");
-            return Ok(());
-        }
-    };
-
-    let mut buf = vec![0u8; total_bytes];
-    for dy in 0..h {
-        let off = (dy as usize) * row_bytes;
-        let row_offset = match (dy as u32).checked_mul(ibpl as u32) {
-            Some(n) => n,
-            None => {
-                tracing::warn!("MC_grpSetRGBPixels: row offset overflow (dy={dy}, ibpl={ibpl})");
-                return Ok(());
-            }
-        };
-        let src_addr = match psrc.checked_add(row_offset) {
-            Some(n) => n,
-            None => {
-                tracing::warn!("MC_grpSetRGBPixels: source address overflow (psrc={psrc:#x}, row_offset={row_offset})");
-                return Ok(());
-            }
-        };
-        context.read_bytes(src_addr, &mut buf[off..off + row_bytes])?;
-    }
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
-    let mut canvas = framebuffer.canvas(context)?;
     let clip = Clip {
         x: 0,
         y: 0,
         width: framebuffer.0.width,
         height: framebuffer.0.height,
     };
-    for dy in 0..h {
-        for dx in 0..w {
-            let off = ((dy as usize) * (w as usize) + dx as usize) * 4;
-            // WIPI spec: pixels are 0x00RRGGBB.
-            let rgb = u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]]);
-            let color = Rgb8Pixel::to_color(rgb);
-            canvas.put_pixel(x + dx, y + dy, color, clip);
-        }
-    }
-    canvas.flush()?;
-
-    Ok(())
+    primitives::set_rgb_pixels(context, &framebuffer, x, y, w, h, psrc, ibpl, clip)
 }
 
 pub async fn get_image_framebuffer(_context: &mut dyn WIPICContext, image: WIPICIndirectPtr) -> Result<WIPICIndirectPtr> {
@@ -716,8 +572,6 @@ pub async fn draw_rect(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x:
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, pgc)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: x as _,
         y: y as _,
@@ -726,10 +580,7 @@ pub async fn draw_rect(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x:
     };
 
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.draw_rect(x as _, y as _, w as _, h as _, color, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::draw_rect(context, &framebuffer, x, y, w as u32, h as u32, color, clip)
 }
 
 pub async fn draw_line(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x1: i32, y1: i32, x2: i32, y2: i32, pgc: WIPICWord) -> Result<()> {
@@ -737,8 +588,6 @@ pub async fn draw_line(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x1
 
     let framebuffer = FrameBuffer(read_generic(context, context.data_ptr(dst)?)?);
     let gctx: WIPICGraphicsContext = read_generic(context, pgc)?;
-    let mut canvas = framebuffer.canvas(context)?;
-
     let clip = Clip {
         x: 0,
         y: 0,
@@ -747,10 +596,7 @@ pub async fn draw_line(context: &mut dyn WIPICContext, dst: WIPICIndirectPtr, x1
     };
 
     let color = framebuffer.pixel_to_color(gctx.fgpxl);
-    canvas.draw_line(x1 as _, y1 as _, x2 as _, y2 as _, color, clip);
-    canvas.flush()?;
-
-    Ok(())
+    primitives::draw_line(context, &framebuffer, x1, y1, x2, y2, color, clip)
 }
 
 pub async fn post_event(context: &mut dyn WIPICContext, id: i32, r#type: i32, param1: i32, param2: i32) -> Result<i32> {

--- a/wie_wipi_c/src/api/graphics.rs
+++ b/wie_wipi_c/src/api/graphics.rs
@@ -2,6 +2,8 @@ mod framebuffer;
 mod grp_context;
 mod image;
 
+pub use framebuffer::FrameBuffer;
+
 use core::mem::size_of;
 
 use alloc::vec;
@@ -16,7 +18,7 @@ use wipi_types::wipic::{WIPICDisplayInfo, WIPICFramebuffer, WIPICGraphicsContext
 
 use crate::context::WIPICContext;
 
-use self::{framebuffer::FrameBuffer, grp_context::WIPICGraphicsContextIdx, image::create_wipi_image};
+use self::{grp_context::WIPICGraphicsContextIdx, image::create_wipi_image};
 
 const FRAMEBUFFER_DEPTH: u32 = 16; // XXX hardcode to 16bpp as some game requires 16bpp framebuffer
 const SCREEN_FRAMEBUFFER_PTR: u32 = 0x7fff1000;

--- a/wie_wipi_c/src/api/graphics/image.rs
+++ b/wie_wipi_c/src/api/graphics/image.rs
@@ -1,20 +1,14 @@
 use alloc::vec;
 
 use wie_backend::canvas::decode_image;
-use wie_util::Result;
+use wie_util::{Result, WieError};
 
 use wipi_types::wipic::{WIPICImage, WIPICIndirectPtr, WIPICWord};
 
 use crate::{api::graphics::framebuffer::FrameBuffer, context::WIPICContext};
 
 pub fn create_wipi_image(context: &mut dyn WIPICContext, buf: WIPICIndirectPtr, offset: WIPICWord, len: WIPICWord) -> Result<WIPICImage> {
-    let ptr_image_data = context.data_ptr(buf)?;
-
-    let mut data = vec![0; len as _];
-    context.read_bytes(ptr_image_data + offset, &mut data)?;
-    let image = decode_image(&data)?;
-
-    let img_framebuffer = FrameBuffer::from_image(context, &*image)?;
+    let img_framebuffer = decode_image_framebuffer(context, buf, offset, len)?;
     let mask_framebuffer = FrameBuffer::empty();
 
     Ok(WIPICImage {
@@ -28,4 +22,12 @@ pub fn create_wipi_image(context: &mut dyn WIPICContext, buf: WIPICIndirectPtr, 
         current: 0,
         len,
     })
+}
+
+pub fn decode_image_framebuffer(context: &mut dyn WIPICContext, buf: WIPICIndirectPtr, offset: WIPICWord, len: WIPICWord) -> Result<FrameBuffer> {
+    let address = context.data_ptr(buf)?.checked_add(offset).ok_or(WieError::AllocationFailure)?;
+    let mut data = vec![0; len as usize];
+    context.read_bytes(address, &mut data)?;
+    let image = decode_image(&data)?;
+    FrameBuffer::from_image(context, &*image)
 }

--- a/wie_wipi_c/src/api/graphics/primitives.rs
+++ b/wie_wipi_c/src/api/graphics/primitives.rs
@@ -1,0 +1,368 @@
+#![allow(clippy::too_many_arguments)]
+
+use alloc::{string::String, vec};
+
+use wie_backend::canvas::{Clip, Color, Image, PixelType, Rgb8Pixel};
+use wie_util::{Result, read_null_terminated_string_bytes};
+
+use crate::{WIPICContext, api::graphics::FrameBuffer};
+
+pub fn read_text(context: &dyn WIPICContext, address: u32, length: i32) -> Result<Option<String>> {
+    let bytes = if length == -1 {
+        read_null_terminated_string_bytes(context, address)?
+    } else if length >= 0 {
+        let mut bytes = vec![0; length as usize];
+        context.read_bytes(address, &mut bytes)?;
+        bytes
+    } else {
+        return Ok(None);
+    };
+
+    Ok(Some(encoding_rs::EUC_KR.decode(&bytes).0.into_owned()))
+}
+
+fn write_canvas<F>(context: &mut dyn WIPICContext, framebuffer: &FrameBuffer, operation: F) -> Result<()>
+where
+    F: FnOnce(&mut dyn wie_backend::canvas::Canvas),
+{
+    let mut canvas = framebuffer.canvas(context)?;
+    operation(&mut **canvas);
+    canvas.flush()
+}
+
+pub fn put_pixel(context: &mut dyn WIPICContext, framebuffer: &FrameBuffer, x: i32, y: i32, color: Color, clip: Clip) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| canvas.put_pixel(x, y, color, clip))
+}
+
+pub fn fill_rect(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    color: Color,
+    clip: Clip,
+) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| canvas.fill_rect(x, y, width, height, color, clip))
+}
+
+pub fn draw_line(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+    color: Color,
+    clip: Clip,
+) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| canvas.draw_line(x1, y1, x2, y2, color, clip))
+}
+
+pub fn draw_rect(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    color: Color,
+    clip: Clip,
+) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| canvas.draw_rect(x, y, width, height, color, clip))
+}
+
+pub fn draw_arc(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    start_angle: i32,
+    arc_angle: i32,
+    color: Color,
+    clip: Clip,
+) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| {
+        canvas.draw_arc(x, y, width, height, start_angle, arc_angle, color, clip)
+    })
+}
+
+pub fn fill_arc(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    start_angle: i32,
+    arc_angle: i32,
+    color: Color,
+    clip: Clip,
+) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| {
+        canvas.fill_arc(x, y, width, height, start_angle, arc_angle, color, clip)
+    })
+}
+
+pub fn draw_image(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    image: &dyn Image,
+    source_x: i32,
+    source_y: i32,
+    clip: Clip,
+) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| {
+        canvas.draw(x, y, width, height, image, source_x, source_y, clip)
+    })
+}
+
+pub fn copy_area(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    source_x: i32,
+    source_y: i32,
+    clip: Clip,
+) -> Result<()> {
+    let image = framebuffer.image(context)?;
+    write_canvas(context, framebuffer, |canvas| {
+        canvas.draw(x, y, width, height, &*image, source_x, source_y, clip)
+    })
+}
+
+pub fn copy_framebuffer(
+    context: &mut dyn WIPICContext,
+    destination: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    source: &FrameBuffer,
+    source_x: i32,
+    source_y: i32,
+    clip: Clip,
+) -> Result<()> {
+    let image = source.image(context)?;
+    write_canvas(context, destination, |canvas| {
+        canvas.draw(x, y, width, height, &*image, source_x, source_y, clip)
+    })
+}
+
+pub fn draw_text(context: &mut dyn WIPICContext, framebuffer: &FrameBuffer, string: &str, x: i32, y: i32, color: Color, clip: Clip) -> Result<()> {
+    write_canvas(context, framebuffer, |canvas| {
+        canvas.draw_text(string, x, y, wie_backend::canvas::TextAlignment::Left, color, clip)
+    })
+}
+
+fn rgb_row_bytes(width: i32, stride: i32) -> Option<usize> {
+    if width <= 0 || stride <= 0 {
+        return None;
+    }
+
+    let row_bytes = (width as usize).checked_mul(4)?;
+    (stride as usize >= row_bytes).then_some(row_bytes)
+}
+
+pub fn get_rgb_pixels(
+    context: &mut dyn WIPICContext,
+    image: &dyn Image,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    destination: u32,
+    destination_bpl: i32,
+) -> Result<()> {
+    if height <= 0 {
+        return Ok(());
+    }
+    let Some(row_bytes) = rgb_row_bytes(width, destination_bpl) else {
+        return Ok(());
+    };
+
+    let mut row = vec![0; row_bytes];
+    for row_index in 0..height {
+        for column in 0..width {
+            let source_x = x.wrapping_add(column);
+            let source_y = y.wrapping_add(row_index);
+            let color = if source_x < 0 || source_y < 0 || source_x >= image.width() as i32 || source_y >= image.height() as i32 {
+                Color { a: 0, r: 0, g: 0, b: 0 }
+            } else {
+                image.get_pixel(source_x, source_y)
+            };
+            let offset = column as usize * 4;
+            row[offset..offset + 4].copy_from_slice(&Rgb8Pixel::from_color(color).to_le_bytes());
+        }
+        let address = destination
+            .checked_add(
+                (row_index as u32)
+                    .checked_mul(destination_bpl as u32)
+                    .ok_or(wie_util::WieError::AllocationFailure)?,
+            )
+            .ok_or(wie_util::WieError::AllocationFailure)?;
+        context.write_bytes(address, &row)?;
+    }
+    Ok(())
+}
+
+pub fn set_rgb_pixels(
+    context: &mut dyn WIPICContext,
+    framebuffer: &FrameBuffer,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    source: u32,
+    source_bpl: i32,
+    clip: Clip,
+) -> Result<()> {
+    if height <= 0 {
+        return Ok(());
+    }
+    let Some(row_bytes) = rgb_row_bytes(width, source_bpl) else {
+        return Ok(());
+    };
+    let Some(total_bytes) = row_bytes.checked_mul(height as usize) else {
+        return Ok(());
+    };
+
+    let mut pixels = vec![0; total_bytes];
+    for row_index in 0..height {
+        let address = source
+            .checked_add(
+                (row_index as u32)
+                    .checked_mul(source_bpl as u32)
+                    .ok_or(wie_util::WieError::AllocationFailure)?,
+            )
+            .ok_or(wie_util::WieError::AllocationFailure)?;
+        let offset = row_index as usize * row_bytes;
+        context.read_bytes(address, &mut pixels[offset..offset + row_bytes])?;
+    }
+
+    write_canvas(context, framebuffer, |canvas| {
+        for row_index in 0..height {
+            let row_offset = row_index as usize * row_bytes;
+            let row = &pixels[row_offset..row_offset + row_bytes];
+            for column in 0..width {
+                let offset = column as usize * 4;
+                let rgb = u32::from_le_bytes([row[offset], row[offset + 1], row[offset + 2], row[offset + 3]]);
+                canvas.put_pixel(x.wrapping_add(column), y.wrapping_add(row_index), Rgb8Pixel::to_color(rgb), clip);
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use wie_backend::canvas::{Clip, Color};
+    use wie_util::{ByteRead, ByteWrite, Result};
+
+    use crate::{
+        api::graphics::{
+            FrameBuffer,
+            primitives::{fill_rect, get_rgb_pixels, put_pixel, set_rgb_pixels},
+        },
+        context::{WIPICContext, test::TestContext},
+    };
+
+    #[test]
+    fn drawing_primitives_write_the_guest_framebuffer() -> Result<()> {
+        let mut context = TestContext::new();
+        let framebuffer = FrameBuffer::new(&mut context, 4, 4, 16)?;
+        let clip = Clip {
+            x: 0,
+            y: 0,
+            width: 4,
+            height: 4,
+        };
+        let red = Color {
+            a: 0xff,
+            r: 0xff,
+            g: 0,
+            b: 0,
+        };
+
+        fill_rect(&mut context, &framebuffer, 1, 1, 2, 2, red, clip)?;
+        put_pixel(&mut context, &framebuffer, 0, 0, red, clip)?;
+
+        let image = framebuffer.image(&mut context)?;
+        assert_eq!(image.get_pixel(0, 0).r, 255);
+        assert_eq!(image.get_pixel(1, 1).r, 255);
+        assert_eq!(image.get_pixel(3, 3).r, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn rgb_pixels_use_the_wipi_little_endian_layout() -> Result<()> {
+        let mut context = TestContext::new();
+        let framebuffer = FrameBuffer::new(&mut context, 1, 1, 16)?;
+        put_pixel(
+            &mut context,
+            &framebuffer,
+            0,
+            0,
+            Color {
+                a: 0xff,
+                r: 0xff,
+                g: 0,
+                b: 0,
+            },
+            Clip {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+        )?;
+        let image = framebuffer.image(&mut context)?;
+
+        get_rgb_pixels(&mut context, &*image, 0, 0, 1, 1, 0x1000, 4)?;
+        let mut bytes = [0; 4];
+        context.read_bytes(0x1000, &mut bytes)?;
+        assert_eq!(u32::from_le_bytes(bytes), 0x00ff_0000);
+        Ok(())
+    }
+
+    #[test]
+    fn rgb_row_bytes_rejects_overflow_and_short_strides() {
+        assert_eq!(super::rgb_row_bytes(i32::MAX, i32::MAX), None);
+        assert_eq!(super::rgb_row_bytes(4, 15), None);
+        assert_eq!(super::rgb_row_bytes(4, 16), Some(16));
+    }
+
+    #[test]
+    fn set_rgb_pixels_wraps_guest_coordinates() -> Result<()> {
+        let mut context = TestContext::new();
+        let framebuffer = FrameBuffer::new(&mut context, 1, 1, 16)?;
+        let source = context.alloc(8)?;
+        context.write_bytes(context.data_ptr(source)?, &[0, 0, 0, 0, 0, 0, 0, 0])?;
+
+        set_rgb_pixels(
+            &mut context,
+            &framebuffer,
+            i32::MAX,
+            0,
+            2,
+            1,
+            source.0,
+            8,
+            Clip {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+        )
+    }
+}

--- a/wie_wipi_c/src/api/kernel.rs
+++ b/wie_wipi_c/src/api/kernel.rs
@@ -5,18 +5,13 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{
-    future::{Ready, ready},
-    iter,
-};
+use core::iter;
 
 use bytemuck::{Pod, Zeroable};
 
 use wipi_types::wipic::{WIPICIndirectPtr, WIPICWord};
 
-use wie_util::{
-    ByteRead, ByteWrite, Result, WieError, read_generic, read_null_terminated_string_bytes, write_generic, write_null_terminated_string_bytes,
-};
+use wie_util::{Result, WieError, read_generic, read_null_terminated_string_bytes, write_generic, write_null_terminated_string_bytes};
 
 use crate::{WIPICResult, context::WIPICContext, method::MethodBody};
 
@@ -236,8 +231,8 @@ pub async fn printk(context: &mut dyn WIPICContext, ptr_format: WIPICWord, a0: W
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn sprintk<C: ByteRead + ByteWrite + Send + Sync + ?Sized>(
-    context: &mut C,
+pub async fn sprintk(
+    context: &mut dyn WIPICContext,
     dest: WIPICWord,
     ptr_format: WIPICWord,
     a0: WIPICWord,
@@ -246,16 +241,15 @@ pub fn sprintk<C: ByteRead + ByteWrite + Send + Sync + ?Sized>(
     a3: WIPICWord,
     a4: WIPICWord,
     a5: WIPICWord,
-) -> Ready<Result<WIPICWord>> {
+) -> Result<WIPICWord> {
     tracing::debug!("MC_knlSprintk({dest:#x}, {ptr_format:#x}, {a1}, {a2}, {a3}, {a4}, {a5})",);
 
-    let result = read_null_terminated_string_bytes(context, ptr_format).and_then(|format_string| {
-        let result = sprintf(context, &format_string, &[a0, a1, a2, a3, a4, a5])?;
-        write_null_terminated_string_bytes(context, dest, &result)?;
-        Ok(result.len() as _)
-    });
+    let format_string = read_null_terminated_string_bytes(context, ptr_format)?;
+    let result = sprintf(context, &format_string, &[a0, a1, a2, a3, a4, a5])?;
 
-    ready(result)
+    write_null_terminated_string_bytes(context, dest, &result)?;
+
+    Ok(result.len() as _)
 }
 
 pub async fn get_total_memory(_context: &mut dyn WIPICContext) -> Result<i32> {
@@ -302,11 +296,11 @@ pub async fn get_program_name(context: &mut dyn WIPICContext, name_buf: WIPICWor
 
 #[cfg(test)]
 mod test {
-    use alloc::string::String;
+    use alloc::{boxed::Box, string::String};
 
     use wie_util::{ByteRead, ByteWrite, Result, read_null_terminated_string_bytes, write_null_terminated_string_bytes};
 
-    use crate::{WIPICContext, context::test::TestContext};
+    use crate::{WIPICContext, context::test::TestContext, method::MethodImpl};
 
     use super::{alloc, calloc, free, get_resource, get_resource_id, get_system_property, sprintk};
 
@@ -314,16 +308,24 @@ mod test {
     async fn test_sprintk() -> Result<()> {
         let mut context = TestContext::new();
 
+        let sprintk = sprintk.into_body();
+
         let format = context.alloc_raw(10).unwrap();
         let dest = context.alloc_raw(10).unwrap();
 
         write_null_terminated_string_bytes(&mut context, format, "%d".as_bytes()).unwrap();
-        sprintk(&mut context, dest, format, 1234, 0, 0, 0, 0, 0).await.unwrap();
+        sprintk
+            .call(&mut context, Box::new([dest, format, 1234, 0, 0, 0, 0, 0, 0, 0]))
+            .await
+            .unwrap();
         let result = read_null_terminated_string_bytes(&context, dest).unwrap();
         assert_eq!(String::from_utf8(result).unwrap(), "1234");
 
         write_null_terminated_string_bytes(&mut context, format, "test %02d".as_bytes()).unwrap();
-        sprintk(&mut context, dest, format, 1, 0, 0, 0, 0, 0).await.unwrap();
+        sprintk
+            .call(&mut context, Box::new([dest, format, 1, 0, 0, 0, 0, 0, 0, 0]))
+            .await
+            .unwrap();
         let result = read_null_terminated_string_bytes(&context, dest).unwrap();
         assert_eq!(String::from_utf8(result).unwrap(), "test 01");
 

--- a/wie_wipi_c/src/api/kernel.rs
+++ b/wie_wipi_c/src/api/kernel.rs
@@ -5,17 +5,22 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::iter;
+use core::{
+    future::{Ready, ready},
+    iter,
+};
 
 use bytemuck::{Pod, Zeroable};
 
 use wipi_types::wipic::{WIPICIndirectPtr, WIPICWord};
 
-use wie_util::{Result, WieError, read_generic, read_null_terminated_string_bytes, write_generic, write_null_terminated_string_bytes};
+use wie_util::{
+    ByteRead, ByteWrite, Result, WieError, read_generic, read_null_terminated_string_bytes, write_generic, write_null_terminated_string_bytes,
+};
 
 use crate::{WIPICResult, context::WIPICContext, method::MethodBody};
 
-use self::sprintf::sprintf;
+pub use self::sprintf::sprintf;
 
 #[repr(C, packed)]
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -222,9 +227,8 @@ pub async fn printk(context: &mut dyn WIPICContext, ptr_format: WIPICWord, a0: W
     tracing::debug!("MC_knlPrintk({ptr_format:#x}, {a0:#x}, {a1:#x}, {a2:#x}, {a3:#x})");
 
     let format_string = read_null_terminated_string_bytes(context, ptr_format)?;
-    let format_string = encoding_rs::EUC_KR.decode(&format_string).0;
-
     let result = sprintf(context, &format_string, &[a0, a1, a2, a3])?;
+    let result = encoding_rs::EUC_KR.decode(&result).0;
 
     context.system().platform().write_stdout(result.as_bytes());
 
@@ -232,8 +236,8 @@ pub async fn printk(context: &mut dyn WIPICContext, ptr_format: WIPICWord, a0: W
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn sprintk(
-    context: &mut dyn WIPICContext,
+pub fn sprintk<C: ByteRead + ByteWrite + Send + Sync + ?Sized>(
+    context: &mut C,
     dest: WIPICWord,
     ptr_format: WIPICWord,
     a0: WIPICWord,
@@ -242,19 +246,16 @@ pub async fn sprintk(
     a3: WIPICWord,
     a4: WIPICWord,
     a5: WIPICWord,
-) -> Result<WIPICWord> {
+) -> Ready<Result<WIPICWord>> {
     tracing::debug!("MC_knlSprintk({dest:#x}, {ptr_format:#x}, {a1}, {a2}, {a3}, {a4}, {a5})",);
 
-    let format_string = read_null_terminated_string_bytes(context, ptr_format)?;
-    let format_string = encoding_rs::EUC_KR.decode(&format_string).0;
+    let result = read_null_terminated_string_bytes(context, ptr_format).and_then(|format_string| {
+        let result = sprintf(context, &format_string, &[a0, a1, a2, a3, a4, a5])?;
+        write_null_terminated_string_bytes(context, dest, &result)?;
+        Ok(result.len() as _)
+    });
 
-    let result = sprintf(context, &format_string, &[a0, a1, a2, a3, a4, a5])?;
-
-    let result_bytes = encoding_rs::EUC_KR.encode(&result).0;
-
-    write_null_terminated_string_bytes(context, dest, &result_bytes)?;
-
-    Ok(result.len() as _)
+    ready(result)
 }
 
 pub async fn get_total_memory(_context: &mut dyn WIPICContext) -> Result<i32> {
@@ -301,11 +302,11 @@ pub async fn get_program_name(context: &mut dyn WIPICContext, name_buf: WIPICWor
 
 #[cfg(test)]
 mod test {
-    use alloc::{boxed::Box, string::String};
+    use alloc::string::String;
 
     use wie_util::{ByteRead, ByteWrite, Result, read_null_terminated_string_bytes, write_null_terminated_string_bytes};
 
-    use crate::{WIPICContext, context::test::TestContext, method::MethodImpl};
+    use crate::{WIPICContext, context::test::TestContext};
 
     use super::{alloc, calloc, free, get_resource, get_resource_id, get_system_property, sprintk};
 
@@ -313,24 +314,16 @@ mod test {
     async fn test_sprintk() -> Result<()> {
         let mut context = TestContext::new();
 
-        let sprintk = sprintk.into_body();
-
         let format = context.alloc_raw(10).unwrap();
         let dest = context.alloc_raw(10).unwrap();
 
         write_null_terminated_string_bytes(&mut context, format, "%d".as_bytes()).unwrap();
-        sprintk
-            .call(&mut context, Box::new([dest, format, 1234, 0, 0, 0, 0, 0, 0, 0]))
-            .await
-            .unwrap();
+        sprintk(&mut context, dest, format, 1234, 0, 0, 0, 0, 0).await.unwrap();
         let result = read_null_terminated_string_bytes(&context, dest).unwrap();
         assert_eq!(String::from_utf8(result).unwrap(), "1234");
 
         write_null_terminated_string_bytes(&mut context, format, "test %02d".as_bytes()).unwrap();
-        sprintk
-            .call(&mut context, Box::new([dest, format, 1, 0, 0, 0, 0, 0, 0, 0]))
-            .await
-            .unwrap();
+        sprintk(&mut context, dest, format, 1, 0, 0, 0, 0, 0).await.unwrap();
         let result = read_null_terminated_string_bytes(&context, dest).unwrap();
         assert_eq!(String::from_utf8(result).unwrap(), "test 01");
 

--- a/wie_wipi_c/src/api/kernel/sprintf.rs
+++ b/wie_wipi_c/src/api/kernel/sprintf.rs
@@ -1,17 +1,18 @@
-use alloc::{format, string::String};
+use alloc::{format, string::String, vec::Vec};
 
-use wie_util::{Result, read_null_terminated_string_bytes};
-
-use crate::context::WIPICContext;
+use wie_util::{ByteRead, Result, read_null_terminated_string_bytes};
 
 const MAX_WIDTH: usize = 4096;
 
-pub fn sprintf(context: &mut dyn WIPICContext, format: &str, args: &[u32]) -> Result<String> {
-    self::format(format, args, &mut |ptr| {
+pub fn sprintf(context: &(impl ByteRead + ?Sized), format_bytes: &[u8], args: &[u32]) -> Result<Vec<u8>> {
+    let format_string = encoding_rs::EUC_KR.decode(format_bytes).0;
+    let result = self::format(&format_string, args, &mut |ptr| {
         let bytes = read_null_terminated_string_bytes(context, ptr)?;
 
         Ok(encoding_rs::EUC_KR.decode(&bytes).0.into_owned())
-    })
+    })?;
+
+    Ok(encoding_rs::EUC_KR.encode(&result).0.into_owned())
 }
 
 fn format(format: &str, args: &[u32], read_string: &mut dyn FnMut(u32) -> Result<String>) -> Result<String> {
@@ -126,9 +127,30 @@ fn next_arg64<'a>(arg_iter: &mut impl Iterator<Item = &'a u32>) -> u64 {
 
 #[cfg(test)]
 mod test {
-    use alloc::string::{String, ToString};
+    use alloc::{
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
 
-    use wie_util::Result;
+    use wie_util::{ByteRead, Result, WieError};
+
+    struct GuestMemory {
+        bytes: Vec<u8>,
+    }
+
+    impl ByteRead for GuestMemory {
+        fn read_bytes(&self, address: u32, result: &mut [u8]) -> Result<usize> {
+            let start = address as usize;
+            let end = start + result.len();
+            if end > self.bytes.len() {
+                return Err(WieError::InvalidMemoryAccess(address));
+            }
+
+            result.copy_from_slice(&self.bytes[start..end]);
+            Ok(result.len())
+        }
+    }
 
     fn format(format_string: &str, args: &[u32]) -> Result<String> {
         super::format(format_string, args, &mut |_| Ok("stub".to_string()))
@@ -201,6 +223,23 @@ mod test {
     fn test_string_and_null() -> Result<()> {
         assert_eq!(format("%s!", &[1])?, "stub!");
         assert_eq!(format("%s", &[0])?, "(null)");
+
+        Ok(())
+    }
+
+    #[test]
+    fn sprintf_formats_euc_kr_guest_strings_and_values() -> Result<()> {
+        let mut memory = GuestMemory { bytes: vec![0; 0x100] };
+        let guest_string = encoding_rs::EUC_KR.encode("세계").0;
+        memory.bytes[0x40..0x40 + guest_string.len()].copy_from_slice(&guest_string);
+        memory.bytes[0x40 + guest_string.len()] = 0;
+
+        let format = encoding_rs::EUC_KR.encode("안녕 %s %c %d %u %x").0;
+        let result = super::sprintf(&memory, &format, &[0x40, b'A' as u32, (-7i32) as u32, 42, 0xbeef])?;
+
+        let expected = "안녕 세계 A -7 42 beef";
+        assert_eq!(encoding_rs::EUC_KR.decode(&result).0, expected);
+        assert_eq!(result, encoding_rs::EUC_KR.encode(expected).0.into_owned());
 
         Ok(())
     }

--- a/wie_wipi_c/src/lib.rs
+++ b/wie_wipi_c/src/lib.rs
@@ -6,12 +6,10 @@ mod context;
 mod method;
 
 pub use self::context::{WIPICContext, WIPICResult};
-pub use self::method::MethodImpl;
+pub use self::method::{MethodBody, MethodImpl};
 
 use alloc::boxed::Box;
 
 use wie_util::WieError;
-
-use crate::method::MethodBody;
 
 pub type WIPICMethodBody = Box<dyn MethodBody<WieError>>;

--- a/wie_wipi_java/src/classes/net/wie/card_canvas.rs
+++ b/wie_wipi_java/src/classes/net/wie/card_canvas.rs
@@ -2,16 +2,15 @@ use alloc::vec;
 
 use java_class_proto::{JavaFieldProto, JavaMethodProto};
 use java_constants::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-use java_runtime::classes::java::lang::{Class, String};
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 use wie_midp::classes::{
-    javax::microedition::lcdui::{Canvas as MidpCanvas, Display as MidpDisplay, Graphics as MidpGraphics},
+    javax::microedition::lcdui::{Canvas as MidpCanvas, Graphics as MidpGraphics},
     net::wie::MIDPKeyCode,
 };
 
-use crate::classes::org::kwis::msp::lcdui::{Card, Display};
+use crate::classes::org::kwis::msp::lcdui::Card;
 
 #[repr(i32)]
 #[allow(clippy::upper_case_acronyms, non_camel_case_types)]
@@ -297,26 +296,6 @@ impl CardCanvas {
         let _: () = jvm.invoke_virtual(&c, "org/kwis/msp/lcdui/Card", "showNotify", "(Z)V", (true,)).await?;
 
         let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
-
-        // HACK: disable java level paint on clet app
-        let class: ClassInstanceRef<Class> = jvm
-            .invoke_virtual(&c, "org/kwis/msp/lcdui/Card", "getClass", "()Ljava/lang/Class;", ())
-            .await?;
-        let class_name: ClassInstanceRef<String> = jvm
-            .invoke_virtual(&class, "java/lang/Class", "getName", "()Ljava/lang/String;", ())
-            .await?;
-        let class_name_str = JavaLangString::to_rust_string(jvm, &class_name).await?;
-
-        if class_name_str == "CletCard" || class_name_str == "net/wie/CletWrapperCard" {
-            let wipi_display: ClassInstanceRef<Display> = jvm
-                .invoke_static("org/kwis/msp/lcdui/Display", "getDefaultDisplay", "()Lorg/kwis/msp/lcdui/Display;", ())
-                .await?;
-            let midp_display: ClassInstanceRef<MidpDisplay> =
-                jvm.get_field(&wipi_display, "midpDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-            let _: () = jvm
-                .invoke_virtual(&midp_display, "javax/microedition/lcdui/Display", "disablePaint", "()V", ())
-                .await?;
-        }
 
         Ok(())
     }


### PR DESCRIPTION
- Stop assuming the JAR inside the ZIP has a specific filename, and load it automatically based on what’s actually in the archive.

- Split out LGT’s screen refresh handling, and remove the special-case game detection based on Java class names from the shared canvas. (I tested nearly fifty games, and found essentially no change in these games' screen rendering. If this would lead to the regression of SKT/KTF, please let me know...)

- Expose framebuffer, sprintf, EUC-KR formatting, WIPIC method bodies, and related functionality so LGT can reuse them.

- Implement LGT-specific framebuffer, graphics context, image records, and rendering flow. Also fix UI alignment issues in some games that use a 240×296 resolution with a 24px status bar at the top.

- Implement the missing LGT Sidlib.

- Fix the allocation size and 64-bit element alignment for LGT Java arrays in guest memory, preventing array data from overwriting other memory.

- Add support for the 0xbf00 NOP instruction in Thumb mode, and improve error messages for undefined ARM/Thumb instructions.

About game: LGT Zake2, 