### PR TITLE
Implement MIDP high-level LCDUI screens and items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - Avoid redundant or defensive validation for states already guaranteed by internal types, trusted workflow context, build tools, or a following command that will fail naturally. Add validation only at meaningful external/dynamic boundaries or when it provides required observable behavior.
 - Keep emulated runtime state authoritative in guest memory. Do not add host-side state or metadata registries; host adapters may only reference and operate on guest-backed structures.
 - Do not add special-case branches keyed to a specific application or Java class in shared runtime infrastructure. Represent confirmed ABI differences as data and handle them through generic mechanisms.
+- Use reference implementations only to understand architectural boundaries and responsibilities. Derive API contracts from public specifications and documentation, and implement behavior independently without copying reference implementation code or algorithms.
 
 ## Project Layout
 - `wie-backend`: System-level services for APIs

--- a/test-utils/src/jvm.rs
+++ b/test-utils/src/jvm.rs
@@ -6,7 +6,7 @@ use core::{
 
 use jvm::{Jvm, Result as JvmResult};
 
-use wie_backend::{DefaultTaskRunner, System};
+use wie_backend::{DefaultTaskRunner, Platform, System};
 use wie_jvm_support::{JvmSupport, RustJavaJvmImplementation, WieJavaClassProto};
 use wie_util::{Result, WieError};
 
@@ -18,7 +18,15 @@ where
     T: FnOnce(Jvm) -> F + Send + 'static,
     F: Future<Output = JvmResult<()>> + Send,
 {
-    let mut system = System::new(Box::new(TestPlatform::new()), "", "", DefaultTaskRunner);
+    run_jvm_test_with_system(protos, Box::new(TestPlatform::new()), move |jvm, _system| func(jvm))
+}
+
+pub fn run_jvm_test_with_system<T, F>(protos: Box<[Box<[WieJavaClassProto]>]>, platform: Box<dyn Platform>, func: T) -> Result<()>
+where
+    T: FnOnce(Jvm, System) -> F + Send + 'static,
+    F: Future<Output = JvmResult<()>> + Send,
+{
+    let mut system = System::new(platform, "", "", DefaultTaskRunner);
 
     let done = Arc::new(AtomicBool::new(false));
     let done_clone = done.clone();
@@ -26,7 +34,7 @@ where
 
     system.spawn(async move || {
         let jvm = JvmSupport::new_jvm(&system_clone, None, protos, &[], RustJavaJvmImplementation).await?;
-        func(jvm).await.unwrap();
+        func(jvm, system_clone).await.unwrap();
 
         done_clone.store(true, Ordering::Relaxed);
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -7,6 +7,6 @@ mod platform;
 
 pub use self::{
     filesystem::MemoryFilesystem,
-    jvm::run_jvm_test,
-    platform::{TestPlatform, TestPlatformEvent},
+    jvm::{run_jvm_test, run_jvm_test_with_system},
+    platform::{TestClock, TestPlatform, TestPlatformEvent},
 };

--- a/test-utils/src/platform.rs
+++ b/test-utils/src/platform.rs
@@ -15,6 +15,25 @@ use crate::filesystem::MemoryFilesystem;
 
 static TEST_EPOCH: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Clone, Default)]
+pub struct TestClock {
+    epoch_millis: Arc<AtomicU64>,
+}
+
+impl TestClock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set(&self, epoch_millis: u64) {
+        self.epoch_millis.store(epoch_millis, Ordering::SeqCst);
+    }
+
+    pub fn advance(&self, millis: u64) {
+        self.epoch_millis.fetch_add(millis, Ordering::SeqCst);
+    }
+}
+
 pub enum TestPlatformEvent {
     Stdout(Vec<u8>),
     Exit,
@@ -26,6 +45,7 @@ pub struct TestPlatform {
     fs: Arc<MemoryFilesystem>,
     db: Arc<MemoryDatabaseRepository>,
     font: Font,
+    clock: Option<TestClock>,
 }
 
 impl Default for TestPlatform {
@@ -42,6 +62,7 @@ impl TestPlatform {
             fs: Arc::new(MemoryFilesystem::default()),
             db: Arc::new(MemoryDatabaseRepository::default()),
             font: Font::try_from_static(include_bytes!("../../assets/neodgm.ttf")).unwrap(),
+            clock: None,
         }
     }
 
@@ -55,6 +76,18 @@ impl TestPlatform {
             fs: Arc::new(MemoryFilesystem::default()),
             db: Arc::new(MemoryDatabaseRepository::default()),
             font: Font::try_from_static(include_bytes!("../../assets/neodgm.ttf")).unwrap(),
+            clock: None,
+        }
+    }
+
+    pub fn with_clock(clock: TestClock) -> Self {
+        Self {
+            screen: TestScreen::default(),
+            event_handler: None,
+            fs: Arc::new(MemoryFilesystem::default()),
+            db: Arc::new(MemoryDatabaseRepository::default()),
+            font: Font::try_from_static(include_bytes!("../../assets/neodgm.ttf")).unwrap(),
+            clock: Some(clock),
         }
     }
 }
@@ -69,6 +102,10 @@ impl Platform for TestPlatform {
     }
 
     fn now(&self) -> Instant {
+        if let Some(clock) = &self.clock {
+            return Instant::from_epoch_millis(clock.epoch_millis.load(Ordering::SeqCst));
+        }
+
         let epoch = TEST_EPOCH.fetch_add(8, Ordering::SeqCst);
         Instant::from_epoch_millis(epoch) // TODO
     }

--- a/wie-backend/src/lib.rs
+++ b/wie-backend/src/lib.rs
@@ -10,6 +10,7 @@ mod screen;
 mod system;
 mod task;
 mod task_runner;
+pub mod text_layout;
 mod time;
 
 pub use self::{

--- a/wie-backend/src/text_layout.rs
+++ b/wie-backend/src/text_layout.rs
@@ -1,0 +1,90 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use crate::canvas::{Font, string_width};
+
+pub fn minimum_width(font: &Font, text: &str, pt_size: f32) -> i32 {
+    text.chars()
+        .filter(|character| *character != '\n')
+        .map(|character| string_width(font, &character.to_string(), pt_size).ceil() as i32)
+        .max()
+        .unwrap_or(0)
+}
+
+pub fn preferred_width(font: &Font, text: &str, pt_size: f32) -> i32 {
+    text.split('\n')
+        .map(|line| string_width(font, line, pt_size).ceil() as i32)
+        .max()
+        .unwrap_or(0)
+}
+
+pub fn wrap(font: &Font, text: &str, pt_size: f32, maximum_width: Option<i32>) -> Vec<String> {
+    let mut lines = Vec::new();
+    for paragraph in text.split('\n') {
+        let characters = paragraph.chars().collect::<Vec<_>>();
+        if characters.is_empty() {
+            lines.push(String::new());
+            continue;
+        }
+
+        let Some(maximum_width) = maximum_width else {
+            lines.push(paragraph.to_string());
+            continue;
+        };
+        let maximum_width = maximum_width.max(1);
+        let mut start = 0;
+        while start < characters.len() {
+            let mut end = start;
+            let mut width = 0;
+            let mut word_boundary = None;
+            while end < characters.len() {
+                let character_width = string_width(font, &characters[end].to_string(), pt_size).ceil() as i32;
+                if end > start && width + character_width > maximum_width {
+                    break;
+                }
+                width += character_width;
+                end += 1;
+                if characters[end - 1].is_whitespace() {
+                    word_boundary = Some(end);
+                }
+            }
+
+            let split = if end == characters.len() {
+                end
+            } else {
+                word_boundary.filter(|boundary| *boundary > start).unwrap_or(end.max(start + 1))
+            };
+            let line = characters[start..split].iter().collect::<String>();
+            lines.push(line.trim_end().to_string());
+            start = split;
+            while start < characters.len() && characters[start].is_whitespace() {
+                start += 1;
+            }
+        }
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod test {
+    use crate::canvas::{Font, string_width};
+
+    use super::wrap;
+
+    #[test]
+    fn preserves_explicit_newlines_and_prefers_word_boundaries() {
+        let font = Font::try_from_static(include_bytes!("../../assets/neodgm.ttf")).unwrap();
+        let width = string_width(&font, "alpha ", 10.0).ceil() as i32;
+        assert_eq!(wrap(&font, "alpha beta\n\ngamma", 10.0, Some(width)), ["alpha", "beta", "", "gamma"]);
+    }
+
+    #[test]
+    fn falls_back_to_character_boundaries_for_long_words() {
+        let font = Font::try_from_static(include_bytes!("../../assets/neodgm.ttf")).unwrap();
+        let width = string_width(&font, "ab", 10.0).ceil() as i32;
+        assert_eq!(wrap(&font, "abcdef", 10.0, Some(width)), ["ab", "cd", "ef"]);
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui.rs
@@ -1,6 +1,7 @@
 mod alert;
 mod alert_type;
 mod canvas;
+mod choice;
 mod choice_group;
 mod command;
 mod command_listener;
@@ -9,14 +10,21 @@ mod displayable;
 mod font;
 mod form;
 pub mod game;
+mod gauge;
 mod graphics;
 mod image;
+mod image_item;
 mod item;
+mod item_command_listener;
+mod item_state_listener;
 mod screen;
+mod string_item;
 mod text_box;
+mod ticker;
 
 pub use {
-    alert::Alert, alert_type::AlertType, canvas::Canvas, choice_group::ChoiceGroup, command::Command, command_listener::CommandListener,
-    display::Display, displayable::Displayable, font::Font, form::Form, graphics::Graphics, image::Image, item::Item, screen::Screen,
-    text_box::TextBox,
+    alert::Alert, alert_type::AlertType, canvas::Canvas, choice::Choice, choice_group::ChoiceGroup, command::Command,
+    command_listener::CommandListener, display::Display, displayable::Displayable, font::Font, form::Form, gauge::Gauge, graphics::Graphics,
+    image::Image, image_item::ImageItem, item::Item, item_command_listener::ItemCommandListener, item_state_listener::ItemStateListener,
+    screen::Screen, string_item::StringItem, text_box::TextBox, ticker::Ticker,
 };

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -5,6 +5,7 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
+use wie_backend::text_layout::wrap;
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::lcdui::{AlertType, Command, CommandListener, Display, Displayable, Font, Gauge, Graphics, Image, Item};
@@ -271,7 +272,7 @@ impl Alert {
             if text.is_empty() {
                 Vec::new()
             } else {
-                Font::wrap(context.system().platform().font(), &text, Some(width.max(1)))
+                wrap(context.system().platform().font(), &text, 10.0, Some(width.max(1)))
             }
         };
         let text_y = if text_lines.is_empty() {

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -168,12 +168,11 @@ impl Alert {
 
         jvm.put_static_field("javax/microedition/lcdui/Alert", "FOREVER", "I", -2).await?;
         let short_label = JavaLangString::from_rust_string(jvm, "").await?;
-        let long_label = ClassInstanceRef::<String>::new(None);
         let dismiss_command = jvm
             .new_class(
                 "javax/microedition/lcdui/Command",
                 "(Ljava/lang/String;Ljava/lang/String;II)V",
-                (short_label, long_label, 4, 0),
+                (short_label, None, 4, 0),
             )
             .await?;
         jvm.put_static_field(
@@ -193,12 +192,7 @@ impl Alert {
             "javax/microedition/lcdui/Alert",
             "<init>",
             "(Ljava/lang/String;Ljava/lang/String;Ljavax/microedition/lcdui/Image;Ljavax/microedition/lcdui/AlertType;)V",
-            (
-                title,
-                ClassInstanceRef::<String>::new(None),
-                ClassInstanceRef::<Image>::new(None),
-                ClassInstanceRef::<AlertType>::new(None),
-            ),
+            (title, None, None, None),
         )
         .await
     }
@@ -236,7 +230,7 @@ impl Alert {
 
     async fn snapshot(jvm: &Jvm, image: &ClassInstanceRef<Image>) -> JvmResult<ClassInstanceRef<Image>> {
         if image.is_null() {
-            Ok(ClassInstanceRef::new(None))
+            Ok(None.into())
         } else {
             jvm.invoke_static(
                 "javax/microedition/lcdui/Image",
@@ -353,7 +347,9 @@ impl Alert {
             return Ok(());
         }
 
-        Display::alert_changed(jvm, context, display).await?;
+        let _: () = jvm
+            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "alertChanged", "()V", ())
+            .await?;
         if request_repaint {
             let _: () = jvm
                 .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
@@ -463,13 +459,8 @@ impl Alert {
         }
 
         if !old_indicator.is_null() {
-            jvm.put_field(
-                &mut old_indicator,
-                "owner",
-                "Ljavax/microedition/lcdui/Displayable;",
-                ClassInstanceRef::<Displayable>::new(None),
-            )
-            .await?;
+            jvm.put_field(&mut old_indicator, "owner", "Ljavax/microedition/lcdui/Displayable;", None)
+                .await?;
         }
         if !indicator.is_null() {
             jvm.put_field(&mut indicator, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
@@ -580,7 +571,7 @@ impl Alert {
         .await
     }
 
-    async fn dispatch_command_at(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
+    async fn dispatch_command_at(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
         let command: ClassInstanceRef<Command> = jvm
             .invoke_virtual(
                 &this,
@@ -606,13 +597,8 @@ impl Alert {
         }
 
         let next: ClassInstanceRef<Displayable> = jvm.get_field(&this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;").await?;
-        jvm.put_field(
-            &mut this,
-            "nextDisplayable",
-            "Ljavax/microedition/lcdui/Displayable;",
-            ClassInstanceRef::<Displayable>::new(None),
-        )
-        .await?;
+        jvm.put_field(&mut this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", None)
+            .await?;
         let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         if display.is_null() {
             return Ok(());
@@ -628,7 +614,15 @@ impl Alert {
             )
             .await?;
         if !current.is_null() && current.identity() == this.identity() {
-            Display::transition(jvm, context, display, next).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "transition",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (next,),
+                )
+                .await?;
         }
 
         Ok(())
@@ -641,13 +635,8 @@ impl Alert {
         display: ClassInstanceRef<Display>,
     ) -> JvmResult<()> {
         if display.is_null() {
-            jvm.put_field(
-                &mut this,
-                "nextDisplayable",
-                "Ljavax/microedition/lcdui/Displayable;",
-                ClassInstanceRef::<Displayable>::new(None),
-            )
-            .await?;
+            jvm.put_field(&mut this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", None)
+                .await?;
         }
         jvm.invoke_special(
             &this,
@@ -818,7 +807,6 @@ mod test {
     use jvm::{Array, ClassInstanceRef, JavaError, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
     use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
     use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-    use rustjava_runtime::classes::java::lang::String;
 
     use test_utils::{TestClock, TestPlatform, run_jvm_test, run_jvm_test_with_system};
     use wie_backend::{Event, System};
@@ -828,7 +816,7 @@ mod test {
     use crate::{
         classes::{
             javax::microedition::{
-                lcdui::{Alert, AlertType, Command, CommandListener, Display, Displayable, Gauge, Graphics, Image},
+                lcdui::{Alert, Command, Display, Displayable, Gauge, Graphics, Image},
                 midlet::MIDlet,
             },
             net::wie::{KeyboardEventType, MIDPKeyCode},
@@ -920,12 +908,7 @@ mod test {
             .new_class(
                 "javax/microedition/lcdui/Alert",
                 "(Ljava/lang/String;Ljava/lang/String;Ljavax/microedition/lcdui/Image;Ljavax/microedition/lcdui/AlertType;)V",
-                (
-                    ClassInstanceRef::<String>::new(None),
-                    JavaLangString::from_rust_string(jvm, text).await?,
-                    ClassInstanceRef::<Image>::new(None),
-                    ClassInstanceRef::<AlertType>::new(None),
-                ),
+                (None, JavaLangString::from_rust_string(jvm, text).await?, None, None),
             )
             .await?
             .into())
@@ -933,11 +916,7 @@ mod test {
 
     async fn new_form(jvm: &Jvm) -> JvmResult<ClassInstanceRef<Displayable>> {
         Ok(jvm
-            .new_class(
-                "javax/microedition/lcdui/Form",
-                "(Ljava/lang/String;)V",
-                (ClassInstanceRef::<String>::new(None),),
-            )
+            .new_class("javax/microedition/lcdui/Form", "(Ljava/lang/String;)V", (None,))
             .await?
             .into())
     }
@@ -958,7 +937,7 @@ mod test {
             .new_class(
                 "javax/microedition/lcdui/Gauge",
                 "(Ljava/lang/String;ZII)V",
-                (ClassInstanceRef::<String>::new(None), interactive, 10, value),
+                (None, interactive, 10, value),
             )
             .await?
             .into())
@@ -1080,7 +1059,15 @@ mod test {
                 .invoke_virtual(&dismiss, "javax/microedition/lcdui/Command", "getLabel", "()Ljava/lang/String;", ())
                 .await?;
             assert_eq!(JavaLangString::to_rust_string(&jvm, &label).await?, "");
-            let mut screen_graphics = Display::screen_graphics(&jvm, &display).await?;
+            let mut screen_graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
             let screen_image = Graphics::image(&jvm, &mut screen_graphics).await?;
             let mut initial_fill = 0;
             for value in [2, 8] {
@@ -1263,7 +1250,7 @@ mod test {
                     "javax/microedition/lcdui/Alert",
                     "setIndicator",
                     "(Ljavax/microedition/lcdui/Gauge;)V",
-                    (ClassInstanceRef::<Gauge>::new(None),),
+                    (None,),
                 )
                 .await?;
             let _: i32 = jvm
@@ -1475,7 +1462,7 @@ mod test {
                         "javax/microedition/lcdui/Alert",
                         "setCommandListener",
                         "(Ljavax/microedition/lcdui/CommandListener;)V",
-                        (ClassInstanceRef::<CommandListener>::new(None),),
+                        (None,),
                     )
                     .await?;
                 let _: () = jvm
@@ -1507,7 +1494,15 @@ mod test {
                     .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setTimeout", "(I)V", (25,))
                     .await?;
                 show(&jvm, &display, JavaValue::from(alert.clone()).into()).await?;
-                let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+                let mut graphics: ClassInstanceRef<Graphics> = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "getScreenGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
+                    .await?;
                 let screen_image = Graphics::image(&jvm, &mut graphics).await?;
                 for expired in [false, true] {
                     if expired {

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -1,13 +1,31 @@
-use alloc::vec;
+use alloc::{string::String as RustString, vec, vec::Vec};
 
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
-use jvm_class_proto::JavaMethodProto;
-use jvm_types::{ClassAccessFlags, MethodAccessFlags};
-use rustjava_runtime::classes::java::lang::String;
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::AlertType;
+use crate::classes::javax::microedition::lcdui::{
+    AlertType, Command, CommandListener, Display, Displayable, Font, Gauge, Graphics, Image, Item, ItemCommandListener,
+};
+use crate::classes::net::wie::{KeyboardEventType, MIDPKeyCode};
+
+const CONTENT_GAP: i32 = 4;
+const LEFT_TOP: i32 = 4 | 16;
+
+struct AlertContentLayout {
+    image: ClassInstanceRef<Image>,
+    image_width: i32,
+    image_height: i32,
+    text_lines: Vec<RustString>,
+    text_y: i32,
+    indicator: ClassInstanceRef<Gauge>,
+    indicator_y: i32,
+    indicator_height: i32,
+    height: i32,
+}
 
 // class javax.microedition.lcdui.Alert
 pub struct Alert;
@@ -19,49 +37,1502 @@ impl Alert {
             parent_class: Some("javax/microedition/lcdui/Screen"),
             interfaces: vec![],
             methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
                 JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;Ljava/lang/String;Ljavax/microedition/lcdui/Image;Ljavax/microedition/lcdui/AlertType;)V",
+                    Self::init_with_contents,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getDefaultTimeout", "()I", Self::get_default_timeout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getTimeout", "()I", Self::get_timeout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setTimeout", "(I)V", Self::set_timeout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "getType",
+                    "()Ljavax/microedition/lcdui/AlertType;",
+                    Self::get_type,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new(
                     "setType",
                     "(Ljavax/microedition/lcdui/AlertType;)V",
                     Self::set_type,
                     MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("setTimeout", "(I)V", Self::set_timeout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getString", "()Ljava/lang/String;", Self::get_string, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "getImage",
+                    "()Ljavax/microedition/lcdui/Image;",
+                    Self::get_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setImage",
+                    "(Ljavax/microedition/lcdui/Image;)V",
+                    Self::set_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "getIndicator",
+                    "()Ljavax/microedition/lcdui/Gauge;",
+                    Self::get_indicator,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setIndicator",
+                    "(Ljavax/microedition/lcdui/Gauge;)V",
+                    Self::set_indicator,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::add_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "removeCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::remove_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setCommandListener",
+                    "(Ljavax/microedition/lcdui/CommandListener;)V",
+                    Self::set_command_listener,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("decorationChanged", "()V", Self::decoration_changed, MethodAccessFlags::empty()),
+                JavaMethodProto::new("getCommandCount", "()I", Self::get_command_count, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    Self::get_command_at,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("dispatchCommandAt", "(I)V", Self::dispatch_command_at, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "setDisplay",
+                    "(Ljavax/microedition/lcdui/Display;)V",
+                    Self::set_display,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "checkItemMutation",
+                    "(Ljavax/microedition/lcdui/Item;)V",
+                    Self::check_item_mutation,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "itemInvalidated",
+                    "(Ljavax/microedition/lcdui/Item;Z)V",
+                    Self::item_invalidated,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "handlePaintEvent",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    Self::handle_paint_event,
+                    MethodAccessFlags::empty(),
+                ),
             ],
-            fields: vec![],
+            fields: vec![
+                JavaFieldProto::new(
+                    "FOREVER",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "DISMISS_COMMAND",
+                    "Ljavax/microedition/lcdui/Command;",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new("text", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("type", "Ljavax/microedition/lcdui/AlertType;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("image", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("displayImage", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("indicator", "Ljavax/microedition/lcdui/Gauge;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("timeout", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("scrollY", "I", FieldAccessFlags::PRIVATE),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Alert::<clinit>");
+
+        jvm.put_static_field("javax/microedition/lcdui/Alert", "FOREVER", "I", -2).await?;
+        let short_label = JavaLangString::from_rust_string(jvm, "").await?;
+        let long_label = ClassInstanceRef::<String>::new(None);
+        let dismiss_command = jvm
+            .new_class(
+                "javax/microedition/lcdui/Command",
+                "(Ljava/lang/String;Ljava/lang/String;II)V",
+                (short_label, long_label, 4, 0),
+            )
+            .await?;
+        jvm.put_static_field(
+            "javax/microedition/lcdui/Alert",
+            "DISMISS_COMMAND",
+            "Ljavax/microedition/lcdui/Command;",
+            dismiss_command,
+        )
+        .await
     }
 
     async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, title: ClassInstanceRef<String>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Alert::<init>({this:?}, {title:?})");
 
-        let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Screen", "<init>", "()V", ()).await?;
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Alert",
+            "<init>",
+            "(Ljava/lang/String;Ljava/lang/String;Ljavax/microedition/lcdui/Image;Ljavax/microedition/lcdui/AlertType;)V",
+            (
+                title,
+                ClassInstanceRef::<String>::new(None),
+                ClassInstanceRef::<Image>::new(None),
+                ClassInstanceRef::<AlertType>::new(None),
+            ),
+        )
+        .await
+    }
 
+    async fn init_with_contents(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        title: ClassInstanceRef<String>,
+        text: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+        alert_type: ClassInstanceRef<AlertType>,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Alert::<init>({this:?}, {title:?}, {text:?}, {image:?}, {alert_type:?})");
+
+        let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Screen", "<init>", "()V", ()).await?;
+        let display_image = Self::snapshot(jvm, &image).await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "type", "Ljavax/microedition/lcdui/AlertType;", alert_type)
+            .await?;
+        jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
+        jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
+            .await?;
+        jvm.put_field(&mut this, "timeout", "I", 2000).await?;
+        jvm.put_field(&mut this, "scrollY", "I", 0).await?;
+        jvm.invoke_virtual(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "setTitle",
+            "(Ljava/lang/String;)V",
+            (title,),
+        )
+        .await
+    }
+
+    async fn snapshot(jvm: &Jvm, image: &ClassInstanceRef<Image>) -> JvmResult<ClassInstanceRef<Image>> {
+        if image.is_null() {
+            Ok(ClassInstanceRef::new(None))
+        } else {
+            jvm.invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(Ljavax/microedition/lcdui/Image;)Ljavax/microedition/lcdui/Image;",
+                (image.clone(),),
+            )
+            .await
+        }
+    }
+
+    async fn content_layout(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>, width: i32) -> JvmResult<AlertContentLayout> {
+        let width = width.max(0);
+        let image: ClassInstanceRef<Image> = jvm.get_field(this, "displayImage", "Ljavax/microedition/lcdui/Image;").await?;
+        let (image_width, image_height): (i32, i32) = if image.is_null() {
+            (0, 0)
+        } else {
+            (
+                jvm.invoke_virtual(&image, "javax/microedition/lcdui/Image", "getWidth", "()I", ())
+                    .await?,
+                jvm.invoke_virtual(&image, "javax/microedition/lcdui/Image", "getHeight", "()I", ())
+                    .await?,
+            )
+        };
+        let image_width = image_width.max(0);
+        let image_height = image_height.max(0);
+        let mut height: i32 = image_height;
+
+        let text: ClassInstanceRef<String> = jvm.get_field(this, "text", "Ljava/lang/String;").await?;
+        let text_lines = if text.is_null() {
+            Vec::new()
+        } else {
+            let text = JavaLangString::to_rust_string(jvm, &text).await?;
+            if text.is_empty() {
+                Vec::new()
+            } else {
+                Font::wrap(context.system().platform().font(), &text, Some(width.max(1)))
+            }
+        };
+        let text_y = if text_lines.is_empty() {
+            height
+        } else {
+            if height > 0 {
+                height = height.saturating_add(CONTENT_GAP);
+            }
+            let text_y = height;
+            height = height.saturating_add((text_lines.len() as i32).saturating_mul(Font::HEIGHT));
+            text_y
+        };
+
+        let indicator: ClassInstanceRef<Gauge> = jvm.get_field(this, "indicator", "Ljavax/microedition/lcdui/Gauge;").await?;
+        let indicator_height: i32 = if indicator.is_null() {
+            0
+        } else {
+            let height: i32 = jvm
+                .invoke_virtual(&indicator, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (width,))
+                .await?;
+            height.max(0)
+        };
+        let indicator_y = if indicator_height == 0 {
+            height
+        } else {
+            if height > 0 {
+                height = height.saturating_add(CONTENT_GAP);
+            }
+            let indicator_y = height;
+            height = height.saturating_add(indicator_height);
+            indicator_y
+        };
+
+        Ok(AlertContentLayout {
+            image,
+            image_width,
+            image_height,
+            text_lines,
+            text_y,
+            indicator,
+            indicator_y,
+            indicator_height,
+            height,
+        })
+    }
+
+    async fn effective_timeout(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let width: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await?;
+        let viewport_height: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await?;
+        let viewport_height = viewport_height.max(0);
+        let content = Self::content_layout(jvm, context, &this, width).await?;
+        let maximum_scroll = content.height.saturating_sub(viewport_height).max(0);
+        let scroll: i32 = jvm.get_field(&this, "scrollY", "I").await?;
+        let clamped_scroll = scroll.clamp(0, maximum_scroll);
+        if clamped_scroll != scroll {
+            jvm.put_field(&mut this, "scrollY", "I", clamped_scroll).await?;
+        }
+
+        let application_command_count: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        if maximum_scroll > 0 || application_command_count > 1 {
+            Ok(-2)
+        } else {
+            jvm.get_field(&this, "timeout", "I").await
+        }
+    }
+
+    async fn invalidate_current(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, request_repaint: bool) -> JvmResult<()> {
+        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if display.is_null() {
+            let _ = Self::effective_timeout(jvm, context, this).await?;
+            return Ok(());
+        }
+
+        Display::alert_changed(jvm, context, display).await?;
+        if request_repaint {
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                .await?;
+        }
         Ok(())
+    }
+
+    async fn get_default_timeout(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(2000)
+    }
+
+    async fn get_timeout(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Self::effective_timeout(jvm, context, this).await
+    }
+
+    async fn set_timeout(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, timeout: i32) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Alert::setTimeout({this:?}, {timeout})");
+
+        if timeout <= 0 && timeout != -2 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid Alert timeout").await);
+        }
+        jvm.put_field(&mut this, "timeout", "I", timeout).await?;
+        Self::invalidate_current(jvm, context, this, true).await
+    }
+
+    async fn get_type(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<AlertType>> {
+        jvm.get_field(&this, "type", "Ljavax/microedition/lcdui/AlertType;").await
     }
 
     async fn set_type(
-        _jvm: &Jvm,
-        _context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
         alert_type: ClassInstanceRef<AlertType>,
     ) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Alert::setType({this:?}, {alert_type:?})");
+        tracing::debug!("javax.microedition.lcdui.Alert::setType({this:?}, {alert_type:?})");
+        jvm.put_field(&mut this, "type", "Ljavax/microedition/lcdui/AlertType;", alert_type)
+            .await?;
+        Self::invalidate_current(jvm, context, this, true).await
+    }
+
+    async fn get_string(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "text", "Ljava/lang/String;").await
+    }
+
+    async fn set_string(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Alert::setString({this:?}, {text:?})");
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        Self::invalidate_current(jvm, context, this, true).await
+    }
+
+    async fn get_image(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Image>> {
+        jvm.get_field(&this, "image", "Ljavax/microedition/lcdui/Image;").await
+    }
+
+    async fn set_image(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, image: ClassInstanceRef<Image>) -> JvmResult<()> {
+        let display_image = Self::snapshot(jvm, &image).await?;
+        jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
+        jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
+            .await?;
+        Self::invalidate_current(jvm, context, this, true).await
+    }
+
+    async fn get_indicator(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Gauge>> {
+        jvm.get_field(&this, "indicator", "Ljavax/microedition/lcdui/Gauge;").await
+    }
+
+    async fn set_indicator(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        mut indicator: ClassInstanceRef<Gauge>,
+    ) -> JvmResult<()> {
+        let mut old_indicator: ClassInstanceRef<Gauge> = jvm.get_field(&this, "indicator", "Ljavax/microedition/lcdui/Gauge;").await?;
+        if (old_indicator.is_null() && indicator.is_null())
+            || (!old_indicator.is_null() && !indicator.is_null() && old_indicator.identity() == indicator.identity())
+        {
+            return Ok(());
+        }
+
+        if !indicator.is_null() {
+            let interactive: bool = jvm.get_field(&indicator, "interactive", "Z").await?;
+            let owner: ClassInstanceRef<Displayable> = jvm.get_field(&indicator, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+            let commands: ClassInstanceRef<Vector> = jvm.get_field(&indicator, "commands", "Ljava/util/Vector;").await?;
+            let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+            let listener: ClassInstanceRef<ItemCommandListener> = jvm
+                .get_field(&indicator, "itemCommandListener", "Ljavax/microedition/lcdui/ItemCommandListener;")
+                .await?;
+            let label: ClassInstanceRef<String> = jvm.get_field(&indicator, "label", "Ljava/lang/String;").await?;
+            let preferred_width: i32 = jvm.get_field(&indicator, "preferredWidth", "I").await?;
+            let preferred_height: i32 = jvm.get_field(&indicator, "preferredHeight", "I").await?;
+            let layout: i32 = jvm.get_field(&indicator, "layout", "I").await?;
+            if interactive
+                || !owner.is_null()
+                || command_count != 0
+                || !listener.is_null()
+                || !label.is_null()
+                || preferred_width != -1
+                || preferred_height != -1
+                || layout != 0
+            {
+                return Err(jvm
+                    .exception("java/lang/IllegalArgumentException", "Gauge cannot be used as an Alert indicator")
+                    .await);
+            }
+        }
+
+        if !old_indicator.is_null() {
+            jvm.put_field(
+                &mut old_indicator,
+                "owner",
+                "Ljavax/microedition/lcdui/Displayable;",
+                ClassInstanceRef::<Displayable>::new(None),
+            )
+            .await?;
+        }
+        if !indicator.is_null() {
+            jvm.put_field(&mut indicator, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
+                .await?;
+        }
+        jvm.put_field(&mut this, "indicator", "Ljavax/microedition/lcdui/Gauge;", indicator)
+            .await?;
+        Self::invalidate_current(jvm, context, this, true).await
+    }
+
+    async fn add_command(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, command: ClassInstanceRef<Command>) -> JvmResult<()> {
+        let dismiss: ClassInstanceRef<Command> = jvm
+            .get_static_field("javax/microedition/lcdui/Alert", "DISMISS_COMMAND", "Ljavax/microedition/lcdui/Command;")
+            .await?;
+        if !command.is_null() && command.identity() == dismiss.identity() {
+            return Ok(());
+        }
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "addCommand",
+            "(Ljavax/microedition/lcdui/Command;)V",
+            (command,),
+        )
+        .await
+    }
+
+    async fn remove_command(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        command: ClassInstanceRef<Command>,
+    ) -> JvmResult<()> {
+        let dismiss: ClassInstanceRef<Command> = jvm
+            .get_static_field("javax/microedition/lcdui/Alert", "DISMISS_COMMAND", "Ljavax/microedition/lcdui/Command;")
+            .await?;
+        if !command.is_null() && command.identity() == dismiss.identity() {
+            return Ok(());
+        }
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "removeCommand",
+            "(Ljavax/microedition/lcdui/Command;)V",
+            (command,),
+        )
+        .await
+    }
+
+    async fn set_command_listener(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        listener: ClassInstanceRef<CommandListener>,
+    ) -> JvmResult<()> {
+        let listener_result: JvmResult<()> = jvm
+            .invoke_special(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "setCommandListener",
+                "(Ljavax/microedition/lcdui/CommandListener;)V",
+                (listener,),
+            )
+            .await;
+        let invalidation_result = Self::invalidate_current(jvm, context, this, true).await;
+        listener_result?;
+        invalidation_result
+    }
+
+    async fn decoration_changed(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let decoration_result: JvmResult<()> = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await;
+        let invalidation_result = Self::invalidate_current(jvm, context, this, false).await;
+        decoration_result?;
+        invalidation_result
+    }
+
+    async fn get_command_count(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let count: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        Ok(count.max(1))
+    }
+
+    async fn get_command_at(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        index: i32,
+    ) -> JvmResult<ClassInstanceRef<Command>> {
+        let count: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        if count == 0 && index == 0 {
+            return jvm
+                .get_static_field("javax/microedition/lcdui/Alert", "DISMISS_COMMAND", "Ljavax/microedition/lcdui/Command;")
+                .await;
+        }
+
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "getCommandAt",
+            "(I)Ljavax/microedition/lcdui/Command;",
+            (index,),
+        )
+        .await
+    }
+
+    async fn dispatch_command_at(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
+        let command: ClassInstanceRef<Command> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getCommandAt",
+                "(I)Ljavax/microedition/lcdui/Command;",
+                (index,),
+            )
+            .await?;
+        let listener: ClassInstanceRef<CommandListener> = jvm
+            .get_field(&this, "commandListener", "Ljavax/microedition/lcdui/CommandListener;")
+            .await?;
+        if !listener.is_null() {
+            return jvm
+                .invoke_virtual(
+                    &listener,
+                    "javax/microedition/lcdui/CommandListener",
+                    "commandAction",
+                    "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                    (command, this),
+                )
+                .await;
+        }
+
+        let next: ClassInstanceRef<Displayable> = jvm.get_field(&this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;").await?;
+        jvm.put_field(
+            &mut this,
+            "nextDisplayable",
+            "Ljavax/microedition/lcdui/Displayable;",
+            ClassInstanceRef::<Displayable>::new(None),
+        )
+        .await?;
+        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if display.is_null() {
+            return Ok(());
+        }
+
+        let current: ClassInstanceRef<Displayable> = jvm
+            .invoke_virtual(
+                &display,
+                "javax/microedition/lcdui/Display",
+                "getCurrent",
+                "()Ljavax/microedition/lcdui/Displayable;",
+                (),
+            )
+            .await?;
+        if !current.is_null() && current.identity() == this.identity() {
+            Display::transition(jvm, context, display, next).await?;
+        }
 
         Ok(())
     }
 
-    async fn set_timeout(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, timeout: i32) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Alert::setTimeout({this:?}, {timeout})");
+    async fn set_display(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        display: ClassInstanceRef<Display>,
+    ) -> JvmResult<()> {
+        if display.is_null() {
+            jvm.put_field(
+                &mut this,
+                "nextDisplayable",
+                "Ljavax/microedition/lcdui/Displayable;",
+                ClassInstanceRef::<Displayable>::new(None),
+            )
+            .await?;
+        }
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "setDisplay",
+            "(Ljavax/microedition/lcdui/Display;)V",
+            (display,),
+        )
+        .await
+    }
+
+    async fn item_invalidated(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        _item: ClassInstanceRef<Item>,
+        _layout_changed: bool,
+    ) -> JvmResult<()> {
+        Self::invalidate_current(jvm, context, this, true).await
+    }
+
+    async fn handle_key_event(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, event_type: i32, code: i32) -> JvmResult<()> {
+        let pressed = event_type == KeyboardEventType::KeyPressed as i32;
+        let repeated = event_type == KeyboardEventType::KeyRepeated as i32;
+        if (pressed || repeated) && (code == MIDPKeyCode::UP as i32 || code == MIDPKeyCode::DOWN as i32) {
+            let width: i32 = jvm
+                .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+                .await?;
+            let viewport_height: i32 = jvm
+                .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+                .await?;
+            let viewport_height = viewport_height.max(0);
+            let content = Self::content_layout(jvm, context, &this, width).await?;
+            let maximum_scroll = content.height.saturating_sub(viewport_height).max(0);
+            let scroll: i32 = jvm.get_field(&this, "scrollY", "I").await?;
+            let scroll = scroll.clamp(0, maximum_scroll);
+            let step = viewport_height.max(1);
+            let next_scroll = if code == MIDPKeyCode::UP as i32 {
+                scroll.saturating_sub(step).max(0)
+            } else {
+                scroll.saturating_add(step).min(maximum_scroll)
+            };
+            if next_scroll != scroll {
+                jvm.put_field(&mut this, "scrollY", "I", next_scroll).await?;
+                return jvm
+                    .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                    .await;
+            }
+        }
+
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "handleKeyEvent",
+            "(II)V",
+            (event_type, code),
+        )
+        .await
+    }
+
+    async fn handle_paint_event(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+    ) -> JvmResult<()> {
+        let _: () = jvm
+            .invoke_special(
+                &this,
+                "javax/microedition/lcdui/Screen",
+                "handlePaintEvent",
+                "(Ljavax/microedition/lcdui/Graphics;)V",
+                (graphics.clone(),),
+            )
+            .await?;
+        let width: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await?;
+        let width = width.max(0);
+        let viewport_height: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await?;
+        let viewport_height = viewport_height.max(0);
+        let content = Self::content_layout(jvm, context, &this, width).await?;
+        let maximum_scroll = content.height.saturating_sub(viewport_height).max(0);
+        let scroll: i32 = jvm.get_field(&this, "scrollY", "I").await?;
+        let scroll = scroll.clamp(0, maximum_scroll);
+        jvm.put_field(&mut this, "scrollY", "I", scroll).await?;
+
+        if !content.image.is_null() && content.image_width > 0 && content.image_height > 0 {
+            let image_x = ((width - content.image_width) / 2).max(0);
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawImage",
+                    "(Ljavax/microedition/lcdui/Image;III)V",
+                    (content.image, image_x, -scroll, LEFT_TOP),
+                )
+                .await?;
+        }
+
+        if !content.text_lines.is_empty() {
+            let font: ClassInstanceRef<Font> = jvm
+                .invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setFont",
+                    "(Ljavax/microedition/lcdui/Font;)V",
+                    (font,),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0,))
+                .await?;
+            for (index, line) in content.text_lines.iter().enumerate() {
+                let y = content.text_y + index as i32 * Font::HEIGHT - scroll;
+                if y.saturating_add(Font::HEIGHT) <= 0 || y >= viewport_height {
+                    continue;
+                }
+                let line = JavaLangString::from_rust_string(jvm, line).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (line, 0, y, LEFT_TOP),
+                    )
+                    .await?;
+            }
+        }
+
+        if !content.indicator.is_null() && content.indicator_height > 0 {
+            let _: () = jvm
+                .invoke_virtual(
+                    &content.indicator,
+                    "javax/microedition/lcdui/Item",
+                    "paintItem",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    (graphics, 0, content.indicator_y - scroll, width, content.indicator_height, false),
+                )
+                .await?;
+        }
 
         Ok(())
     }
 
-    async fn set_string(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Alert::setString({this:?}, {text:?})");
+    async fn check_item_mutation(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        _this: ClassInstanceRef<Self>,
+        _item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        Err(jvm
+            .exception("java/lang/IllegalStateException", "Alert indicator cannot be modified")
+            .await)
+    }
+}
 
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec};
+
+    use jvm::{Array, ClassInstanceRef, JavaError, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
+    use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+    use rustjava_runtime::classes::java::lang::String;
+
+    use test_utils::{TestClock, TestPlatform, run_jvm_test, run_jvm_test_with_system};
+    use wie_backend::{Event, System};
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_util::Result;
+
+    use crate::{
+        classes::{
+            javax::microedition::{
+                lcdui::{Alert, AlertType, Command, CommandListener, Display, Displayable, Gauge, Graphics, Image},
+                midlet::MIDlet,
+            },
+            net::wie::{KeyboardEventType, MIDPKeyCode},
+        },
+        get_protos,
+    };
+
+    struct RecordingAlertCommandListener;
+    struct AlertTestMidlet;
+
+    impl RecordingAlertCommandListener {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestAlertCommandListener",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec!["javax/microedition/lcdui/CommandListener"],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "commandAction",
+                        "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                        Self::command_action,
+                        MethodAccessFlags::PUBLIC,
+                    ),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("count", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastCommand", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+        }
+
+        async fn command_action(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            command: ClassInstanceRef<Command>,
+            displayable: ClassInstanceRef<Displayable>,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastCommand", "Ljavax/microedition/lcdui/Command;", command)
+                .await?;
+            jvm.put_field(&mut this, "lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", displayable)
+                .await?;
+            Err(jvm.exception("java/lang/RuntimeException", "listener failure").await)
+        }
+    }
+
+    impl AlertTestMidlet {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/midlet/TestAlertMidlet",
+                parent_class: Some("javax/microedition/midlet/MIDlet"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("startApp", "()V", Self::start_app, MethodAccessFlags::PROTECTED),
+                ],
+                fields: vec![],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/midlet/MIDlet", "<init>", "()V", ()).await
+        }
+
+        async fn start_app(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            Ok(())
+        }
+    }
+
+    fn test_protos() -> Box<[Box<[WieJavaClassProto]>]> {
+        Box::new([
+            get_protos().into(),
+            [RecordingAlertCommandListener::as_proto(), AlertTestMidlet::as_proto()].into(),
+        ])
+    }
+
+    async fn new_alert(jvm: &Jvm, text: &str) -> JvmResult<ClassInstanceRef<Alert>> {
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Alert",
+                "(Ljava/lang/String;Ljava/lang/String;Ljavax/microedition/lcdui/Image;Ljavax/microedition/lcdui/AlertType;)V",
+                (
+                    ClassInstanceRef::<String>::new(None),
+                    JavaLangString::from_rust_string(jvm, text).await?,
+                    ClassInstanceRef::<Image>::new(None),
+                    ClassInstanceRef::<AlertType>::new(None),
+                ),
+            )
+            .await?
+            .into())
+    }
+
+    async fn new_form(jvm: &Jvm) -> JvmResult<ClassInstanceRef<Displayable>> {
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Form",
+                "(Ljava/lang/String;)V",
+                (ClassInstanceRef::<String>::new(None),),
+            )
+            .await?
+            .into())
+    }
+
+    async fn new_command(jvm: &Jvm, label: &str) -> JvmResult<ClassInstanceRef<Command>> {
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Command",
+                "(Ljava/lang/String;II)V",
+                (JavaLangString::from_rust_string(jvm, label).await?, 4, 0),
+            )
+            .await?
+            .into())
+    }
+
+    async fn new_gauge(jvm: &Jvm, interactive: bool, value: i32) -> JvmResult<ClassInstanceRef<Gauge>> {
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Gauge",
+                "(Ljava/lang/String;ZII)V",
+                (ClassInstanceRef::<String>::new(None), interactive, 10, value),
+            )
+            .await?
+            .into())
+    }
+
+    async fn current(jvm: &Jvm, display: &ClassInstanceRef<Display>) -> JvmResult<ClassInstanceRef<Displayable>> {
+        jvm.invoke_virtual(
+            display,
+            "javax/microedition/lcdui/Display",
+            "getCurrent",
+            "()Ljavax/microedition/lcdui/Displayable;",
+            (),
+        )
+        .await
+    }
+
+    async fn show(jvm: &Jvm, display: &ClassInstanceRef<Display>, displayable: ClassInstanceRef<Displayable>) -> JvmResult<()> {
+        jvm.invoke_virtual(
+            display,
+            "javax/microedition/lcdui/Display",
+            "setCurrent",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (displayable,),
+        )
+        .await
+    }
+
+    async fn test_midlet_display(jvm: &Jvm) -> JvmResult<ClassInstanceRef<Display>> {
+        let midlet: ClassInstanceRef<MIDlet> = jvm.new_class("javax/microedition/midlet/TestAlertMidlet", "()V", ()).await?.into();
+        MIDlet::display(jvm, &midlet).await
+    }
+
+    async fn pump_backend_queue(jvm: &Jvm, system: &System) -> JvmResult<()> {
+        // A FIFO sentinel returns control after preceding timers have been processed.
+        system.event_queue().push(Event::Notify {
+            r#type: 731,
+            param1: 19,
+            param2: 23,
+        });
+        let queue = jvm
+            .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+            .await?;
+        let event: ClassInstanceRef<Array<i32>> = jvm.instantiate_array("I", 4).await?.into();
+        let _: () = jvm
+            .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+            .await?;
+        assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [1000, 731, 19, 23]);
         Ok(())
+    }
+
+    #[test]
+    fn alert_renders_snapshots_indicator_updates_and_scrolls_overflow() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let mut display = test_midlet_display(&jvm).await?;
+            jvm.put_field(&mut display, "width", "I", 60).await?;
+            jvm.put_field(&mut display, "height", "I", 80).await?;
+            let source: ClassInstanceRef<Image> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Image",
+                    "createImage",
+                    "(II)Ljavax/microedition/lcdui/Image;",
+                    (10, 6),
+                )
+                .await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &source,
+                    "javax/microedition/lcdui/Image",
+                    "getGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
+            let alert = new_alert(&jvm, "status").await?;
+            for color in [0xcc2233, 0x22bb55] {
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 10, 6))
+                    .await?;
+                if color == 0xcc2233 {
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &alert,
+                            "javax/microedition/lcdui/Alert",
+                            "setImage",
+                            "(Ljavax/microedition/lcdui/Image;)V",
+                            (source.clone(),),
+                        )
+                        .await?;
+                }
+            }
+            let indicator = new_gauge(&jvm, false, 2).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &alert,
+                    "javax/microedition/lcdui/Alert",
+                    "setIndicator",
+                    "(Ljavax/microedition/lcdui/Gauge;)V",
+                    (indicator.clone(),),
+                )
+                .await?;
+            show(&jvm, &display, JavaValue::from(alert.clone()).into()).await?;
+            let dismiss: ClassInstanceRef<Command> = jvm
+                .get_static_field("javax/microedition/lcdui/Alert", "DISMISS_COMMAND", "Ljavax/microedition/lcdui/Command;")
+                .await?;
+            let effective: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(
+                    &alert,
+                    "javax/microedition/lcdui/Displayable",
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    (0,),
+                )
+                .await?;
+            assert_eq!(dismiss.identity(), effective.identity());
+            let label = jvm
+                .invoke_virtual(&dismiss, "javax/microedition/lcdui/Command", "getLabel", "()Ljava/lang/String;", ())
+                .await?;
+            assert_eq!(JavaLangString::to_rust_string(&jvm, &label).await?, "");
+            let mut screen_graphics = Display::screen_graphics(&jvm, &display).await?;
+            let screen_image = Graphics::image(&jvm, &mut screen_graphics).await?;
+            let mut initial_fill = 0;
+            for value in [2, 8] {
+                let _: () = jvm
+                    .invoke_virtual(&indicator, "javax/microedition/lcdui/Gauge", "setValue", "(I)V", (value,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                    .await?;
+                let image = Image::image(&jvm, &screen_image).await?;
+                assert!(
+                    (64..76).any(|y| (4..20).any(|x| {
+                        let pixel = image.get_pixel(x, y);
+                        (pixel.r, pixel.g, pixel.b) != (0x26, 0x37, 0x46)
+                    })),
+                    "implicit dismissal must have a visible softkey caption"
+                );
+                let (mut image_y, mut text_y, mut gauge_y) = (None, None, None);
+                let mut fill = 0;
+                for y in 0..64 {
+                    for x in 0..60 {
+                        let color = image.get_pixel(x, y);
+                        match (color.r, color.g, color.b) {
+                            (0xcc, 0x22, 0x33) => image_y = Some(image_y.unwrap_or(y)),
+                            (0, 0, 0) => text_y = Some(text_y.unwrap_or(y)),
+                            (0x2f, 0x7e, 0xb8) => {
+                                gauge_y = Some(gauge_y.unwrap_or(y));
+                                fill += 1;
+                            }
+                            (0x22, 0xbb, 0x55) => panic!("Alert must paint the snapshot, not the mutated source"),
+                            _ => {}
+                        }
+                    }
+                }
+                assert!(image_y.unwrap() < text_y.unwrap() && text_y.unwrap() < gauge_y.unwrap());
+                if value == 2 {
+                    initial_fill = fill;
+                } else {
+                    assert!(fill > initial_fill, "indicator mutation must reach the rendered buffer");
+                }
+            }
+
+            let long_text = JavaLangString::from_rust_string(&jvm, &"line\n".repeat(20)).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &alert,
+                    "javax/microedition/lcdui/Alert",
+                    "setString",
+                    "(Ljava/lang/String;)V",
+                    (long_text,),
+                )
+                .await?;
+            let timeout: i32 = jvm
+                .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "getTimeout", "()I", ())
+                .await?;
+            assert_eq!(timeout, -2);
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "handleKeyEvent",
+                    "(II)V",
+                    (KeyboardEventType::KeyPressed as i32, MIDPKeyCode::DOWN as i32),
+                )
+                .await?;
+            assert!(jvm.get_field::<i32>(&alert, "scrollY", "I").await? > 0);
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
+            {
+                let image = Image::image(&jvm, &screen_image).await?;
+                assert!(
+                    (0..64).all(|y| (0..60).all(|x| {
+                        let color = image.get_pixel(x, y);
+                        (color.r, color.g, color.b) != (0xcc, 0x22, 0x33)
+                    })),
+                    "scrolling must move the image out of the viewport"
+                );
+            }
+            let text = JavaLangString::from_rust_string(&jvm, "short").await?;
+            let _: () = jvm
+                .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setString", "(Ljava/lang/String;)V", (text,))
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&alert, "scrollY", "I").await?, 0);
+            let timeout: i32 = jvm
+                .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "getTimeout", "()I", ())
+                .await?;
+            assert_eq!(timeout, 2000);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn indicator_replacement_is_atomic_restricted_and_releases_ownership() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let alert = new_alert(&jvm, "").await?;
+            let form = new_form(&jvm).await?;
+            let first = new_gauge(&jvm, false, 2).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &alert,
+                    "javax/microedition/lcdui/Alert",
+                    "setIndicator",
+                    "(Ljavax/microedition/lcdui/Gauge;)V",
+                    (first.clone(),),
+                )
+                .await?;
+            for interactive in [true, false] {
+                let candidate = new_gauge(&jvm, interactive, 2).await?;
+                if !interactive {
+                    let _: i32 = jvm
+                        .invoke_virtual(
+                            &form,
+                            "javax/microedition/lcdui/Form",
+                            "append",
+                            "(Ljavax/microedition/lcdui/Item;)I",
+                            (candidate.clone(),),
+                        )
+                        .await?;
+                }
+                let result: JvmResult<()> = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        "setIndicator",
+                        "(Ljavax/microedition/lcdui/Gauge;)V",
+                        (candidate,),
+                    )
+                    .await;
+                let Err(JavaError::JavaException(exception)) = result else {
+                    panic!("invalid indicator accepted: {result:?}")
+                };
+                assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+                let retained: ClassInstanceRef<Gauge> = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        "getIndicator",
+                        "()Ljavax/microedition/lcdui/Gauge;",
+                        (),
+                    )
+                    .await?;
+                assert_eq!(retained.identity(), first.identity());
+            }
+            let result: JvmResult<()> = jvm
+                .invoke_virtual(
+                    &first,
+                    "javax/microedition/lcdui/Gauge",
+                    "setLabel",
+                    "(Ljava/lang/String;)V",
+                    (JavaLangString::from_rust_string(&jvm, "forbidden").await?,),
+                )
+                .await;
+            let Err(JavaError::JavaException(exception)) = result else {
+                panic!("owned indicator mutation accepted: {result:?}")
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/IllegalStateException"));
+            let second = new_gauge(&jvm, false, 5).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &alert,
+                    "javax/microedition/lcdui/Alert",
+                    "setIndicator",
+                    "(Ljavax/microedition/lcdui/Gauge;)V",
+                    (second.clone(),),
+                )
+                .await?;
+            let _: i32 = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Form",
+                    "append",
+                    "(Ljavax/microedition/lcdui/Item;)I",
+                    (first,),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &alert,
+                    "javax/microedition/lcdui/Alert",
+                    "setIndicator",
+                    "(Ljavax/microedition/lcdui/Gauge;)V",
+                    (ClassInstanceRef::<Gauge>::new(None),),
+                )
+                .await?;
+            let _: i32 = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Form",
+                    "append",
+                    "(Ljavax/microedition/lcdui/Item;)I",
+                    (second,),
+                )
+                .await?;
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn effective_commands_control_timeout_and_default_transitions() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let display = test_midlet_display(&jvm).await?;
+            let previous = new_form(&jvm).await?;
+            let alert = new_alert(&jvm, "").await?;
+            let first = new_command(&jvm, "Continue").await?;
+            let second = new_command(&jvm, "Cancel").await?;
+            let _: () = jvm
+                .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setTimeout", "(I)V", (100,))
+                .await?;
+            for (method, command, timeout) in [
+                ("addCommand", first.clone(), 100),
+                ("addCommand", second.clone(), -2),
+                ("removeCommand", second, 100),
+                ("removeCommand", first, 100),
+            ] {
+                let _: () = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        method,
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (command,),
+                    )
+                    .await?;
+                let actual_timeout: i32 = jvm
+                    .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "getTimeout", "()I", ())
+                    .await?;
+                assert_eq!(actual_timeout, timeout);
+            }
+            show(&jvm, &display, previous.clone()).await?;
+            show(&jvm, &display, JavaValue::from(alert.clone()).into()).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "handleKeyEvent",
+                    "(II)V",
+                    (KeyboardEventType::KeyPressed as i32, MIDPKeyCode::LEFT_SOFT_KEY as i32),
+                )
+                .await?;
+            assert_eq!(current(&jvm, &display).await?.identity(), previous.identity());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn queue_timers_reschedule_mutations_and_ignore_departed_alerts() -> Result<()> {
+        let clock = TestClock::new();
+        run_jvm_test_with_system(
+            test_protos(),
+            Box::new(TestPlatform::with_clock(clock.clone())),
+            move |jvm, system| async move {
+                let display = test_midlet_display(&jvm).await?;
+                let previous = new_form(&jvm).await?;
+                let alert = new_alert(&jvm, "initial").await?;
+                let indicator = new_gauge(&jvm, false, 2).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        "setIndicator",
+                        "(Ljavax/microedition/lcdui/Gauge;)V",
+                        (indicator.clone(),),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setTimeout", "(I)V", (100,))
+                    .await?;
+
+                // Exercise decoration, Alert content, and indicator invalidation through their deadlines.
+                for (index, method) in ["setTitle", "setString", "setValue", "setMaxValue"].into_iter().enumerate() {
+                    let start = 1000 * (index as u64 + 1);
+                    clock.set(start);
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &display,
+                            "javax/microedition/lcdui/Display",
+                            "setCurrent",
+                            "(Ljavax/microedition/lcdui/Alert;Ljavax/microedition/lcdui/Displayable;)V",
+                            (alert.clone(), previous.clone()),
+                        )
+                        .await?;
+                    clock.set(start + 50);
+                    if index < 2 {
+                        let text = JavaLangString::from_rust_string(&jvm, "changed").await?;
+                        let _: () = jvm
+                            .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", method, "(Ljava/lang/String;)V", (text,))
+                            .await?;
+                    } else {
+                        let _: () = jvm
+                            .invoke_virtual(&indicator, "javax/microedition/lcdui/Gauge", method, "(I)V", (8,))
+                            .await?;
+                    }
+                    for now in [start + 100, start + 149] {
+                        clock.set(now);
+                        pump_backend_queue(&jvm, &system).await?;
+                        assert_eq!(
+                            current(&jvm, &display).await?.identity(),
+                            alert.identity(),
+                            "{method}: stale or early timeout"
+                        );
+                    }
+                    clock.set(start + 150);
+                    pump_backend_queue(&jvm, &system).await?;
+                    assert_eq!(
+                        current(&jvm, &display).await?.identity(),
+                        previous.identity(),
+                        "{method}: replacement timer did not fire"
+                    );
+                }
+
+                show(&jvm, &display, JavaValue::from(alert.clone()).into()).await?;
+                let other = new_form(&jvm).await?;
+                show(&jvm, &display, other.clone()).await?;
+                clock.advance(100);
+                pump_backend_queue(&jvm, &system).await?;
+                assert_eq!(current(&jvm, &display).await?.identity(), other.identity());
+                let next: ClassInstanceRef<Displayable> = jvm.get_field(&alert, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;").await?;
+                assert!(next.is_null());
+
+                let _: () = jvm
+                    .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setTimeout", "(I)V", (-2,))
+                    .await?;
+                show(&jvm, &display, JavaValue::from(alert.clone()).into()).await?;
+                clock.advance(1000);
+                pump_backend_queue(&jvm, &system).await?;
+                assert_eq!(current(&jvm, &display).await?.identity(), alert.identity());
+                assert!(system.event_queue().pop().is_none(), "modal Alert must not schedule a timer");
+                Ok(())
+            },
+        )
+    }
+
+    #[test]
+    fn sole_application_command_fires_once_at_the_exact_deadline_despite_listener_exception() -> Result<()> {
+        let clock = TestClock::new();
+        run_jvm_test_with_system(
+            test_protos(),
+            Box::new(TestPlatform::with_clock(clock.clone())),
+            move |jvm, system| async move {
+                let display = test_midlet_display(&jvm).await?;
+                let previous = new_form(&jvm).await?;
+                let alert = new_alert(&jvm, "custom").await?;
+                let command = new_command(&jvm, "Continue").await?;
+                let listener = jvm.new_class("javax/microedition/lcdui/TestAlertCommandListener", "()V", ()).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        "addCommand",
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (command.clone(),),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        "setCommandListener",
+                        "(Ljavax/microedition/lcdui/CommandListener;)V",
+                        (listener.clone(),),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setTimeout", "(I)V", (50,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "setCurrent",
+                        "(Ljavax/microedition/lcdui/Alert;Ljavax/microedition/lcdui/Displayable;)V",
+                        (alert.clone(), previous.clone()),
+                    )
+                    .await?;
+                for (now, count) in [(49, 0), (50, 1), (50, 1), (1000, 1)] {
+                    clock.set(now);
+                    pump_backend_queue(&jvm, &system).await?;
+                    assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, count);
+                    assert_eq!(current(&jvm, &display).await?.identity(), alert.identity());
+                }
+                let delivered: ClassInstanceRef<Command> = jvm.get_field(&listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+                let target: ClassInstanceRef<Displayable> = jvm
+                    .get_field(&listener, "lastDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                    .await?;
+                assert_eq!(delivered.identity(), command.identity());
+                assert_eq!(target.identity(), alert.identity());
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &alert,
+                        "javax/microedition/lcdui/Alert",
+                        "setCommandListener",
+                        "(Ljavax/microedition/lcdui/CommandListener;)V",
+                        (ClassInstanceRef::<CommandListener>::new(None),),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "handleKeyEvent",
+                        "(II)V",
+                        (KeyboardEventType::KeyPressed as i32, MIDPKeyCode::LEFT_SOFT_KEY as i32),
+                    )
+                    .await?;
+                assert_eq!(current(&jvm, &display).await?.identity(), previous.identity());
+                assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, 1);
+                Ok(())
+            },
+        )
+    }
+
+    #[test]
+    fn timed_alert_without_previous_screen_clears_the_backing_image() -> Result<()> {
+        let clock = TestClock::new();
+        run_jvm_test_with_system(
+            test_protos(),
+            Box::new(TestPlatform::with_clock(clock.clone())),
+            move |jvm, system| async move {
+                let display = test_midlet_display(&jvm).await?;
+                let alert = new_alert(&jvm, "temporary").await?;
+                let _: () = jvm
+                    .invoke_virtual(&alert, "javax/microedition/lcdui/Alert", "setTimeout", "(I)V", (25,))
+                    .await?;
+                show(&jvm, &display, JavaValue::from(alert.clone()).into()).await?;
+                let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+                let screen_image = Graphics::image(&jvm, &mut graphics).await?;
+                for expired in [false, true] {
+                    if expired {
+                        clock.set(25);
+                        pump_backend_queue(&jvm, &system).await?;
+                        assert!(current(&jvm, &display).await?.is_null());
+                        let shown: bool = jvm
+                            .invoke_virtual(&alert, "javax/microedition/lcdui/Displayable", "isShown", "()Z", ())
+                            .await?;
+                        assert!(!shown);
+                    }
+                    let _: () = jvm
+                        .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                        .await?;
+                    let image = Image::image(&jvm, &screen_image).await?;
+                    let blank = (0..240).all(|y| {
+                        (0..320).all(|x| {
+                            let color = image.get_pixel(x, y);
+                            (color.r, color.g, color.b) == (0xff, 0xff, 0xff)
+                        })
+                    });
+                    assert_eq!(blank, expired);
+                }
+                Ok(())
+            },
+        )
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -3,13 +3,11 @@ use alloc::{string::String as RustString, vec, vec::Vec};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-use rustjava_runtime::classes::java::{lang::String, util::Vector};
+use rustjava_runtime::classes::java::lang::String;
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::{
-    AlertType, Command, CommandListener, Display, Displayable, Font, Gauge, Graphics, Image, Item, ItemCommandListener,
-};
+use crate::classes::javax::microedition::lcdui::{AlertType, Command, CommandListener, Display, Displayable, Font, Gauge, Graphics, Image, Item};
 use crate::classes::net::wie::{KeyboardEventType, MIDPKeyCode};
 
 const CONTENT_GAP: i32 = 4;
@@ -110,6 +108,12 @@ impl Alert {
                     "getCommandAt",
                     "(I)Ljavax/microedition/lcdui/Command;",
                     Self::get_command_at,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "setNextDisplayable",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    Self::set_next_displayable,
                     MethodAccessFlags::empty(),
                 ),
                 JavaMethodProto::new("dispatchCommandAt", "(I)V", Self::dispatch_command_at, MethodAccessFlags::empty()),
@@ -341,7 +345,15 @@ impl Alert {
     }
 
     async fn invalidate_current(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, request_repaint: bool) -> JvmResult<()> {
-        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if display.is_null() {
             let _ = Self::effective_timeout(jvm, context, this).await?;
             return Ok(());
@@ -422,9 +434,9 @@ impl Alert {
         jvm: &Jvm,
         context: &mut WieJvmContext,
         mut this: ClassInstanceRef<Self>,
-        mut indicator: ClassInstanceRef<Gauge>,
+        indicator: ClassInstanceRef<Gauge>,
     ) -> JvmResult<()> {
-        let mut old_indicator: ClassInstanceRef<Gauge> = jvm.get_field(&this, "indicator", "Ljavax/microedition/lcdui/Gauge;").await?;
+        let old_indicator: ClassInstanceRef<Gauge> = jvm.get_field(&this, "indicator", "Ljavax/microedition/lcdui/Gauge;").await?;
         if (old_indicator.is_null() && indicator.is_null())
             || (!old_indicator.is_null() && !indicator.is_null() && old_indicator.identity() == indicator.identity())
         {
@@ -432,26 +444,10 @@ impl Alert {
         }
 
         if !indicator.is_null() {
-            let interactive: bool = jvm.get_field(&indicator, "interactive", "Z").await?;
-            let owner: ClassInstanceRef<Displayable> = jvm.get_field(&indicator, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
-            let commands: ClassInstanceRef<Vector> = jvm.get_field(&indicator, "commands", "Ljava/util/Vector;").await?;
-            let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
-            let listener: ClassInstanceRef<ItemCommandListener> = jvm
-                .get_field(&indicator, "itemCommandListener", "Ljavax/microedition/lcdui/ItemCommandListener;")
+            let eligible: bool = jvm
+                .invoke_virtual(&indicator, "javax/microedition/lcdui/Gauge", "canBeAlertIndicator", "()Z", ())
                 .await?;
-            let label: ClassInstanceRef<String> = jvm.get_field(&indicator, "label", "Ljava/lang/String;").await?;
-            let preferred_width: i32 = jvm.get_field(&indicator, "preferredWidth", "I").await?;
-            let preferred_height: i32 = jvm.get_field(&indicator, "preferredHeight", "I").await?;
-            let layout: i32 = jvm.get_field(&indicator, "layout", "I").await?;
-            if interactive
-                || !owner.is_null()
-                || command_count != 0
-                || !listener.is_null()
-                || !label.is_null()
-                || preferred_width != -1
-                || preferred_height != -1
-                || layout != 0
-            {
+            if !eligible {
                 return Err(jvm
                     .exception("java/lang/IllegalArgumentException", "Gauge cannot be used as an Alert indicator")
                     .await);
@@ -459,12 +455,24 @@ impl Alert {
         }
 
         if !old_indicator.is_null() {
-            jvm.put_field(&mut old_indicator, "owner", "Ljavax/microedition/lcdui/Displayable;", None)
-                .await?;
+            jvm.invoke_virtual::<_, ()>(
+                &old_indicator,
+                "javax/microedition/lcdui/Item",
+                "setOwner",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (None,),
+            )
+            .await?;
         }
         if !indicator.is_null() {
-            jvm.put_field(&mut indicator, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
-                .await?;
+            jvm.invoke_virtual::<_, ()>(
+                &indicator,
+                "javax/microedition/lcdui/Item",
+                "setOwner",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (this.clone(),),
+            )
+            .await?;
         }
         jvm.put_field(&mut this, "indicator", "Ljavax/microedition/lcdui/Gauge;", indicator)
             .await?;
@@ -581,25 +589,31 @@ impl Alert {
                 (index,),
             )
             .await?;
-        let listener: ClassInstanceRef<CommandListener> = jvm
-            .get_field(&this, "commandListener", "Ljavax/microedition/lcdui/CommandListener;")
+        let dispatched: bool = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "dispatchCommand",
+                "(Ljavax/microedition/lcdui/Command;)Z",
+                (command,),
+            )
             .await?;
-        if !listener.is_null() {
-            return jvm
-                .invoke_virtual(
-                    &listener,
-                    "javax/microedition/lcdui/CommandListener",
-                    "commandAction",
-                    "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
-                    (command, this),
-                )
-                .await;
+        if dispatched {
+            return Ok(());
         }
 
         let next: ClassInstanceRef<Displayable> = jvm.get_field(&this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;").await?;
         jvm.put_field(&mut this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", None)
             .await?;
-        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if display.is_null() {
             return Ok(());
         }
@@ -626,6 +640,16 @@ impl Alert {
         }
 
         Ok(())
+    }
+
+    async fn set_next_displayable(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        next: ClassInstanceRef<Displayable>,
+    ) -> JvmResult<()> {
+        jvm.put_field(&mut this, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", next)
+            .await
     }
 
     async fn set_display(

--- a/wie-midp/src/classes/javax/microedition/lcdui/canvas.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/canvas.rs
@@ -144,14 +144,14 @@ impl Canvas {
             return Ok(());
         }
 
+        jvm.put_field(&mut this, "isInFullScreenMode", "Z", mode).await?;
+
         let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         if !display.is_null() {
             let _: () = jvm
                 .invoke_virtual(&display, "javax/microedition/lcdui/Display", "setFullscreen", "(Z)V", (mode,))
                 .await?;
         }
-
-        jvm.put_field(&mut this, "isInFullScreenMode", "Z", mode).await?;
 
         Ok(())
     }
@@ -184,7 +184,7 @@ impl Canvas {
                 jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "keyRepeated", "(I)V", (code,))
                     .await
             }
-            _ => unimplemented!(),
+            KeyboardEventType::KeyTyped => Ok(()),
         }?;
 
         Ok(())
@@ -209,5 +209,284 @@ impl Canvas {
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec};
+    use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
+    use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+    use test_utils::run_jvm_test;
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_util::Result;
+
+    use crate::{
+        classes::{
+            javax::microedition::lcdui::{Canvas, Command, Display, Graphics, Image},
+            net::wie::{KeyboardEventType, MIDPKeyCode},
+        },
+        get_protos,
+    };
+
+    struct RecordingCanvas;
+    struct RecordingGameCanvas;
+
+    impl RecordingCanvas {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingCanvas",
+                parent_class: Some("javax/microedition/lcdui/Canvas"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "paint",
+                        "(Ljavax/microedition/lcdui/Graphics;)V",
+                        Self::paint,
+                        MethodAccessFlags::PROTECTED,
+                    ),
+                    JavaMethodProto::new("sizeChanged", "(II)V", Self::size_changed, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, MethodAccessFlags::PROTECTED),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("translateX", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("translateY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipX", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipHeight", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("sizeChangedCount", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastHeight", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("pressed", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("repeated", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("released", "I", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/lcdui/Canvas", "<init>", "()V", ()).await
+        }
+
+        async fn paint(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            graphics: ClassInstanceRef<Graphics>,
+        ) -> JvmResult<()> {
+            for (field, method) in [
+                ("translateX", "getTranslateX"),
+                ("translateY", "getTranslateY"),
+                ("clipX", "getClipX"),
+                ("clipY", "getClipY"),
+                ("clipWidth", "getClipWidth"),
+                ("clipHeight", "getClipHeight"),
+            ] {
+                let value: i32 = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", method, "()I", ())
+                    .await?;
+                jvm.put_field(&mut this, field, "I", value).await?;
+            }
+
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x22aa44,))
+                .await?;
+            jvm.invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 320, 240))
+                .await
+        }
+
+        async fn size_changed(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "sizeChangedCount", "I").await?;
+            jvm.put_field(&mut this, "sizeChangedCount", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastWidth", "I", width).await?;
+            jvm.put_field(&mut this, "lastHeight", "I", height).await
+        }
+
+        async fn key_pressed(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, code: i32) -> JvmResult<()> {
+            jvm.put_field(&mut this, "pressed", "I", code).await
+        }
+
+        async fn key_repeated(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, code: i32) -> JvmResult<()> {
+            jvm.put_field(&mut this, "repeated", "I", code).await
+        }
+
+        async fn key_released(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, code: i32) -> JvmResult<()> {
+            jvm.put_field(&mut this, "released", "I", code).await
+        }
+    }
+
+    impl RecordingGameCanvas {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingGameCanvas",
+                parent_class: Some("javax/microedition/lcdui/game/GameCanvas"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("sizeChanged", "(II)V", Self::size_changed, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyPressed", "(I)V", Self::key_pressed, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyRepeated", "(I)V", Self::key_repeated, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new("keyReleased", "(I)V", Self::key_released, MethodAccessFlags::PROTECTED),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("sizeChangedCount", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastHeight", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("pressed", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("repeated", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("released", "I", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/lcdui/game/GameCanvas", "<init>", "(Z)V", (false,))
+                .await
+        }
+
+        async fn size_changed(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "sizeChangedCount", "I").await?;
+            jvm.put_field(&mut this, "sizeChangedCount", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastWidth", "I", width).await?;
+            jvm.put_field(&mut this, "lastHeight", "I", height).await
+        }
+
+        async fn key_pressed(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, code: i32) -> JvmResult<()> {
+            jvm.put_field(&mut this, "pressed", "I", code).await
+        }
+
+        async fn key_repeated(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, code: i32) -> JvmResult<()> {
+            jvm.put_field(&mut this, "repeated", "I", code).await
+        }
+
+        async fn key_released(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, code: i32) -> JvmResult<()> {
+            jvm.put_field(&mut this, "released", "I", code).await
+        }
+    }
+
+    #[test]
+    fn canvas_and_game_canvas_fullscreen_preserve_paint_and_keys() -> Result<()> {
+        run_jvm_test(
+            Box::new([get_protos().into(), [RecordingCanvas::as_proto(), RecordingGameCanvas::as_proto()].into()]),
+            |jvm| async move {
+                let display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
+                for (class, game_canvas) in [
+                    ("javax/microedition/lcdui/TestRecordingCanvas", false),
+                    ("javax/microedition/lcdui/TestRecordingGameCanvas", true),
+                ] {
+                    let canvas: ClassInstanceRef<Canvas> = jvm.new_class(class, "()V", ()).await?.into();
+                    let title = JavaLangString::from_rust_string(&jvm, "Canvas title").await?;
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &canvas,
+                            "javax/microedition/lcdui/Displayable",
+                            "setTitle",
+                            "(Ljava/lang/String;)V",
+                            (title,),
+                        )
+                        .await?;
+                    let label = JavaLangString::from_rust_string(&jvm, "Select").await?;
+                    let command: ClassInstanceRef<Command> = jvm
+                        .new_class("javax/microedition/lcdui/Command", "(Ljava/lang/String;II)V", (label, 4, 0))
+                        .await?
+                        .into();
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &canvas,
+                            "javax/microedition/lcdui/Displayable",
+                            "addCommand",
+                            "(Ljavax/microedition/lcdui/Command;)V",
+                            (command,),
+                        )
+                        .await?;
+                    let decorated_height: i32 = jvm
+                        .invoke_virtual(&canvas, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+                        .await?;
+                    assert!(decorated_height < 240);
+                    if game_canvas {
+                        let graphics: ClassInstanceRef<Graphics> = jvm
+                            .invoke_virtual(
+                                &canvas,
+                                "javax/microedition/lcdui/game/GameCanvas",
+                                "getGraphics",
+                                "()Ljavax/microedition/lcdui/Graphics;",
+                                (),
+                            )
+                            .await?;
+                        let _: () = jvm
+                            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x22aa44,))
+                            .await?;
+                        let _: () = jvm
+                            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 320, 240))
+                            .await?;
+                    }
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &display,
+                            "javax/microedition/lcdui/Display",
+                            "setCurrent",
+                            "(Ljavax/microedition/lcdui/Displayable;)V",
+                            (canvas.clone(),),
+                        )
+                        .await?;
+                    for (fullscreen, callback_count, event_type, field, key) in [
+                        (false, 1, KeyboardEventType::KeyPressed, "pressed", MIDPKeyCode::KEY_NUM1),
+                        (true, 2, KeyboardEventType::KeyRepeated, "repeated", MIDPKeyCode::KEY_NUM2),
+                        (false, 3, KeyboardEventType::KeyReleased, "released", MIDPKeyCode::KEY_NUM3),
+                    ] {
+                        let _: () = jvm
+                            .invoke_virtual(&canvas, "javax/microedition/lcdui/Canvas", "setFullScreenMode", "(Z)V", (fullscreen,))
+                            .await?;
+                        let key = key as i32;
+                        let height = if fullscreen { 240 } else { decorated_height };
+                        assert_eq!(
+                            jvm.invoke_virtual::<_, i32>(&canvas, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+                                .await?,
+                            height
+                        );
+                        assert_eq!(jvm.get_field::<i32>(&canvas, "sizeChangedCount", "I").await?, callback_count);
+                        assert_eq!(jvm.get_field::<i32>(&canvas, "lastHeight", "I").await?, height);
+                        let _: () = jvm
+                            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                            .await?;
+                        if !game_canvas {
+                            for coordinate in ["translateX", "clipX", "clipY"] {
+                                assert_eq!(jvm.get_field::<i32>(&canvas, coordinate, "I").await?, 0);
+                            }
+                            assert_eq!(jvm.get_field::<i32>(&canvas, "translateY", "I").await? == 0, fullscreen);
+                            assert_eq!(jvm.get_field::<i32>(&canvas, "clipWidth", "I").await?, 320);
+                            assert_eq!(jvm.get_field::<i32>(&canvas, "clipHeight", "I").await?, height);
+                        }
+                        let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+                        let image_ref = Graphics::image(&jvm, &mut graphics).await?;
+                        let image = Image::image(&jvm, &image_ref).await?;
+                        let content = image.get_pixel(160, 120);
+                        assert_eq!((content.r, content.g, content.b), (0x22, 0xaa, 0x44));
+                        for (x, y) in [(0, 0), (319, 239)] {
+                            let pixel = image.get_pixel(x, y);
+                            assert_eq!((pixel.r, pixel.g, pixel.b) == (0x22, 0xaa, 0x44), fullscreen);
+                        }
+                        let _: () = jvm
+                            .invoke_virtual(
+                                &display,
+                                "javax/microedition/lcdui/Display",
+                                "handleKeyEvent",
+                                "(II)V",
+                                (event_type as i32, key),
+                            )
+                            .await?;
+                        assert_eq!(jvm.get_field::<i32>(&canvas, field, "I").await?, key);
+                    }
+                }
+                Ok(())
+            },
+        )
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/canvas.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/canvas.rs
@@ -63,7 +63,15 @@ impl Canvas {
     async fn repaint(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Canvas::repaint({this:?})");
 
-        let display = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         let _: () = jvm
             .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
             .await?;
@@ -82,7 +90,15 @@ impl Canvas {
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Canvas::repaint({this:?}, {x}, {y}, {width}, {height})");
 
-        let display = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         let _: () = jvm
             .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (x, y, width, height))
             .await?;
@@ -93,7 +109,15 @@ impl Canvas {
     async fn service_repaints(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Canvas::serviceRepaints({this:?})");
 
-        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if !display.is_null() {
             let _: () = jvm
                 .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
@@ -136,24 +160,9 @@ impl Canvas {
         Ok(())
     }
 
-    async fn set_full_screen_mode(jvm: &Jvm, _: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, mode: bool) -> JvmResult<()> {
-        tracing::debug!("javax.microedition.lcdui.Canvas::setFullScreenMode({this:?}, {mode})");
-
-        let previous_mode: bool = jvm.get_field(&this, "isInFullScreenMode", "Z").await?;
-        if previous_mode == mode {
-            return Ok(());
-        }
-
-        jvm.put_field(&mut this, "isInFullScreenMode", "Z", mode).await?;
-
-        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        if !display.is_null() {
-            let _: () = jvm
-                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "setFullscreen", "(Z)V", (mode,))
-                .await?;
-        }
-
-        Ok(())
+    async fn set_full_screen_mode(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, mode: bool) -> JvmResult<()> {
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "setFullScreen", "(Z)V", (mode,))
+            .await
     }
 
     async fn is_double_buffered(_: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {

--- a/wie-midp/src/classes/javax/microedition/lcdui/canvas.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/canvas.rs
@@ -464,7 +464,15 @@ mod test {
                             assert_eq!(jvm.get_field::<i32>(&canvas, "clipWidth", "I").await?, 320);
                             assert_eq!(jvm.get_field::<i32>(&canvas, "clipHeight", "I").await?, height);
                         }
-                        let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+                        let mut graphics: ClassInstanceRef<Graphics> = jvm
+                            .invoke_virtual(
+                                &display,
+                                "javax/microedition/lcdui/Display",
+                                "getScreenGraphics",
+                                "()Ljavax/microedition/lcdui/Graphics;",
+                                (),
+                            )
+                            .await?;
                         let image_ref = Graphics::image(&jvm, &mut graphics).await?;
                         let image = Image::image(&jvm, &image_ref).await?;
                         let content = image.get_pixel(160, 120);

--- a/wie-midp/src/classes/javax/microedition/lcdui/choice.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/choice.rs
@@ -1,0 +1,99 @@
+use alloc::vec;
+
+use jvm::{Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+// interface javax.microedition.lcdui.Choice
+pub struct Choice;
+
+impl Choice {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/Choice",
+            parent_class: None,
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new_abstract("size", "()I", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "getString",
+                    "(I)Ljava/lang/String;",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract(
+                    "getImage",
+                    "(I)Ljavax/microedition/lcdui/Image;",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract(
+                    "append",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;)I",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract(
+                    "insert",
+                    "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract("delete", "(I)V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("deleteAll", "()V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "set",
+                    "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract("isSelected", "(I)Z", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("getSelectedIndex", "()I", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("getSelectedFlags", "([Z)I", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("setSelectedIndex", "(IZ)V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("setSelectedFlags", "([Z)V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("setFitPolicy", "(I)V", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract("getFitPolicy", "()I", MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT),
+                JavaMethodProto::new_abstract(
+                    "setFont",
+                    "(ILjavax/microedition/lcdui/Font;)V",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+                JavaMethodProto::new_abstract(
+                    "getFont",
+                    "(I)Ljavax/microedition/lcdui/Font;",
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+                ),
+            ],
+            fields: [
+                "EXCLUSIVE",
+                "MULTIPLE",
+                "IMPLICIT",
+                "POPUP",
+                "TEXT_WRAP_DEFAULT",
+                "TEXT_WRAP_ON",
+                "TEXT_WRAP_OFF",
+            ]
+            .into_iter()
+            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
+            .collect(),
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Choice::<clinit>");
+
+        for (name, value) in [
+            ("EXCLUSIVE", 1),
+            ("MULTIPLE", 2),
+            ("IMPLICIT", 3),
+            ("POPUP", 4),
+            ("TEXT_WRAP_DEFAULT", 0),
+            ("TEXT_WRAP_ON", 1),
+            ("TEXT_WRAP_OFF", 2),
+        ] {
+            jvm.put_static_field("javax/microedition/lcdui/Choice", name, "I", value).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/choice.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/choice.rs
@@ -63,18 +63,43 @@ impl Choice {
                     MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
                 ),
             ],
-            fields: [
-                "EXCLUSIVE",
-                "MULTIPLE",
-                "IMPLICIT",
-                "POPUP",
-                "TEXT_WRAP_DEFAULT",
-                "TEXT_WRAP_ON",
-                "TEXT_WRAP_OFF",
-            ]
-            .into_iter()
-            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-            .collect(),
+            fields: vec![
+                JavaFieldProto::new(
+                    "EXCLUSIVE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "MULTIPLE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "IMPLICIT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "POPUP",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "TEXT_WRAP_DEFAULT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "TEXT_WRAP_ON",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "TEXT_WRAP_OFF",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+            ],
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
         }
     }

--- a/wie-midp/src/classes/javax/microedition/lcdui/choice.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/choice.rs
@@ -82,17 +82,14 @@ impl Choice {
     async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Choice::<clinit>");
 
-        for (name, value) in [
-            ("EXCLUSIVE", 1),
-            ("MULTIPLE", 2),
-            ("IMPLICIT", 3),
-            ("POPUP", 4),
-            ("TEXT_WRAP_DEFAULT", 0),
-            ("TEXT_WRAP_ON", 1),
-            ("TEXT_WRAP_OFF", 2),
-        ] {
-            jvm.put_static_field("javax/microedition/lcdui/Choice", name, "I", value).await?;
-        }
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "EXCLUSIVE", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "MULTIPLE", "I", 2).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "IMPLICIT", "I", 3).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "POPUP", "I", 4).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "TEXT_WRAP_DEFAULT", "I", 0)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "TEXT_WRAP_ON", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Choice", "TEXT_WRAP_OFF", "I", 2).await?;
 
         Ok(())
     }

--- a/wie-midp/src/classes/javax/microedition/lcdui/choice_group.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/choice_group.rs
@@ -1,13 +1,41 @@
-use alloc::vec;
+use alloc::{
+    string::{String as RustString, ToString},
+    vec,
+    vec::Vec,
+};
 
-use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
-use jvm_class_proto::JavaMethodProto;
-use jvm_types::{ClassAccessFlags, MethodAccessFlags};
-use rustjava_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::Image;
+use crate::classes::{
+    javax::microedition::lcdui::{Font, Graphics, Image, Item},
+    net::wie::{ChoiceElement, MIDPKeyCode},
+};
+
+const INDICATOR_SIZE: i32 = 10;
+const CONTROL_GAP: i32 = 4;
+const IMAGE_TEXT_GAP: i32 = 3;
+const ROW_VERTICAL_INSET: i32 = 1;
+const POPUP_INSET: i32 = 2;
+const TEXT_COLOR: i32 = 0x17212b;
+const CONTROL_COLOR: i32 = 0x596773;
+const SELECTED_COLOR: i32 = 0x2f7eb8;
+const HIGHLIGHT_BACKGROUND: i32 = 0xdcecf7;
+const POPUP_BACKGROUND: i32 = 0xf8fafb;
+const LEFT_TOP: i32 = 4 | 16;
+
+struct ElementContent {
+    text: RustString,
+    display_image: ClassInstanceRef<Image>,
+    image_width: i32,
+    image_height: i32,
+    font: ClassInstanceRef<Font>,
+    font_height: i32,
+}
 
 // class javax.microedition.lcdui.ChoiceGroup
 pub struct ChoiceGroup;
@@ -17,7 +45,7 @@ impl ChoiceGroup {
         WieJavaClassProto {
             name: "javax/microedition/lcdui/ChoiceGroup",
             parent_class: Some("javax/microedition/lcdui/Item"),
-            interfaces: vec![],
+            interfaces: vec!["javax/microedition/lcdui/Choice"],
             methods: vec![
                 JavaMethodProto::new("<init>", "(Ljava/lang/String;I)V", Self::init, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
@@ -26,8 +54,79 @@ impl ChoiceGroup {
                     Self::init_with_elements,
                     MethodAccessFlags::PUBLIC,
                 ),
+                JavaMethodProto::new("size", "()I", Self::size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getString", "(I)Ljava/lang/String;", Self::get_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "getImage",
+                    "(I)Ljavax/microedition/lcdui/Image;",
+                    Self::get_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "append",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;)I",
+                    Self::append,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "insert",
+                    "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                    Self::insert,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("delete", "(I)V", Self::delete, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("deleteAll", "()V", Self::delete_all, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "set",
+                    "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                    Self::set,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("isSelected", "(I)Z", Self::is_selected, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getSelectedIndex", "()I", Self::get_selected_index, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getSelectedFlags", "([Z)I", Self::get_selected_flags, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setSelectedIndex", "(IZ)V", Self::set_selected_index, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setSelectedFlags", "([Z)V", Self::set_selected_flags, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setFitPolicy", "(I)V", Self::set_fit_policy, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getFitPolicy", "()I", Self::get_fit_policy, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "setFont",
+                    "(ILjavax/microedition/lcdui/Font;)V",
+                    Self::set_font,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getFont", "(I)Ljavax/microedition/lcdui/Font;", Self::get_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "preferredContentHeight",
+                    "(I)I",
+                    Self::preferred_content_height,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "paintContent",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    Self::paint_content,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getFocusContentBounds",
+                    "(I)[I",
+                    Self::get_focus_content_bounds,
+                    MethodAccessFlags::empty(),
+                ),
             ],
-            fields: vec![],
+            fields: vec![
+                JavaFieldProto::new("choiceType", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("elements", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("fitPolicy", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("highlightedIndex", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("popupOpen", "Z", FieldAccessFlags::PRIVATE),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }
@@ -42,24 +141,21 @@ impl ChoiceGroup {
         tracing::debug!("javax.microedition.lcdui.ChoiceGroup::<init>({this:?}, {label:?}, {choice_type})");
 
         let string_elements = jvm.instantiate_array("[Ljava/lang/String;", 0).await?;
-
-        let _: () = jvm
-            .invoke_special(
-                &this,
-                "javax/microedition/lcdui/ChoiceGroup",
-                "<init>",
-                "(Ljava/lang/String;I[Ljava/lang/String;[Ljavax/microedition/lcdui/Image;)V",
-                (label, choice_type, string_elements, None),
-            )
-            .await?;
-
-        Ok(())
+        let image_elements = ClassInstanceRef::<Array<ClassInstanceRef<Image>>>::new(None);
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/ChoiceGroup",
+            "<init>",
+            "(Ljava/lang/String;I[Ljava/lang/String;[Ljavax/microedition/lcdui/Image;)V",
+            (label, choice_type, string_elements, image_elements),
+        )
+        .await
     }
 
     async fn init_with_elements(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         label: ClassInstanceRef<String>,
         choice_type: i32,
         string_elements: ClassInstanceRef<Array<ClassInstanceRef<String>>>,
@@ -67,8 +163,1338 @@ impl ChoiceGroup {
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.ChoiceGroup::<init>({this:?}, {label:?}, {choice_type}, {string_elements:?}, {image_elements:?})");
 
+        if !matches!(choice_type, 1 | 2 | 4) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid ChoiceGroup type").await);
+        }
+        if string_elements.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "String element array is null").await);
+        }
+
+        let element_count = jvm.array_length(&string_elements).await?;
+        if !image_elements.is_null() && jvm.array_length(&image_elements).await? != element_count {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "Choice element array lengths differ")
+                .await);
+        }
+        let strings: Vec<ClassInstanceRef<String>> = jvm.load_array(&string_elements, 0, element_count).await?;
+        if strings.iter().any(ClassInstanceRef::is_null) {
+            return Err(jvm.exception("java/lang/NullPointerException", "Choice string is null").await);
+        }
+        let images: Vec<ClassInstanceRef<Image>> = if image_elements.is_null() {
+            vec![ClassInstanceRef::new(None); element_count]
+        } else {
+            jvm.load_array(&image_elements, 0, element_count).await?
+        };
+
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
+        let elements: ClassInstanceRef<Vector> = jvm.new_class("java/util/Vector", "()V", ()).await?.into();
+        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        jvm.put_field(&mut this, "choiceType", "I", choice_type).await?;
+        jvm.put_field(&mut this, "elements", "Ljava/util/Vector;", elements.clone()).await?;
+        jvm.put_field(&mut this, "fitPolicy", "I", 0).await?;
+        jvm.put_field(&mut this, "highlightedIndex", "I", -1).await?;
+        jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
+
+        for (index, (text, image)) in strings.into_iter().zip(images).enumerate() {
+            let element = jvm
+                .new_class(
+                    "net/wie/ChoiceElement",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;Z)V",
+                    (text, image, choice_type != 2 && index == 0),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&elements, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (element,))
+                .await?;
+        }
+
+        Self::normalize_highlight(jvm, &mut this).await?;
 
         Ok(())
+    }
+
+    async fn element_at(jvm: &Jvm, this: &ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<ChoiceElement>> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if index < 0 || index >= size {
+            return Err(jvm
+                .exception("java/lang/IndexOutOfBoundsException", "Choice index is out of bounds")
+                .await);
+        }
+
+        jvm.invoke_virtual(&elements, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+            .await
+    }
+
+    async fn selected_index(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        for index in 0..size {
+            let element = Self::element_at(jvm, this, index).await?;
+            if jvm.get_field(&element, "selected", "Z").await? {
+                return Ok(index);
+            }
+        }
+        Ok(-1)
+    }
+
+    async fn select_only(jvm: &Jvm, this: &ClassInstanceRef<Self>, selected_index: i32) -> JvmResult<bool> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        let mut changed = false;
+        for index in 0..size {
+            let mut element = Self::element_at(jvm, this, index).await?;
+            let selected: bool = jvm.get_field(&element, "selected", "Z").await?;
+            let new_selected = index == selected_index;
+            if selected != new_selected {
+                jvm.put_field(&mut element, "selected", "Z", new_selected).await?;
+                changed = true;
+            }
+        }
+        Ok(changed)
+    }
+
+    async fn normalize_highlight(jvm: &Jvm, this: &mut ClassInstanceRef<Self>) -> JvmResult<()> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            jvm.put_field(this, "highlightedIndex", "I", -1).await?;
+            return jvm.put_field(this, "popupOpen", "Z", false).await;
+        }
+
+        let highlighted_index: i32 = jvm.get_field(this, "highlightedIndex", "I").await?;
+        let highlighted_index = if highlighted_index < 0 {
+            let choice_type: i32 = jvm.get_field(this, "choiceType", "I").await?;
+            if choice_type == 2 { 0 } else { Self::selected_index(jvm, this).await? }
+        } else {
+            highlighted_index.min(size - 1)
+        };
+        jvm.put_field(this, "highlightedIndex", "I", highlighted_index).await
+    }
+
+    async fn element_content(jvm: &Jvm, element: &ClassInstanceRef<ChoiceElement>) -> JvmResult<ElementContent> {
+        let text: ClassInstanceRef<String> = jvm.get_field(element, "text", "Ljava/lang/String;").await?;
+        let text = JavaLangString::to_rust_string(jvm, &text).await?;
+        let display_image: ClassInstanceRef<Image> = jvm.get_field(element, "displayImage", "Ljavax/microedition/lcdui/Image;").await?;
+        let (image_width, image_height) = if display_image.is_null() {
+            (0, 0)
+        } else {
+            (
+                jvm.invoke_virtual(&display_image, "javax/microedition/lcdui/Image", "getWidth", "()I", ())
+                    .await?,
+                jvm.invoke_virtual(&display_image, "javax/microedition/lcdui/Image", "getHeight", "()I", ())
+                    .await?,
+            )
+        };
+        let mut font: ClassInstanceRef<Font> = jvm.get_field(element, "font", "Ljavax/microedition/lcdui/Font;").await?;
+        if font.is_null() {
+            font = jvm
+                .invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await?;
+        }
+        let font_height: i32 = jvm.invoke_virtual(&font, "javax/microedition/lcdui/Font", "getHeight", "()I", ()).await?;
+
+        Ok(ElementContent {
+            text,
+            display_image,
+            image_width,
+            image_height,
+            font,
+            font_height: font_height.max(1),
+        })
+    }
+
+    async fn font_text_width(jvm: &Jvm, font: &ClassInstanceRef<Font>, text: &str) -> JvmResult<i32> {
+        let text = JavaLangString::from_rust_string(jvm, text).await?;
+        jvm.invoke_virtual(font, "javax/microedition/lcdui/Font", "stringWidth", "(Ljava/lang/String;)I", (text,))
+            .await
+    }
+
+    async fn preferred_text_width(jvm: &Jvm, content: &ElementContent) -> JvmResult<i32> {
+        let mut width = 0;
+        for line in content.text.split('\n') {
+            width = width.max(Self::font_text_width(jvm, &content.font, line).await?);
+        }
+        Ok(width)
+    }
+
+    async fn minimum_text_width(jvm: &Jvm, content: &ElementContent, fit_policy: i32) -> JvmResult<i32> {
+        if fit_policy == 2 {
+            return Self::preferred_text_width(jvm, content).await;
+        }
+
+        let mut width = 0;
+        for character in content.text.chars().filter(|character| *character != '\n') {
+            width = width.max(Self::font_text_width(jvm, &content.font, &character.to_string()).await?);
+        }
+        Ok(width)
+    }
+
+    async fn wrap_text(jvm: &Jvm, content: &ElementContent, maximum_width: Option<i32>) -> JvmResult<Vec<RustString>> {
+        let mut lines = Vec::new();
+        for paragraph in content.text.split('\n') {
+            let characters = paragraph.chars().collect::<Vec<_>>();
+            if characters.is_empty() {
+                lines.push(RustString::new());
+                continue;
+            }
+
+            let Some(maximum_width) = maximum_width else {
+                lines.push(paragraph.to_string());
+                continue;
+            };
+            let maximum_width = maximum_width.max(1);
+            let mut widths = Vec::with_capacity(characters.len());
+            for character in &characters {
+                widths.push(Self::font_text_width(jvm, &content.font, &character.to_string()).await?);
+            }
+
+            let mut start = 0;
+            while start < characters.len() {
+                let mut end = start;
+                let mut width = 0;
+                let mut word_boundary = None;
+                while end < characters.len() {
+                    let character_width = widths[end];
+                    if end > start && width + character_width > maximum_width {
+                        break;
+                    }
+                    width += character_width;
+                    end += 1;
+                    if characters[end - 1].is_whitespace() {
+                        word_boundary = Some(end);
+                    }
+                }
+
+                let split = if end == characters.len() {
+                    end
+                } else {
+                    word_boundary.filter(|boundary| *boundary > start).unwrap_or(end.max(start + 1))
+                };
+                let line = characters[start..split].iter().collect::<RustString>();
+                lines.push(line.trim_end().to_string());
+                start = split;
+                while start < characters.len() && characters[start].is_whitespace() {
+                    start += 1;
+                }
+            }
+        }
+        Ok(lines)
+    }
+
+    fn image_and_text_width(content: &ElementContent, text_width: i32) -> i32 {
+        content.image_width
+            + if content.image_width > 0 && !content.text.is_empty() {
+                IMAGE_TEXT_GAP
+            } else {
+                0
+            }
+            + text_width
+    }
+
+    async fn element_row_height(jvm: &Jvm, content: &ElementContent, width: i32, fit_policy: i32) -> JvmResult<i32> {
+        let text_width = (width - INDICATOR_SIZE - CONTROL_GAP - Self::image_and_text_width(content, 0)).max(1);
+        let lines = Self::wrap_text(jvm, content, (fit_policy != 2).then_some(text_width)).await?;
+        Ok((lines.len() as i32 * content.font_height).max(content.image_height).max(INDICATOR_SIZE) + ROW_VERTICAL_INSET * 2)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_element(
+        jvm: &Jvm,
+        graphics: &ClassInstanceRef<Graphics>,
+        content: &ElementContent,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        choice_type: i32,
+        fit_policy: i32,
+        selected: bool,
+        highlighted: bool,
+        popup_closed: bool,
+    ) -> JvmResult<()> {
+        if highlighted {
+            let _: () = jvm
+                .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (HIGHLIGHT_BACKGROUND,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (x, y, width.max(0), height.max(0)),
+                )
+                .await?;
+        }
+
+        let control_on_left = !popup_closed;
+        if control_on_left {
+            let indicator_x = x;
+            let indicator_y = y + (height - INDICATOR_SIZE) / 2;
+            let _: () = jvm
+                .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (CONTROL_COLOR,))
+                .await?;
+            if choice_type == 2 {
+                let _: () = jvm
+                    .invoke_virtual(
+                        graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawRect",
+                        "(IIII)V",
+                        (indicator_x, indicator_y, INDICATOR_SIZE - 1, INDICATOR_SIZE - 1),
+                    )
+                    .await?;
+                if selected {
+                    let _: () = jvm
+                        .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (SELECTED_COLOR,))
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(
+                            graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "fillRect",
+                            "(IIII)V",
+                            (indicator_x + 2, indicator_y + 2, INDICATOR_SIZE - 4, INDICATOR_SIZE - 4),
+                        )
+                        .await?;
+                }
+            } else {
+                let _: () = jvm
+                    .invoke_virtual(
+                        graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawArc",
+                        "(IIIIII)V",
+                        (indicator_x, indicator_y, INDICATOR_SIZE - 1, INDICATOR_SIZE - 1, 0, 360),
+                    )
+                    .await?;
+                if selected {
+                    let _: () = jvm
+                        .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (SELECTED_COLOR,))
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(
+                            graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "fillArc",
+                            "(IIIIII)V",
+                            (indicator_x + 3, indicator_y + 3, INDICATOR_SIZE - 6, INDICATOR_SIZE - 6, 0, 360),
+                        )
+                        .await?;
+                }
+            }
+        }
+
+        if popup_closed {
+            let arrow_x = x + width - INDICATOR_SIZE / 2 - 1;
+            let arrow_y = y + height / 2;
+            let _: () = jvm
+                .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (CONTROL_COLOR,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawLine",
+                    "(IIII)V",
+                    (arrow_x - 3, arrow_y - 2, arrow_x, arrow_y + 1),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawLine",
+                    "(IIII)V",
+                    (arrow_x, arrow_y + 1, arrow_x + 3, arrow_y - 2),
+                )
+                .await?;
+        }
+
+        let mut content_x = x + if control_on_left { INDICATOR_SIZE + CONTROL_GAP } else { 0 };
+        let trailing_control_width = if popup_closed { INDICATOR_SIZE + CONTROL_GAP } else { 0 };
+        let available_right = x + width - trailing_control_width;
+        if !content.display_image.is_null() && content.image_width > 0 && content.image_height > 0 {
+            let image_y = y + (height - content.image_height) / 2;
+            let _: () = jvm
+                .invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawImage",
+                    "(Ljavax/microedition/lcdui/Image;III)V",
+                    (content.display_image.clone(), content_x, image_y, LEFT_TOP),
+                )
+                .await?;
+            content_x += content.image_width;
+            if !content.text.is_empty() {
+                content_x += IMAGE_TEXT_GAP;
+            }
+        }
+
+        let text_width = (available_right - content_x).max(1);
+        let lines = Self::wrap_text(jvm, content, (fit_policy != 2).then_some(text_width)).await?;
+        let text_height = lines.len() as i32 * content.font_height;
+        let text_y = y + (height - text_height) / 2;
+        let _: () = jvm
+            .invoke_virtual(
+                graphics,
+                "javax/microedition/lcdui/Graphics",
+                "setFont",
+                "(Ljavax/microedition/lcdui/Font;)V",
+                (content.font.clone(),),
+            )
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TEXT_COLOR,))
+            .await?;
+        for (line_index, line) in lines.iter().enumerate() {
+            let line_y = text_y + line_index as i32 * content.font_height;
+            if line_y >= y + height {
+                break;
+            }
+            let line = JavaLangString::from_rust_string(jvm, line).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawString",
+                    "(Ljava/lang/String;III)V",
+                    (line, content_x, line_y, LEFT_TOP),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await
+    }
+
+    async fn get_string(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<String>> {
+        let element = Self::element_at(jvm, &this, index).await?;
+        jvm.get_field(&element, "text", "Ljava/lang/String;").await
+    }
+
+    async fn get_image(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<Image>> {
+        let element = Self::element_at(jvm, &this, index).await?;
+        jvm.get_field(&element, "image", "Ljavax/microedition/lcdui/Image;").await
+    }
+
+    async fn append(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        text: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+    ) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let index: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/ChoiceGroup",
+                "insert",
+                "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                (index, text, image),
+            )
+            .await?;
+        Ok(index)
+    }
+
+    async fn insert(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        index: i32,
+        text: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+    ) -> JvmResult<()> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if index < 0 || index > size {
+            return Err(jvm
+                .exception("java/lang/IndexOutOfBoundsException", "Choice insert index is out of bounds")
+                .await);
+        }
+        if text.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Choice string is null").await);
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let element = jvm
+            .new_class(
+                "net/wie/ChoiceElement",
+                "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;Z)V",
+                (text, image, choice_type != 2 && size == 0),
+            )
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &elements,
+                "java/util/Vector",
+                "insertElementAt",
+                "(Ljava/lang/Object;I)V",
+                (element, index),
+            )
+            .await?;
+
+        let highlighted_index: i32 = jvm.get_field(&this, "highlightedIndex", "I").await?;
+        jvm.put_field(
+            &mut this,
+            "highlightedIndex",
+            "I",
+            if highlighted_index < 0 {
+                -1
+            } else if index <= highlighted_index {
+                highlighted_index + 1
+            } else {
+                highlighted_index
+            },
+        )
+        .await?;
+        Self::normalize_highlight(jvm, &mut this).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn delete(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
+        let removed = Self::element_at(jvm, &this, index).await?;
+        let was_selected: bool = jvm.get_field(&removed, "selected", "Z").await?;
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let _: ClassInstanceRef<ChoiceElement> = jvm
+            .invoke_virtual(&elements, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (index,))
+            .await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        if was_selected && choice_type != 2 && size > 0 {
+            let mut replacement = Self::element_at(jvm, &this, index.min(size - 1)).await?;
+            jvm.put_field(&mut replacement, "selected", "Z", true).await?;
+        }
+
+        let highlighted_index: i32 = jvm.get_field(&this, "highlightedIndex", "I").await?;
+        let highlighted_index = if highlighted_index > index {
+            highlighted_index - 1
+        } else {
+            highlighted_index
+        };
+        jvm.put_field(&mut this, "highlightedIndex", "I", highlighted_index).await?;
+        Self::normalize_highlight(jvm, &mut this).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn delete_all(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let _: () = jvm.invoke_virtual(&elements, "java/util/Vector", "removeAllElements", "()V", ()).await?;
+        jvm.put_field(&mut this, "highlightedIndex", "I", -1).await?;
+        jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
+        Self::normalize_highlight(jvm, &mut this).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn set(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        index: i32,
+        text: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+    ) -> JvmResult<()> {
+        let mut element = Self::element_at(jvm, &this, index).await?;
+        if text.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Choice string is null").await);
+        }
+        let display_image: ClassInstanceRef<Image> = if image.is_null() {
+            ClassInstanceRef::new(None)
+        } else {
+            jvm.invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(Ljavax/microedition/lcdui/Image;)Ljavax/microedition/lcdui/Image;",
+                (image.clone(),),
+            )
+            .await?
+        };
+        jvm.put_field(&mut element, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut element, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
+        jvm.put_field(&mut element, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
+            .await?;
+        Self::normalize_highlight(jvm, &mut this).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn is_selected(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<bool> {
+        let element = Self::element_at(jvm, &this, index).await?;
+        jvm.get_field(&element, "selected", "Z").await
+    }
+
+    async fn get_selected_index(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        if choice_type == 2 {
+            return Ok(-1);
+        }
+        Self::selected_index(jvm, &this).await
+    }
+
+    async fn get_selected_flags(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        mut selected_array: ClassInstanceRef<Array<bool>>,
+    ) -> JvmResult<i32> {
+        if selected_array.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Selection array is null").await);
+        }
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        let array_length = jvm.array_length(&selected_array).await?;
+        if array_length < size as usize {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Selection array is too short").await);
+        }
+
+        let mut selected_count = 0;
+        let mut flags = vec![false; array_length];
+        for index in 0..size {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let selected: bool = jvm.get_field(&element, "selected", "Z").await?;
+            flags[index as usize] = selected;
+            selected_count += i32::from(selected);
+        }
+        jvm.store_array(&mut selected_array, 0, flags).await?;
+        Ok(selected_count)
+    }
+
+    async fn set_selected_index(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        index: i32,
+        selected: bool,
+    ) -> JvmResult<()> {
+        let mut target = Self::element_at(jvm, &this, index).await?;
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let changed = if choice_type == 2 {
+            let old_selected: bool = jvm.get_field(&target, "selected", "Z").await?;
+            if old_selected != selected {
+                jvm.put_field(&mut target, "selected", "Z", selected).await?;
+            }
+            old_selected != selected
+        } else if selected {
+            Self::select_only(jvm, &this, index).await?
+        } else {
+            false
+        };
+        Self::normalize_highlight(jvm, &mut this).await?;
+        if changed {
+            Item::invalidate(jvm, &this, choice_type == 4).await?;
+        }
+        Ok(())
+    }
+
+    async fn set_selected_flags(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        selected_array: ClassInstanceRef<Array<bool>>,
+    ) -> JvmResult<()> {
+        if selected_array.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Selection array is null").await);
+        }
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if jvm.array_length(&selected_array).await? < size as usize {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Selection array is too short").await);
+        }
+        let flags: Vec<bool> = jvm.load_array(&selected_array, 0, size as usize).await?;
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let mut changed = false;
+        if choice_type == 2 {
+            for (index, selected) in flags.into_iter().enumerate() {
+                let mut element = Self::element_at(jvm, &this, index as i32).await?;
+                let old_selected: bool = jvm.get_field(&element, "selected", "Z").await?;
+                if old_selected != selected {
+                    jvm.put_field(&mut element, "selected", "Z", selected).await?;
+                    changed = true;
+                }
+            }
+        } else if size > 0 {
+            let selected_index = flags.iter().position(|selected| *selected).unwrap_or(0) as i32;
+            changed = Self::select_only(jvm, &this, selected_index).await?;
+        }
+        Self::normalize_highlight(jvm, &mut this).await?;
+        if changed {
+            Item::invalidate(jvm, &this, choice_type == 4).await?;
+        }
+        Ok(())
+    }
+
+    async fn set_fit_policy(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, fit_policy: i32) -> JvmResult<()> {
+        if !(0..=2).contains(&fit_policy) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid Choice fit policy").await);
+        }
+        jvm.put_field(&mut this, "fitPolicy", "I", fit_policy).await?;
+        Self::normalize_highlight(jvm, &mut this).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_fit_policy(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "fitPolicy", "I").await
+    }
+
+    async fn set_font(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        index: i32,
+        font: ClassInstanceRef<Font>,
+    ) -> JvmResult<()> {
+        let mut element = Self::element_at(jvm, &this, index).await?;
+        jvm.put_field(&mut element, "font", "Ljavax/microedition/lcdui/Font;", font).await?;
+        Self::normalize_highlight(jvm, &mut this).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_font(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<Font>> {
+        let element = Self::element_at(jvm, &this, index).await?;
+        let font: ClassInstanceRef<Font> = jvm.get_field(&element, "font", "Ljavax/microedition/lcdui/Font;").await?;
+        if font.is_null() {
+            jvm.invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await
+        } else {
+            Ok(font)
+        }
+    }
+
+    async fn minimum_content_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(0);
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let fit_policy: i32 = jvm.get_field(&this, "fitPolicy", "I").await?;
+        let mut width = 0;
+        for index in 0..size {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let content = Self::element_content(jvm, &element).await?;
+            let text_width = Self::minimum_text_width(jvm, &content, fit_policy).await?;
+            width = width.max(INDICATOR_SIZE + CONTROL_GAP + Self::image_and_text_width(&content, text_width));
+        }
+        Ok(width + if choice_type == 4 { POPUP_INSET * 2 } else { 0 })
+    }
+
+    async fn minimum_content_height(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(0);
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let popup_open: bool = jvm.get_field(&this, "popupOpen", "Z").await?;
+        let selected_index = if choice_type == 4 && !popup_open {
+            Self::selected_index(jvm, &this).await?
+        } else {
+            0
+        };
+        let end_index = if choice_type == 4 && !popup_open { selected_index + 1 } else { size };
+        let mut height = 0;
+        for index in selected_index..end_index {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let content = Self::element_content(jvm, &element).await?;
+            let explicit_lines = content.text.split('\n').count() as i32;
+            height += (explicit_lines * content.font_height).max(content.image_height).max(INDICATOR_SIZE) + ROW_VERTICAL_INSET * 2;
+        }
+        Ok(height + if choice_type == 4 { POPUP_INSET * 2 } else { 0 })
+    }
+
+    async fn preferred_content_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(0);
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let mut width = 0;
+        for index in 0..size {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let content = Self::element_content(jvm, &element).await?;
+            let text_width = Self::preferred_text_width(jvm, &content).await?;
+            width = width.max(INDICATOR_SIZE + CONTROL_GAP + Self::image_and_text_width(&content, text_width));
+        }
+        Ok(width + if choice_type == 4 { POPUP_INSET * 2 } else { 0 })
+    }
+
+    async fn preferred_content_height(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(0);
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let fit_policy: i32 = jvm.get_field(&this, "fitPolicy", "I").await?;
+        let popup_open: bool = jvm.get_field(&this, "popupOpen", "Z").await?;
+        let selected_index = if choice_type == 4 && !popup_open {
+            Self::selected_index(jvm, &this).await?
+        } else {
+            0
+        };
+        let end_index = if choice_type == 4 && !popup_open { selected_index + 1 } else { size };
+        let row_width = (width - if choice_type == 4 { POPUP_INSET * 2 } else { 0 }).max(0);
+        let mut height = 0;
+        for index in selected_index..end_index {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let content = Self::element_content(jvm, &element).await?;
+            height += Self::element_row_height(jvm, &content, row_width, fit_policy).await?;
+        }
+        Ok(height + if choice_type == 4 { POPUP_INSET * 2 } else { 0 })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_content(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        focused: bool,
+    ) -> JvmResult<()> {
+        if width <= 0 || height <= 0 {
+            return Ok(());
+        }
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(());
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let fit_policy: i32 = jvm.get_field(&this, "fitPolicy", "I").await?;
+        let highlighted_index: i32 = jvm.get_field(&this, "highlightedIndex", "I").await?;
+        let popup_open: bool = jvm.get_field(&this, "popupOpen", "Z").await?;
+        let popup_closed = choice_type == 4 && !popup_open;
+
+        let (row_x, mut row_y, row_width) = if choice_type == 4 {
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (POPUP_BACKGROUND,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (x, y, width, height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (CONTROL_COLOR,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawRect",
+                    "(IIII)V",
+                    (x, y, width - 1, height - 1),
+                )
+                .await?;
+            (x + POPUP_INSET, y + POPUP_INSET, (width - POPUP_INSET * 2).max(0))
+        } else {
+            (x, y, width)
+        };
+
+        let start_index = if popup_closed { Self::selected_index(jvm, &this).await? } else { 0 };
+        let end_index = if popup_closed { start_index + 1 } else { size };
+        for index in start_index..end_index {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let content = Self::element_content(jvm, &element).await?;
+            let row_height = Self::element_row_height(jvm, &content, row_width, fit_policy).await?;
+            let selected: bool = jvm.get_field(&element, "selected", "Z").await?;
+            Self::paint_element(
+                jvm,
+                &graphics,
+                &content,
+                row_x,
+                row_y,
+                row_width,
+                row_height,
+                choice_type,
+                fit_policy,
+                selected,
+                index == highlighted_index && (focused || popup_open),
+                popup_closed,
+            )
+            .await?;
+            row_y += row_height;
+        }
+
+        Ok(())
+    }
+
+    async fn get_focus_content_bounds(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        width: i32,
+    ) -> JvmResult<ClassInstanceRef<Array<i32>>> {
+        let highlighted_index: i32 = jvm.get_field(&this, "highlightedIndex", "I").await?;
+        if highlighted_index < 0 {
+            return Ok(ClassInstanceRef::new(None));
+        }
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let popup_open: bool = jvm.get_field(&this, "popupOpen", "Z").await?;
+        let popup_closed = choice_type == 4 && !popup_open;
+        let active_index = if popup_closed {
+            Self::selected_index(jvm, &this).await?
+        } else {
+            highlighted_index
+        };
+        let inset = if choice_type == 4 { POPUP_INSET } else { 0 };
+        let fit_policy: i32 = jvm.get_field(&this, "fitPolicy", "I").await?;
+        let mut top = inset;
+        let mut bottom = inset;
+        for index in if popup_closed { active_index } else { 0 }..=active_index {
+            let element = Self::element_at(jvm, &this, index).await?;
+            let content = Self::element_content(jvm, &element).await?;
+            top = bottom;
+            bottom += Self::element_row_height(jvm, &content, (width - inset * 2).max(0), fit_policy).await?;
+        }
+        let mut bounds = jvm.instantiate_array("[I", 2).await?;
+        jvm.store_array(&mut bounds, 0, [top, bottom]).await?;
+        Ok(bounds.into())
+    }
+
+    async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        if jvm.invoke_virtual::<_, i32>(&elements, "java/util/Vector", "size", "()I", ()).await? > 0 {
+            return Ok(true);
+        }
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ()).await
+    }
+
+    async fn handle_item_key(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, key: i32) -> JvmResult<i32> {
+        let elements: ClassInstanceRef<Vector> = jvm.get_field(&this, "elements", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&elements, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(0);
+        }
+
+        let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
+        let highlighted_index: i32 = jvm.get_field(&this, "highlightedIndex", "I").await?;
+        if choice_type == 4 {
+            let popup_open: bool = jvm.get_field(&this, "popupOpen", "Z").await?;
+            if !popup_open {
+                if key != MIDPKeyCode::FIRE as i32 {
+                    return Ok(0);
+                }
+                let selected_index = Self::selected_index(jvm, &this).await?;
+                jvm.put_field(&mut this, "highlightedIndex", "I", selected_index).await?;
+                jvm.put_field(&mut this, "popupOpen", "Z", true).await?;
+                Self::normalize_highlight(jvm, &mut this).await?;
+                Item::invalidate(jvm, &this, true).await?;
+                return Ok(Item::INPUT_HANDLED);
+            }
+
+            if key == MIDPKeyCode::UP as i32 || key == MIDPKeyCode::DOWN as i32 {
+                let new_highlight = if key == MIDPKeyCode::UP as i32 {
+                    highlighted_index.saturating_sub(1).max(0)
+                } else {
+                    highlighted_index.saturating_add(1).min(size - 1)
+                };
+                if new_highlight != highlighted_index {
+                    jvm.put_field(&mut this, "highlightedIndex", "I", new_highlight).await?;
+                    Item::invalidate(jvm, &this, false).await?;
+                }
+                return Ok(Item::INPUT_HANDLED);
+            }
+            if key == MIDPKeyCode::FIRE as i32 {
+                let changed = Self::select_only(jvm, &this, highlighted_index).await?;
+                jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
+                Self::normalize_highlight(jvm, &mut this).await?;
+                Item::invalidate(jvm, &this, true).await?;
+                return Ok(Item::INPUT_HANDLED | if changed { Item::INPUT_CHANGED } else { 0 });
+            }
+            if key == MIDPKeyCode::CLEAR as i32 {
+                let selected_index = Self::selected_index(jvm, &this).await?;
+                jvm.put_field(&mut this, "highlightedIndex", "I", selected_index).await?;
+                jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
+                Self::normalize_highlight(jvm, &mut this).await?;
+                Item::invalidate(jvm, &this, true).await?;
+                return Ok(Item::INPUT_HANDLED);
+            }
+            return Ok(0);
+        }
+
+        if key == MIDPKeyCode::UP as i32 || key == MIDPKeyCode::DOWN as i32 {
+            let new_highlight = if key == MIDPKeyCode::UP as i32 {
+                highlighted_index - 1
+            } else {
+                highlighted_index + 1
+            };
+            if new_highlight < 0 || new_highlight >= size {
+                return Ok(0);
+            }
+            jvm.put_field(&mut this, "highlightedIndex", "I", new_highlight).await?;
+            Item::invalidate(jvm, &this, false).await?;
+            return Ok(Item::INPUT_HANDLED);
+        }
+        if key != MIDPKeyCode::FIRE as i32 {
+            return Ok(0);
+        }
+
+        let mut element = Self::element_at(jvm, &this, highlighted_index).await?;
+        let selected: bool = jvm.get_field(&element, "selected", "Z").await?;
+        let changed = if choice_type == 2 {
+            jvm.put_field(&mut element, "selected", "Z", !selected).await?;
+            true
+        } else if selected {
+            false
+        } else {
+            Self::select_only(jvm, &this, highlighted_index).await?
+        };
+        if changed {
+            Item::invalidate(jvm, &this, false).await?;
+        }
+        Ok(Item::INPUT_HANDLED | if changed { Item::INPUT_CHANGED } else { 0 })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec::Vec};
+
+    use jvm::{Array, ClassInstanceRef, JavaError, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use rustjava_runtime::classes::java::lang::String;
+
+    use test_utils::run_jvm_test;
+    use wie_util::Result;
+
+    use crate::{
+        classes::{
+            javax::microedition::lcdui::{ChoiceGroup, Graphics, Image},
+            net::wie::MIDPKeyCode,
+        },
+        get_protos,
+    };
+
+    async fn choice_with_elements(
+        jvm: &Jvm,
+        choice_type: i32,
+        texts: &[&str],
+        images: Option<&[ClassInstanceRef<Image>]>,
+    ) -> JvmResult<ClassInstanceRef<ChoiceGroup>> {
+        let mut string_array: ClassInstanceRef<Array<ClassInstanceRef<String>>> =
+            jvm.instantiate_array("[Ljava/lang/String;", texts.len()).await?.into();
+        let mut strings = Vec::with_capacity(texts.len());
+        for text in texts {
+            strings.push(ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(jvm, text).await?));
+        }
+        jvm.store_array(&mut string_array, 0, strings).await?;
+
+        let image_array: ClassInstanceRef<Array<ClassInstanceRef<Image>>> = if let Some(images) = images {
+            let mut image_array: ClassInstanceRef<Array<ClassInstanceRef<Image>>> =
+                jvm.instantiate_array("[Ljavax/microedition/lcdui/Image;", images.len()).await?.into();
+            jvm.store_array(&mut image_array, 0, images.to_vec()).await?;
+            image_array
+        } else {
+            ClassInstanceRef::new(None)
+        };
+
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/ChoiceGroup",
+                "(Ljava/lang/String;I[Ljava/lang/String;[Ljavax/microedition/lcdui/Image;)V",
+                (ClassInstanceRef::<String>::new(None), choice_type, string_array, image_array),
+            )
+            .await?
+            .into())
+    }
+
+    async fn create_image_and_graphics(jvm: &Jvm, width: i32, height: i32) -> JvmResult<(ClassInstanceRef<Image>, ClassInstanceRef<Graphics>)> {
+        let image: ClassInstanceRef<Image> = jvm
+            .invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(II)Ljavax/microedition/lcdui/Image;",
+                (width, height),
+            )
+            .await?;
+        let graphics: ClassInstanceRef<Graphics> = jvm
+            .invoke_virtual(
+                &image,
+                "javax/microedition/lcdui/Image",
+                "getGraphics",
+                "()Ljavax/microedition/lcdui/Graphics;",
+                (),
+            )
+            .await?;
+        Ok((image, graphics))
+    }
+
+    async fn fill(jvm: &Jvm, graphics: &ClassInstanceRef<Graphics>, color: i32, width: i32, height: i32) -> JvmResult<()> {
+        let _: () = jvm
+            .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+            .await?;
+        jvm.invoke_virtual(
+            graphics,
+            "javax/microedition/lcdui/Graphics",
+            "fillRect",
+            "(IIII)V",
+            (0, 0, width, height),
+        )
+        .await
+    }
+
+    async fn solid_image(jvm: &Jvm, color: i32) -> JvmResult<ClassInstanceRef<Image>> {
+        let (image, graphics) = create_image_and_graphics(jvm, 6, 5).await?;
+        fill(jvm, &graphics, color, 6, 5).await?;
+        Ok(image)
+    }
+
+    async fn measure(jvm: &Jvm, choice: &ClassInstanceRef<ChoiceGroup>, width: i32) -> JvmResult<i32> {
+        jvm.invoke_virtual(choice, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (width,))
+            .await
+    }
+
+    async fn paint(
+        jvm: &Jvm,
+        choice: &ClassInstanceRef<ChoiceGroup>,
+        graphics: ClassInstanceRef<Graphics>,
+        width: i32,
+        height: i32,
+    ) -> JvmResult<()> {
+        jvm.invoke_virtual(
+            choice,
+            "javax/microedition/lcdui/Item",
+            "paintItem",
+            "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+            (graphics, 0, 0, width, height, false),
+        )
+        .await
+    }
+
+    async fn handle_key(jvm: &Jvm, choice: &ClassInstanceRef<ChoiceGroup>, key: MIDPKeyCode) -> JvmResult<i32> {
+        jvm.invoke_virtual(choice, "javax/microedition/lcdui/Item", "handleItemKey", "(I)I", (key as i32,))
+            .await
+    }
+
+    async fn has_color(jvm: &Jvm, image: &ClassInstanceRef<Image>, width: i32, height: i32, color: (u8, u8, u8)) -> JvmResult<bool> {
+        let pixels = Image::image(jvm, image).await?;
+        for y in 0..height {
+            for x in 0..width {
+                let pixel = pixels.get_pixel(x, y);
+                if (pixel.r, pixel.g, pixel.b) == color {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    #[test]
+    fn choice_interface_selection_survives_mutation() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let choice = choice_with_elements(&jvm, 1, &["first", "second"], None).await?;
+            assert!(jvm.is_instance(&**choice, "javax/microedition/lcdui/Choice"));
+            let _: () = jvm
+                .invoke_virtual(&choice, "javax/microedition/lcdui/Choice", "setSelectedIndex", "(IZ)V", (1, true))
+                .await?;
+            let text = JavaLangString::from_rust_string(&jvm, "inserted").await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &choice,
+                    "javax/microedition/lcdui/Choice",
+                    "insert",
+                    "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                    (0, text, ClassInstanceRef::<Image>::new(None)),
+                )
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&choice, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                2
+            );
+            let _: () = jvm
+                .invoke_virtual(&choice, "javax/microedition/lcdui/Choice", "delete", "(I)V", (2,))
+                .await?;
+            let selected: i32 = jvm
+                .invoke_virtual(&choice, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                .await?;
+            assert!(
+                (0..2).contains(&selected),
+                "deleting the selected element must select a remaining element"
+            );
+
+            let multiple = choice_with_elements(&jvm, 2, &["first", "second"], None).await?;
+            let mut flags: ClassInstanceRef<Array<bool>> = jvm.instantiate_array("Z", 3).await?.into();
+            jvm.store_array(&mut flags, 0, [true, true, true]).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &multiple,
+                    "javax/microedition/lcdui/Choice",
+                    "setSelectedFlags",
+                    "([Z)V",
+                    (flags.clone(),),
+                )
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(
+                    &multiple,
+                    "javax/microedition/lcdui/Choice",
+                    "getSelectedFlags",
+                    "([Z)I",
+                    (flags.clone(),)
+                )
+                .await?,
+                2
+            );
+            assert_eq!(jvm.load_array::<bool>(&flags, 0, 3).await?, [true, true, false]);
+
+            let invalid = choice_with_elements(&jvm, 3, &[], None).await;
+            let Err(JavaError::JavaException(exception)) = invalid else {
+                panic!("ChoiceGroup accepted IMPLICIT");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn choice_group_inline_keys_report_boundaries_and_selection_changes_exactly() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let exclusive = choice_with_elements(&jvm, 1, &["first", "second", "third"], None).await?;
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::UP).await?, 0);
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::FIRE).await?, 1);
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::DOWN).await?, 1);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&exclusive, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                0
+            );
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::FIRE).await?, 3);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&exclusive, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                1
+            );
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::FIRE).await?, 1);
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::DOWN).await?, 1);
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::DOWN).await?, 0);
+            assert_eq!(handle_key(&jvm, &exclusive, MIDPKeyCode::RIGHT).await?, 0);
+
+            let multiple = choice_with_elements(&jvm, 2, &["first", "second"], None).await?;
+            assert_eq!(handle_key(&jvm, &multiple, MIDPKeyCode::UP).await?, 0);
+            assert_eq!(handle_key(&jvm, &multiple, MIDPKeyCode::FIRE).await?, 3);
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&multiple, "javax/microedition/lcdui/Choice", "isSelected", "(I)Z", (0,))
+                    .await?
+            );
+            assert_eq!(handle_key(&jvm, &multiple, MIDPKeyCode::FIRE).await?, 3);
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&multiple, "javax/microedition/lcdui/Choice", "isSelected", "(I)Z", (0,))
+                    .await?
+            );
+            assert_eq!(handle_key(&jvm, &multiple, MIDPKeyCode::DOWN).await?, 1);
+            assert_eq!(handle_key(&jvm, &multiple, MIDPKeyCode::FIRE).await?, 3);
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&multiple, "javax/microedition/lcdui/Choice", "isSelected", "(I)Z", (1,))
+                    .await?
+            );
+            assert_eq!(handle_key(&jvm, &multiple, MIDPKeyCode::DOWN).await?, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn choice_group_popup_paints_closed_and_open_states_then_commits_or_cancels() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let red = solid_image(&jvm, 0xcc1122).await?;
+            let green = solid_image(&jvm, 0x22aa55).await?;
+            let blue = solid_image(&jvm, 0x2255dd).await?;
+            let choice = choice_with_elements(&jvm, 4, &["red", "green", "blue"], Some(&[red, green, blue])).await?;
+
+            let closed_height = measure(&jvm, &choice, 90).await?;
+            let (closed_target, closed_graphics) = create_image_and_graphics(&jvm, 90, closed_height).await?;
+            fill(&jvm, &closed_graphics, 0xffffff, 90, closed_height).await?;
+            paint(&jvm, &choice, closed_graphics, 90, closed_height).await?;
+            assert!(has_color(&jvm, &closed_target, 90, closed_height, (0xcc, 0x11, 0x22)).await?);
+            assert!(!has_color(&jvm, &closed_target, 90, closed_height, (0x22, 0xaa, 0x55)).await?);
+            assert!(!has_color(&jvm, &closed_target, 90, closed_height, (0x22, 0x55, 0xdd)).await?);
+
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::FIRE).await?, 1);
+            let open_height = measure(&jvm, &choice, 90).await?;
+            assert!(open_height > closed_height);
+            let (open_target, open_graphics) = create_image_and_graphics(&jvm, 90, open_height).await?;
+            fill(&jvm, &open_graphics, 0xffffff, 90, open_height).await?;
+            paint(&jvm, &choice, open_graphics, 90, open_height).await?;
+            assert!(has_color(&jvm, &open_target, 90, open_height, (0xcc, 0x11, 0x22)).await?);
+            assert!(has_color(&jvm, &open_target, 90, open_height, (0x22, 0xaa, 0x55)).await?);
+            assert!(has_color(&jvm, &open_target, 90, open_height, (0x22, 0x55, 0xdd)).await?);
+
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::UP).await?, 1);
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::DOWN).await?, 1);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&choice, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                0
+            );
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::CLEAR).await?, 1);
+            assert_eq!(measure(&jvm, &choice, 90).await?, closed_height);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&choice, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                0
+            );
+
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::FIRE).await?, 1);
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::DOWN).await?, 1);
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::DOWN).await?, 1);
+            assert_eq!(
+                handle_key(&jvm, &choice, MIDPKeyCode::DOWN).await?,
+                1,
+                "open popup consumes DOWN at its lower bound"
+            );
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::FIRE).await?, 3);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&choice, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                2
+            );
+            assert_eq!(measure(&jvm, &choice, 90).await?, closed_height);
+
+            let (committed_target, committed_graphics) = create_image_and_graphics(&jvm, 90, closed_height).await?;
+            fill(&jvm, &committed_graphics, 0xffffff, 90, closed_height).await?;
+            paint(&jvm, &choice, committed_graphics, 90, closed_height).await?;
+            assert!(!has_color(&jvm, &committed_target, 90, closed_height, (0xcc, 0x11, 0x22)).await?);
+            assert!(!has_color(&jvm, &committed_target, 90, closed_height, (0x22, 0xaa, 0x55)).await?);
+            assert!(has_color(&jvm, &committed_target, 90, closed_height, (0x22, 0x55, 0xdd)).await?);
+
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::FIRE).await?, 1);
+            assert_eq!(
+                handle_key(&jvm, &choice, MIDPKeyCode::FIRE).await?,
+                1,
+                "committing the selected element is a no-op"
+            );
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::FIRE).await?, 1);
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::UP).await?, 1);
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::CLEAR).await?, 1);
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&choice, "javax/microedition/lcdui/Choice", "getSelectedIndex", "()I", ())
+                    .await?,
+                2
+            );
+            assert_eq!(handle_key(&jvm, &choice, MIDPKeyCode::CLEAR).await?, 0);
+
+            Ok(())
+        })
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/choice_group.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/choice_group.rs
@@ -187,7 +187,9 @@ impl ChoiceGroup {
 
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
         let elements: ClassInstanceRef<Vector> = jvm.new_class("java/util/Vector", "()V", ()).await?.into();
-        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        let _: () = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Item", "setLabel", "(Ljava/lang/String;)V", (label,))
+            .await?;
         jvm.put_field(&mut this, "choiceType", "I", choice_type).await?;
         jvm.put_field(&mut this, "elements", "Ljava/util/Vector;", elements.clone()).await?;
         jvm.put_field(&mut this, "fitPolicy", "I", 0).await?;

--- a/wie-midp/src/classes/javax/microedition/lcdui/choice_group.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/choice_group.rs
@@ -141,13 +141,12 @@ impl ChoiceGroup {
         tracing::debug!("javax.microedition.lcdui.ChoiceGroup::<init>({this:?}, {label:?}, {choice_type})");
 
         let string_elements = jvm.instantiate_array("[Ljava/lang/String;", 0).await?;
-        let image_elements = ClassInstanceRef::<Array<ClassInstanceRef<Image>>>::new(None);
         jvm.invoke_special(
             &this,
             "javax/microedition/lcdui/ChoiceGroup",
             "<init>",
             "(Ljava/lang/String;I[Ljava/lang/String;[Ljavax/microedition/lcdui/Image;)V",
-            (label, choice_type, string_elements, image_elements),
+            (label, choice_type, string_elements, None),
         )
         .await
     }
@@ -181,7 +180,7 @@ impl ChoiceGroup {
             return Err(jvm.exception("java/lang/NullPointerException", "Choice string is null").await);
         }
         let images: Vec<ClassInstanceRef<Image>> = if image_elements.is_null() {
-            vec![ClassInstanceRef::new(None); element_count]
+            vec![None.into(); element_count]
         } else {
             jvm.load_array(&image_elements, 0, element_count).await?
         };
@@ -656,7 +655,8 @@ impl ChoiceGroup {
         )
         .await?;
         Self::normalize_highlight(jvm, &mut this).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn delete(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
@@ -681,7 +681,8 @@ impl ChoiceGroup {
         };
         jvm.put_field(&mut this, "highlightedIndex", "I", highlighted_index).await?;
         Self::normalize_highlight(jvm, &mut this).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn delete_all(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
@@ -690,7 +691,8 @@ impl ChoiceGroup {
         jvm.put_field(&mut this, "highlightedIndex", "I", -1).await?;
         jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
         Self::normalize_highlight(jvm, &mut this).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn set(
@@ -706,7 +708,7 @@ impl ChoiceGroup {
             return Err(jvm.exception("java/lang/NullPointerException", "Choice string is null").await);
         }
         let display_image: ClassInstanceRef<Image> = if image.is_null() {
-            ClassInstanceRef::new(None)
+            None.into()
         } else {
             jvm.invoke_static(
                 "javax/microedition/lcdui/Image",
@@ -721,7 +723,8 @@ impl ChoiceGroup {
         jvm.put_field(&mut element, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
             .await?;
         Self::normalize_highlight(jvm, &mut this).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn is_selected(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<bool> {
@@ -787,7 +790,9 @@ impl ChoiceGroup {
         };
         Self::normalize_highlight(jvm, &mut this).await?;
         if changed {
-            Item::invalidate(jvm, &this, choice_type == 4).await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (choice_type == 4,))
+                .await?;
         }
         Ok(())
     }
@@ -824,7 +829,9 @@ impl ChoiceGroup {
         }
         Self::normalize_highlight(jvm, &mut this).await?;
         if changed {
-            Item::invalidate(jvm, &this, choice_type == 4).await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (choice_type == 4,))
+                .await?;
         }
         Ok(())
     }
@@ -835,7 +842,8 @@ impl ChoiceGroup {
         }
         jvm.put_field(&mut this, "fitPolicy", "I", fit_policy).await?;
         Self::normalize_highlight(jvm, &mut this).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_fit_policy(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -852,7 +860,8 @@ impl ChoiceGroup {
         let mut element = Self::element_at(jvm, &this, index).await?;
         jvm.put_field(&mut element, "font", "Ljavax/microedition/lcdui/Font;", font).await?;
         Self::normalize_highlight(jvm, &mut this).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_font(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<Font>> {
@@ -1047,7 +1056,7 @@ impl ChoiceGroup {
     ) -> JvmResult<ClassInstanceRef<Array<i32>>> {
         let highlighted_index: i32 = jvm.get_field(&this, "highlightedIndex", "I").await?;
         if highlighted_index < 0 {
-            return Ok(ClassInstanceRef::new(None));
+            return Ok(None.into());
         }
         let choice_type: i32 = jvm.get_field(&this, "choiceType", "I").await?;
         let popup_open: bool = jvm.get_field(&this, "popupOpen", "Z").await?;
@@ -1099,7 +1108,9 @@ impl ChoiceGroup {
                 jvm.put_field(&mut this, "highlightedIndex", "I", selected_index).await?;
                 jvm.put_field(&mut this, "popupOpen", "Z", true).await?;
                 Self::normalize_highlight(jvm, &mut this).await?;
-                Item::invalidate(jvm, &this, true).await?;
+                let _: () = jvm
+                    .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+                    .await?;
                 return Ok(Item::INPUT_HANDLED);
             }
 
@@ -1111,7 +1122,9 @@ impl ChoiceGroup {
                 };
                 if new_highlight != highlighted_index {
                     jvm.put_field(&mut this, "highlightedIndex", "I", new_highlight).await?;
-                    Item::invalidate(jvm, &this, false).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+                        .await?;
                 }
                 return Ok(Item::INPUT_HANDLED);
             }
@@ -1119,7 +1132,9 @@ impl ChoiceGroup {
                 let changed = Self::select_only(jvm, &this, highlighted_index).await?;
                 jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
                 Self::normalize_highlight(jvm, &mut this).await?;
-                Item::invalidate(jvm, &this, true).await?;
+                let _: () = jvm
+                    .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+                    .await?;
                 return Ok(Item::INPUT_HANDLED | if changed { Item::INPUT_CHANGED } else { 0 });
             }
             if key == MIDPKeyCode::CLEAR as i32 {
@@ -1127,7 +1142,9 @@ impl ChoiceGroup {
                 jvm.put_field(&mut this, "highlightedIndex", "I", selected_index).await?;
                 jvm.put_field(&mut this, "popupOpen", "Z", false).await?;
                 Self::normalize_highlight(jvm, &mut this).await?;
-                Item::invalidate(jvm, &this, true).await?;
+                let _: () = jvm
+                    .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+                    .await?;
                 return Ok(Item::INPUT_HANDLED);
             }
             return Ok(0);
@@ -1143,7 +1160,9 @@ impl ChoiceGroup {
                 return Ok(0);
             }
             jvm.put_field(&mut this, "highlightedIndex", "I", new_highlight).await?;
-            Item::invalidate(jvm, &this, false).await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+                .await?;
             return Ok(Item::INPUT_HANDLED);
         }
         if key != MIDPKeyCode::FIRE as i32 {
@@ -1161,7 +1180,9 @@ impl ChoiceGroup {
             Self::select_only(jvm, &this, highlighted_index).await?
         };
         if changed {
-            Item::invalidate(jvm, &this, false).await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+                .await?;
         }
         Ok(Item::INPUT_HANDLED | if changed { Item::INPUT_CHANGED } else { 0 })
     }
@@ -1205,14 +1226,14 @@ mod test {
             jvm.store_array(&mut image_array, 0, images.to_vec()).await?;
             image_array
         } else {
-            ClassInstanceRef::new(None)
+            None.into()
         };
 
         Ok(jvm
             .new_class(
                 "javax/microedition/lcdui/ChoiceGroup",
                 "(Ljava/lang/String;I[Ljava/lang/String;[Ljavax/microedition/lcdui/Image;)V",
-                (ClassInstanceRef::<String>::new(None), choice_type, string_array, image_array),
+                (None, choice_type, string_array, image_array),
             )
             .await?
             .into())
@@ -1314,7 +1335,7 @@ mod test {
                     "javax/microedition/lcdui/Choice",
                     "insert",
                     "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
-                    (0, text, ClassInstanceRef::<Image>::new(None)),
+                    (0, text, None),
                 )
                 .await?;
             assert_eq!(

--- a/wie-midp/src/classes/javax/microedition/lcdui/command.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/command.rs
@@ -17,33 +17,94 @@ impl Command {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
                 JavaMethodProto::new("<init>", "(Ljava/lang/String;II)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;Ljava/lang/String;II)V",
+                    Self::init_with_long_label,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new("getLabel", "()Ljava/lang/String;", Self::get_label, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getLongLabel", "()Ljava/lang/String;", Self::get_long_label, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("getCommandType", "()I", Self::get_command_type, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("getPriority", "()I", Self::get_priority, MethodAccessFlags::PUBLIC),
             ],
-            fields: vec![
-                JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
-                JavaFieldProto::new("commandType", "I", FieldAccessFlags::PRIVATE),
-                JavaFieldProto::new("priority", "I", FieldAccessFlags::PRIVATE),
-            ],
+            fields: ["SCREEN", "BACK", "CANCEL", "OK", "HELP", "STOP", "EXIT", "ITEM"]
+                .into_iter()
+                .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
+                .chain([
+                    JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("longLabel", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("commandType", "I", FieldAccessFlags::PRIVATE),
+                    JavaFieldProto::new("priority", "I", FieldAccessFlags::PRIVATE),
+                ])
+                .collect(),
             access_flags: ClassAccessFlags::PUBLIC,
         }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Command::<clinit>");
+
+        for (name, value) in [
+            ("SCREEN", 1),
+            ("BACK", 2),
+            ("CANCEL", 3),
+            ("OK", 4),
+            ("HELP", 5),
+            ("STOP", 6),
+            ("EXIT", 7),
+            ("ITEM", 8),
+        ] {
+            jvm.put_static_field("javax/microedition/lcdui/Command", name, "I", value).await?;
+        }
+
+        Ok(())
     }
 
     async fn init(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
-        mut this: ClassInstanceRef<Self>,
+        this: ClassInstanceRef<Self>,
         label: ClassInstanceRef<String>,
         command_type: i32,
         priority: i32,
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Command::<init>({this:?}, {label:?}, {command_type}, {priority})");
 
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Command",
+            "<init>",
+            "(Ljava/lang/String;Ljava/lang/String;II)V",
+            (label, ClassInstanceRef::<String>::new(None), command_type, priority),
+        )
+        .await
+    }
+
+    async fn init_with_long_label(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        label: ClassInstanceRef<String>,
+        long_label: ClassInstanceRef<String>,
+        command_type: i32,
+        priority: i32,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Command::<init>({this:?}, {label:?}, {long_label:?}, {command_type}, {priority})");
+
+        if label.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Command short label is null").await);
+        }
+        if !(1..=8).contains(&command_type) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid command type").await);
+        }
+
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
         jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        jvm.put_field(&mut this, "longLabel", "Ljava/lang/String;", long_label).await?;
         jvm.put_field(&mut this, "commandType", "I", command_type).await?;
         jvm.put_field(&mut this, "priority", "I", priority).await?;
 
@@ -56,6 +117,12 @@ impl Command {
         let label: ClassInstanceRef<String> = jvm.get_field(&this, "label", "Ljava/lang/String;").await?;
 
         Ok(label)
+    }
+
+    async fn get_long_label(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        tracing::debug!("javax.microedition.lcdui.Command::getLongLabel({this:?})");
+
+        jvm.get_field(&this, "longLabel", "Ljava/lang/String;").await
     }
 
     async fn get_command_type(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {

--- a/wie-midp/src/classes/javax/microedition/lcdui/command.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/command.rs
@@ -30,16 +30,28 @@ impl Command {
                 JavaMethodProto::new("getCommandType", "()I", Self::get_command_type, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("getPriority", "()I", Self::get_priority, MethodAccessFlags::PUBLIC),
             ],
-            fields: ["SCREEN", "BACK", "CANCEL", "OK", "HELP", "STOP", "EXIT", "ITEM"]
-                .into_iter()
-                .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-                .chain([
-                    JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
-                    JavaFieldProto::new("longLabel", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
-                    JavaFieldProto::new("commandType", "I", FieldAccessFlags::PRIVATE),
-                    JavaFieldProto::new("priority", "I", FieldAccessFlags::PRIVATE),
-                ])
-                .collect(),
+            fields: vec![
+                JavaFieldProto::new(
+                    "SCREEN",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new("BACK", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new(
+                    "CANCEL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new("OK", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new("HELP", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new("STOP", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new("EXIT", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new("ITEM", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("longLabel", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commandType", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("priority", "I", FieldAccessFlags::PRIVATE),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }

--- a/wie-midp/src/classes/javax/microedition/lcdui/command.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/command.rs
@@ -47,18 +47,14 @@ impl Command {
     async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Command::<clinit>");
 
-        for (name, value) in [
-            ("SCREEN", 1),
-            ("BACK", 2),
-            ("CANCEL", 3),
-            ("OK", 4),
-            ("HELP", 5),
-            ("STOP", 6),
-            ("EXIT", 7),
-            ("ITEM", 8),
-        ] {
-            jvm.put_static_field("javax/microedition/lcdui/Command", name, "I", value).await?;
-        }
+        jvm.put_static_field("javax/microedition/lcdui/Command", "SCREEN", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "BACK", "I", 2).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "CANCEL", "I", 3).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "OK", "I", 4).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "HELP", "I", 5).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "STOP", "I", 6).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "EXIT", "I", 7).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Command", "ITEM", "I", 8).await?;
 
         Ok(())
     }
@@ -78,7 +74,7 @@ impl Command {
             "javax/microedition/lcdui/Command",
             "<init>",
             "(Ljava/lang/String;Ljava/lang/String;II)V",
-            (label, ClassInstanceRef::<String>::new(None), command_type, priority),
+            (label, None, command_type, priority),
         )
         .await
     }

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -5,11 +5,11 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::{Runnable, String as JavaString};
 
-use wie_backend::Event;
+use wie_backend::{Event, text_layout::wrap};
 use wie_jvm_support::{JvmSupport, WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::{
-    lcdui::{Alert, Displayable, Font, Graphics, Image, Ticker},
+    lcdui::{Alert, Displayable, Graphics, Image, Ticker},
     midlet::MIDlet,
 };
 
@@ -233,9 +233,10 @@ impl Display {
             Vec::new()
         } else {
             let title = JavaLangString::to_rust_string(jvm, &title).await?;
-            Font::wrap(
+            wrap(
                 context.system().platform().font(),
                 &title,
+                10.0,
                 Some((width - TITLE_HORIZONTAL_PADDING * 2).max(1)),
             )
         };
@@ -388,6 +389,8 @@ impl Display {
         mut this: ClassInstanceRef<Self>,
         displayable: ClassInstanceRef<Displayable>,
     ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Display::transition({this:?}, {displayable:?})");
+
         let alert_generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
         let alert_generation = alert_generation.wrapping_add(1);
         jvm.put_field(&mut this, "alertGeneration", "I", alert_generation).await?;

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -1,16 +1,71 @@
-use alloc::vec;
+use alloc::{string::String as RustString, vec, vec::Vec};
 
-use jvm::{ClassInstanceRef, JavaError, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm::{ClassInstanceRef, JavaError, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-use rustjava_runtime::classes::java::lang::Runnable;
+use rustjava_runtime::classes::java::lang::{Runnable, String as JavaString};
 
-use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+use wie_backend::Event;
+use wie_jvm_support::{JvmSupport, WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::{
-    lcdui::{Displayable, Graphics, Image},
-    midlet::MIDlet,
+use crate::classes::{
+    javax::microedition::{
+        lcdui::{Alert, Command, Displayable, Font, Graphics, Image, Ticker},
+        midlet::MIDlet,
+    },
+    net::wie::{KeyboardEventType, MIDPKeyCode},
 };
+
+const FONT_HEIGHT: i32 = 12;
+const TITLE_HORIZONTAL_PADDING: i32 = 4;
+const TITLE_VERTICAL_PADDING: i32 = 2;
+const TICKER_HEIGHT: i32 = 16;
+const TICKER_INTERVAL_MS: u64 = 100;
+const TICKER_SCROLL_STEP: i32 = 2;
+const SOFTKEY_HEIGHT: i32 = 18;
+const MENU_ROW_HEIGHT: i32 = 18;
+
+const TITLE_BACKGROUND: i32 = 0x263746;
+const TICKER_BACKGROUND: i32 = 0xdde5ec;
+const SOFTKEY_BACKGROUND: i32 = 0x263746;
+const MENU_SELECTION_BACKGROUND: i32 = 0x2f6f9f;
+const WHITE: i32 = 0xffffff;
+const BLACK: i32 = 0;
+
+const COMMAND_BACK: i32 = 2;
+const COMMAND_CANCEL: i32 = 3;
+const COMMAND_OK: i32 = 4;
+const COMMAND_STOP: i32 = 6;
+const COMMAND_EXIT: i32 = 7;
+
+const LEFT_TOP: i32 = 4 | 16;
+const RIGHT_TOP: i32 = 8 | 16;
+
+pub struct ChromeLayout {
+    pub content_width: i32,
+    pub content_height: i32,
+    content_x: i32,
+    content_y: i32,
+    title_height: i32,
+    title_lines: Vec<RustString>,
+    ticker_y: i32,
+    ticker_height: i32,
+    softkey_y: i32,
+    softkey_height: i32,
+}
+
+#[derive(Clone)]
+struct CommandBinding {
+    command: ClassInstanceRef<Command>,
+    command_type: i32,
+    priority: i32,
+    effective_index: i32,
+}
+
+struct CommandLayout {
+    right: Option<CommandBinding>,
+    remaining: Vec<CommandBinding>,
+}
 
 // class javax.microedition.lcdui.Display
 pub struct Display;
@@ -27,6 +82,12 @@ impl Display {
                     "setCurrent",
                     "(Ljavax/microedition/lcdui/Displayable;)V",
                     Self::set_current,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Alert;Ljavax/microedition/lcdui/Displayable;)V",
+                    Self::set_current_alert,
                     MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
@@ -49,6 +110,8 @@ impl Display {
                 JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleAlertTimeout", "(I)V", Self::handle_alert_timeout, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleTickerTick", "(I)V", Self::handle_ticker_tick, MethodAccessFlags::empty()),
                 JavaMethodProto::new("setFullscreen", "(Z)V", Self::set_fullscreen, MethodAccessFlags::empty()),
                 JavaMethodProto::new("repaint", "(IIII)V", Self::repaint, MethodAccessFlags::empty()),
                 JavaMethodProto::new("disablePaint", "()V", Self::disable_paint, MethodAccessFlags::empty()),
@@ -61,6 +124,9 @@ impl Display {
                 JavaFieldProto::new("width", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("height", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("paintDisabled", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("repaintPending", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("alertGeneration", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("tickerGeneration", "I", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
@@ -106,6 +172,129 @@ impl Display {
         Ok(())
     }
 
+    pub async fn chrome_layout(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        displayable: &ClassInstanceRef<Displayable>,
+        width: i32,
+        height: i32,
+    ) -> JvmResult<ChromeLayout> {
+        let width = width.max(0);
+        let height = height.max(0);
+        let fullscreen: bool = jvm.get_field(displayable, "isInFullScreenMode", "Z").await?;
+        if fullscreen {
+            return Ok(ChromeLayout {
+                content_x: 0,
+                content_y: 0,
+                content_width: width,
+                content_height: height,
+                title_height: 0,
+                title_lines: Vec::new(),
+                ticker_y: 0,
+                ticker_height: 0,
+                softkey_y: height,
+                softkey_height: 0,
+            });
+        }
+
+        let command_count: i32 = jvm
+            .invoke_virtual(displayable, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        let ticker: ClassInstanceRef<Ticker> = jvm.get_field(displayable, "ticker", "Ljavax/microedition/lcdui/Ticker;").await?;
+        let title: ClassInstanceRef<JavaString> = jvm.get_field(displayable, "title", "Ljava/lang/String;").await?;
+        let title_lines = if title.is_null() {
+            Vec::new()
+        } else {
+            let title = JavaLangString::to_rust_string(jvm, &title).await?;
+            Font::wrap(
+                context.system().platform().font(),
+                &title,
+                Some((width - TITLE_HORIZONTAL_PADDING * 2).max(1)),
+            )
+        };
+
+        let softkey_height = if command_count > 0 { SOFTKEY_HEIGHT.min(height) } else { 0 };
+        let ticker_height = if ticker.is_null() {
+            0
+        } else {
+            TICKER_HEIGHT.min((height - softkey_height).max(0))
+        };
+        let desired_title_height = if title_lines.is_empty() {
+            0
+        } else {
+            title_lines.len() as i32 * FONT_HEIGHT + TITLE_VERTICAL_PADDING * 2
+        };
+        let title_height = desired_title_height.min((height - softkey_height - ticker_height).max(0));
+        let content_y = title_height + ticker_height;
+        let content_height = (height - content_y - softkey_height).max(0);
+
+        Ok(ChromeLayout {
+            content_x: 0,
+            content_y,
+            content_width: width,
+            content_height,
+            title_height,
+            title_lines,
+            ticker_y: title_height,
+            ticker_height,
+            softkey_y: height - softkey_height,
+            softkey_height,
+        })
+    }
+
+    async fn command_layout(jvm: &Jvm, displayable: &ClassInstanceRef<Displayable>) -> JvmResult<CommandLayout> {
+        let count: i32 = jvm
+            .invoke_virtual(displayable, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        let mut bindings = Vec::with_capacity(count.max(0) as usize);
+        for effective_index in 0..count {
+            let command: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(
+                    displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    (effective_index,),
+                )
+                .await?;
+            let command_type: i32 = jvm
+                .invoke_virtual(&command, "javax/microedition/lcdui/Command", "getCommandType", "()I", ())
+                .await?;
+            let priority: i32 = jvm
+                .invoke_virtual(&command, "javax/microedition/lcdui/Command", "getPriority", "()I", ())
+                .await?;
+            bindings.push(CommandBinding {
+                command,
+                command_type,
+                priority,
+                effective_index,
+            });
+        }
+
+        let right = bindings
+            .iter()
+            .filter(|binding| matches!(binding.command_type, COMMAND_BACK | COMMAND_CANCEL | COMMAND_STOP | COMMAND_EXIT))
+            .min_by_key(|binding| (binding.priority, binding.effective_index))
+            .cloned();
+        let mut remaining = bindings
+            .into_iter()
+            .filter(|binding| right.as_ref().is_none_or(|right| binding.effective_index != right.effective_index))
+            .collect::<Vec<_>>();
+        remaining.sort_by_key(|binding| {
+            (
+                if matches!(binding.command_type, COMMAND_BACK | COMMAND_CANCEL | COMMAND_STOP | COMMAND_EXIT) {
+                    1
+                } else {
+                    0
+                },
+                binding.priority,
+                binding.effective_index,
+            )
+        });
+
+        Ok(CommandLayout { right, remaining })
+    }
+
     async fn get_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("javax.microedition.lcdui.Display::getWidth({this:?})");
 
@@ -142,17 +331,76 @@ impl Display {
 
     async fn set_current(
         jvm: &Jvm,
-        _context: &mut WieJvmContext,
-        mut this: ClassInstanceRef<Self>,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
         displayable: ClassInstanceRef<Displayable>,
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Display::setCurrent({this:?}, {displayable:?})");
+
+        if displayable.is_null() {
+            return Ok(());
+        }
+
+        if jvm.is_instance(&**displayable, "javax/microedition/lcdui/Alert") {
+            let current: ClassInstanceRef<Displayable> = jvm
+                .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                .await?;
+            if !current.is_null() && jvm.is_instance(&**current, "javax/microedition/lcdui/Alert") {
+                return Err(jvm
+                    .exception("java/lang/IllegalArgumentException", "An Alert cannot follow an Alert")
+                    .await);
+            }
+            let mut alert: ClassInstanceRef<Alert> = JavaValue::from(displayable.clone()).into();
+            jvm.put_field(&mut alert, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", current)
+                .await?;
+        }
+
+        Self::transition(jvm, context, this, displayable).await
+    }
+
+    async fn set_current_alert(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        mut alert: ClassInstanceRef<Alert>,
+        next_displayable: ClassInstanceRef<Displayable>,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Display::setCurrent({this:?}, {alert:?}, {next_displayable:?})");
+
+        if alert.is_null() || next_displayable.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Alert transition argument is null").await);
+        }
+        if jvm.is_instance(&**next_displayable, "javax/microedition/lcdui/Alert") {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "An Alert cannot follow an Alert")
+                .await);
+        }
+
+        jvm.put_field(&mut alert, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", next_displayable)
+            .await?;
+        let displayable: ClassInstanceRef<Displayable> = JavaValue::from(alert).into();
+        Self::transition(jvm, context, this, displayable).await
+    }
+
+    pub async fn transition(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        displayable: ClassInstanceRef<Displayable>,
+    ) -> JvmResult<()> {
+        let alert_generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
+        let alert_generation = alert_generation.wrapping_add(1);
+        jvm.put_field(&mut this, "alertGeneration", "I", alert_generation).await?;
+        let ticker_generation: i32 = jvm.get_field(&this, "tickerGeneration", "I").await?;
+        let ticker_generation = ticker_generation.wrapping_add(1);
+        jvm.put_field(&mut this, "tickerGeneration", "I", ticker_generation).await?;
 
         let old_displayable: ClassInstanceRef<Displayable> = jvm
             .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
             .await?;
 
-        if !old_displayable.is_null() {
+        let same_displayable = !old_displayable.is_null() && !displayable.is_null() && old_displayable.identity() == displayable.identity();
+        if !old_displayable.is_null() && !same_displayable {
             let _: () = jvm
                 .invoke_virtual(
                     &old_displayable,
@@ -172,27 +420,217 @@ impl Display {
         )
         .await?;
 
-        let _: () = jvm
-            .invoke_virtual(
-                &displayable,
-                "javax/microedition/lcdui/Displayable",
-                "setDisplay",
-                "(Ljavax/microedition/lcdui/Display;)V",
-                (this.clone(),),
-            )
-            .await?;
+        if displayable.is_null() {
+            jvm.put_field(&mut this, "isInFullScreenMode", "Z", false).await?;
+            let width: i32 = jvm.get_field(&this, "width", "I").await?;
+            let height: i32 = jvm.get_field(&this, "height", "I").await?;
+            return jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, width, height))
+                .await;
+        }
+
+        if !same_displayable {
+            let _: () = jvm
+                .invoke_virtual(
+                    &displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "setDisplay",
+                    "(Ljavax/microedition/lcdui/Display;)V",
+                    (this.clone(),),
+                )
+                .await?;
+        }
 
         let fullscreen_mode: bool = jvm.get_field(&displayable, "isInFullScreenMode", "Z").await?;
         jvm.put_field(&mut this, "isInFullScreenMode", "Z", fullscreen_mode).await?;
 
         let width: i32 = jvm.get_field(&this, "width", "I").await?;
         let height: i32 = jvm.get_field(&this, "height", "I").await?;
-
-        let _: () = jvm
+        let notification_result = Displayable::notify_size_changed(jvm, context, displayable).await;
+        let timer_result = Self::schedule_alert_timeout(jvm, context, this.clone(), alert_generation).await;
+        let ticker_result = Self::schedule_ticker_tick(jvm, context, this.clone(), ticker_generation).await;
+        let repaint_result: JvmResult<()> = jvm
             .invoke_virtual(&this, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, width, height))
-            .await?;
+            .await;
+        notification_result?;
+        timer_result?;
+        ticker_result?;
+        repaint_result?;
 
         Ok(())
+    }
+
+    async fn schedule_alert_timeout(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, generation: i32) -> JvmResult<()> {
+        let current_generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
+        if current_generation != generation {
+            return Ok(());
+        }
+
+        let current: ClassInstanceRef<Displayable> = jvm
+            .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+            .await?;
+        if current.is_null() || !jvm.is_instance(&**current, "javax/microedition/lcdui/Alert") {
+            return Ok(());
+        }
+        let attached_display: ClassInstanceRef<Display> = jvm.get_field(&current, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if attached_display.is_null() || attached_display.identity() != this.identity() {
+            return Ok(());
+        }
+
+        let timeout: i32 = jvm
+            .invoke_virtual(&current, "javax/microedition/lcdui/Alert", "getTimeout", "()I", ())
+            .await?;
+        if timeout <= 0 {
+            return Ok(());
+        }
+
+        let due = context.system().platform().now() + timeout as u64;
+        let timer_jvm = jvm.clone();
+        context.system().event_queue().push(Event::timer(due, move || {
+            let jvm = timer_jvm;
+            async move {
+                let result: JvmResult<()> = async {
+                    let midlet: ClassInstanceRef<MIDlet> = jvm
+                        .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                        .await?;
+                    if midlet.is_null() {
+                        return Ok(());
+                    }
+
+                    let display: ClassInstanceRef<Display> = jvm
+                        .invoke_static(
+                            "javax/microedition/lcdui/Display",
+                            "getDisplay",
+                            "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
+                            (midlet,),
+                        )
+                        .await?;
+                    jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "handleAlertTimeout", "(I)V", (generation,))
+                        .await
+                }
+                .await;
+
+                match result {
+                    Ok(()) => Ok(()),
+                    Err(error) => Err(JvmSupport::to_wie_err(&jvm, error).await),
+                }
+            }
+        }));
+
+        Ok(())
+    }
+
+    pub async fn alert_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
+        let generation = generation.wrapping_add(1);
+        jvm.put_field(&mut this, "alertGeneration", "I", generation).await?;
+        Self::schedule_alert_timeout(jvm, context, this, generation).await
+    }
+
+    pub async fn visible_ticker(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Ticker>> {
+        let current: ClassInstanceRef<Displayable> = jvm
+            .get_field(this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+            .await?;
+        if current.is_null() {
+            return Ok(None.into());
+        }
+        let attached_display: ClassInstanceRef<Display> = jvm.get_field(&current, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if attached_display.is_null() || attached_display.identity() != this.identity() {
+            return Ok(None.into());
+        }
+
+        let width: i32 = jvm.get_field(this, "width", "I").await?;
+        let height: i32 = jvm.get_field(this, "height", "I").await?;
+        let layout = Self::chrome_layout(jvm, context, &current, width, height).await?;
+        if layout.ticker_height == 0 || layout.content_width == 0 {
+            return Ok(None.into());
+        }
+        jvm.get_field(&current, "ticker", "Ljavax/microedition/lcdui/Ticker;").await
+    }
+
+    pub async fn ticker_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let generation: i32 = jvm.get_field(&this, "tickerGeneration", "I").await?;
+        let generation = generation.wrapping_add(1);
+        jvm.put_field(&mut this, "tickerGeneration", "I", generation).await?;
+        Self::schedule_ticker_tick(jvm, context, this, generation).await
+    }
+
+    async fn schedule_ticker_tick(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, generation: i32) -> JvmResult<()> {
+        if jvm.get_field::<i32>(&this, "tickerGeneration", "I").await? != generation {
+            return Ok(());
+        }
+        let ticker = Self::visible_ticker(jvm, context, &this).await?;
+        if ticker.is_null() {
+            return Ok(());
+        }
+        let text: ClassInstanceRef<JavaString> = jvm.get_field(&ticker, "text", "Ljava/lang/String;").await?;
+        if JavaLangString::to_rust_string(jvm, &text).await?.is_empty() {
+            return Ok(());
+        }
+
+        let due = context.system().platform().now() + TICKER_INTERVAL_MS;
+        let timer_jvm = jvm.clone();
+        context.system().event_queue().push(Event::timer(due, move || {
+            let jvm = timer_jvm;
+            async move {
+                let result: JvmResult<()> = async {
+                    let midlet: ClassInstanceRef<MIDlet> = jvm
+                        .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                        .await?;
+                    if midlet.is_null() {
+                        return Ok(());
+                    }
+                    let display: ClassInstanceRef<Display> = jvm
+                        .invoke_static(
+                            "javax/microedition/lcdui/Display",
+                            "getDisplay",
+                            "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
+                            (midlet,),
+                        )
+                        .await?;
+                    jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "handleTickerTick", "(I)V", (generation,))
+                        .await
+                }
+                .await;
+                match result {
+                    Ok(()) => Ok(()),
+                    Err(error) => Err(JvmSupport::to_wie_err(&jvm, error).await),
+                }
+            }
+        }));
+
+        Ok(())
+    }
+
+    async fn handle_ticker_tick(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, generation: i32) -> JvmResult<()> {
+        if jvm.get_field::<i32>(&this, "tickerGeneration", "I").await? != generation {
+            return Ok(());
+        }
+        let mut ticker = Self::visible_ticker(jvm, context, &this).await?;
+        if ticker.is_null() {
+            return Ok(());
+        }
+        let text: ClassInstanceRef<JavaString> = jvm.get_field(&ticker, "text", "Ljava/lang/String;").await?;
+        let text = JavaLangString::to_rust_string(jvm, &text)
+            .await?
+            .replace("\r\n", " ")
+            .replace(['\r', '\n'], " ");
+        if text.is_empty() {
+            return Ok(());
+        }
+        let offset: i32 = jvm.get_field(&ticker, "scrollOffset", "I").await?;
+        let offset = offset + TICKER_SCROLL_STEP;
+        let offset = if offset >= Font::text_width(context.system().platform().font(), &text) + TITLE_HORIZONTAL_PADDING {
+            let width: i32 = jvm.get_field(&this, "width", "I").await?;
+            TITLE_HORIZONTAL_PADDING - width
+        } else {
+            offset
+        };
+        jvm.put_field(&mut ticker, "scrollOffset", "I", offset).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
+            .await?;
+        Self::schedule_ticker_tick(jvm, context, this, generation).await
     }
 
     async fn get_current(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Displayable>> {
@@ -222,9 +660,9 @@ impl Display {
     }
 
     async fn repaint(
-        _jvm: &Jvm,
+        jvm: &Jvm,
         context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         x: i32,
         y: i32,
         width: i32,
@@ -232,6 +670,7 @@ impl Display {
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Display::repaint({this:?}, {x}, {y}, {width}, {height})");
 
+        jvm.put_field(&mut this, "repaintPending", "Z", true).await?;
         let platform = context.system().platform();
         let screen = platform.screen();
         screen.request_redraw().unwrap();
@@ -247,15 +686,7 @@ impl Display {
             .await?;
 
         if !current_displayable.is_null() {
-            let result: JvmResult<()> = jvm
-                .invoke_virtual(
-                    &current_displayable,
-                    "javax/microedition/lcdui/Displayable",
-                    "handleKeyEvent",
-                    "(II)V",
-                    (event_type, code),
-                )
-                .await;
+            let result = Self::route_key_event(jvm, &current_displayable, event_type, code).await;
 
             if let Err(x) = result {
                 Self::handle_exception(jvm, x).await?;
@@ -265,17 +696,90 @@ impl Display {
         Ok(())
     }
 
-    async fn handle_paint_event(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn handle_alert_timeout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, generation: i32) -> JvmResult<()> {
+        let current_generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
+        if current_generation != generation {
+            return Ok(());
+        }
+
+        let current: ClassInstanceRef<Displayable> = jvm
+            .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+            .await?;
+        if current.is_null() || !jvm.is_instance(&**current, "javax/microedition/lcdui/Alert") {
+            return Ok(());
+        }
+        let attached_display: ClassInstanceRef<Display> = jvm.get_field(&current, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if attached_display.is_null() || attached_display.identity() != this.identity() {
+            return Ok(());
+        }
+
+        let result: JvmResult<()> = jvm
+            .invoke_virtual(&current, "javax/microedition/lcdui/Displayable", "dispatchCommandAt", "(I)V", (0,))
+            .await;
+        if let Err(error) = result {
+            Self::handle_exception(jvm, error).await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_paint_event(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Display::handlePaintEvent({this:?})");
 
+        // Repaints requested during painting belong to the next cycle.
+        jvm.put_field(&mut this, "repaintPending", "Z", false).await?;
         let current_displayable: ClassInstanceRef<Displayable> = jvm
             .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
             .await?;
+        let screen_graphics: ClassInstanceRef<Graphics> = jvm.get_field(&this, "screenGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
+        let width: i32 = jvm.get_field(&this, "width", "I").await?;
+        let height: i32 = jvm.get_field(&this, "height", "I").await?;
 
-        if !current_displayable.is_null() {
-            let screen_graphics: ClassInstanceRef<Graphics> = jvm.get_field(&this, "screenGraphics", "Ljavax/microedition/lcdui/Graphics;").await?;
+        if current_displayable.is_null() {
+            let _: () = jvm
+                .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen_graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (0, 0, width, height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
+                .await?;
+        } else {
+            if let Err(error) = Displayable::notify_size_changed(jvm, context, current_displayable.clone()).await {
+                Self::handle_exception(jvm, error).await?;
+            }
 
-            // TODO draw title and bottom soft bar if not fullscreen
+            let layout = Self::chrome_layout(jvm, context, &current_displayable, width, height).await?;
+            let _: () = jvm
+                .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen_graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "translate",
+                    "(II)V",
+                    (layout.content_x, layout.content_y),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen_graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, 0, layout.content_width, layout.content_height),
+                )
+                .await?;
 
             let result: JvmResult<()> = jvm
                 .invoke_virtual(
@@ -294,18 +798,482 @@ impl Display {
                 Self::handle_exception(jvm, x).await?;
             }
 
-            // HACK: disable paint for clet apps, as they handle paint by themselves
-            let disable_paint: bool = jvm.get_field(&this, "paintDisabled", "Z").await?;
-            if !disable_paint {
-                let screen_image: ClassInstanceRef<Image> = jvm.get_field(&this, "screenImage", "Ljavax/microedition/lcdui/Image;").await?;
-                let image = Image::image(jvm, &screen_image).await?;
-
-                let platform = context.system().platform();
-                let screen = platform.screen();
-
-                screen.paint(&*image);
+            let chrome_result = Self::paint_chrome(jvm, current_displayable, screen_graphics.clone(), &layout).await;
+            let _: () = jvm
+                .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
+                .await?;
+            if let Err(error) = chrome_result {
+                Self::handle_exception(jvm, error).await?;
             }
-            jvm.collect_garbage()?;
+        }
+
+        // HACK: disable paint for clet apps, as they handle paint by themselves
+        let disable_paint: bool = jvm.get_field(&this, "paintDisabled", "Z").await?;
+        if !disable_paint {
+            let screen_image: ClassInstanceRef<Image> = jvm.get_field(&this, "screenImage", "Ljavax/microedition/lcdui/Image;").await?;
+            let image = Image::image(jvm, &screen_image).await?;
+
+            let platform = context.system().platform();
+            let screen = platform.screen();
+
+            screen.paint(&*image);
+        }
+        jvm.collect_garbage()?;
+
+        Ok(())
+    }
+
+    async fn route_key_event(jvm: &Jvm, displayable: &ClassInstanceRef<Displayable>, event_type: i32, code: i32) -> JvmResult<()> {
+        let mut displayable = displayable.clone();
+        let command_layout = Self::command_layout(jvm, &displayable).await?;
+        let mut menu_open: bool = jvm.get_field(&displayable, "commandMenuOpen", "Z").await?;
+
+        if menu_open && command_layout.remaining.len() < 2 {
+            jvm.put_field(&mut displayable, "commandMenuOpen", "Z", false).await?;
+            jvm.put_field(&mut displayable, "commandMenuIndex", "I", -1).await?;
+            menu_open = false;
+        }
+
+        if menu_open {
+            let pressed = event_type == KeyboardEventType::KeyPressed as i32;
+            let repeated = event_type == KeyboardEventType::KeyRepeated as i32;
+            if code == MIDPKeyCode::UP as i32 || code == MIDPKeyCode::DOWN as i32 {
+                if pressed || repeated {
+                    let index: i32 = jvm.get_field(&displayable, "commandMenuIndex", "I").await?;
+                    let maximum = command_layout.remaining.len() as i32 - 1;
+                    let new_index = if code == MIDPKeyCode::UP as i32 {
+                        (index - 1).max(0)
+                    } else {
+                        (index + 1).min(maximum)
+                    };
+                    if new_index != index {
+                        jvm.put_field(&mut displayable, "commandMenuIndex", "I", new_index).await?;
+                        let _: () = jvm
+                            .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                            .await?;
+                    }
+                }
+                return Ok(());
+            }
+
+            if code == MIDPKeyCode::FIRE as i32 || code == MIDPKeyCode::LEFT_SOFT_KEY as i32 {
+                if pressed {
+                    let index: i32 = jvm.get_field(&displayable, "commandMenuIndex", "I").await?;
+                    let command_index = command_layout.remaining[index.clamp(0, command_layout.remaining.len() as i32 - 1) as usize].effective_index;
+                    jvm.put_field(&mut displayable, "commandMenuOpen", "Z", false).await?;
+                    jvm.put_field(&mut displayable, "commandMenuIndex", "I", -1).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                        .await?;
+                    return jvm
+                        .invoke_virtual(
+                            &displayable,
+                            "javax/microedition/lcdui/Displayable",
+                            "dispatchCommandAt",
+                            "(I)V",
+                            (command_index,),
+                        )
+                        .await;
+                }
+                return Ok(());
+            }
+
+            if code == MIDPKeyCode::RIGHT_SOFT_KEY as i32 {
+                if pressed {
+                    jvm.put_field(&mut displayable, "commandMenuOpen", "Z", false).await?;
+                    jvm.put_field(&mut displayable, "commandMenuIndex", "I", -1).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                        .await?;
+                }
+                return Ok(());
+            }
+        } else {
+            if code == MIDPKeyCode::RIGHT_SOFT_KEY as i32 {
+                if let Some(binding) = command_layout.right {
+                    if event_type == KeyboardEventType::KeyPressed as i32 {
+                        return jvm
+                            .invoke_virtual(
+                                &displayable,
+                                "javax/microedition/lcdui/Displayable",
+                                "dispatchCommandAt",
+                                "(I)V",
+                                (binding.effective_index,),
+                            )
+                            .await;
+                    }
+                    return Ok(());
+                }
+            } else if code == MIDPKeyCode::LEFT_SOFT_KEY as i32 && !command_layout.remaining.is_empty() {
+                if event_type == KeyboardEventType::KeyPressed as i32 {
+                    if command_layout.remaining.len() == 1 {
+                        return jvm
+                            .invoke_virtual(
+                                &displayable,
+                                "javax/microedition/lcdui/Displayable",
+                                "dispatchCommandAt",
+                                "(I)V",
+                                (command_layout.remaining[0].effective_index,),
+                            )
+                            .await;
+                    }
+                    jvm.put_field(&mut displayable, "commandMenuOpen", "Z", true).await?;
+                    jvm.put_field(&mut displayable, "commandMenuIndex", "I", 0).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                        .await?;
+                }
+                return Ok(());
+            }
+        }
+
+        jvm.invoke_virtual(
+            &displayable,
+            "javax/microedition/lcdui/Displayable",
+            "handleKeyEvent",
+            "(II)V",
+            (event_type, code),
+        )
+        .await
+    }
+
+    async fn paint_chrome(
+        jvm: &Jvm,
+        mut displayable: ClassInstanceRef<Displayable>,
+        graphics: ClassInstanceRef<Graphics>,
+        layout: &ChromeLayout,
+    ) -> JvmResult<()> {
+        if layout.title_height > 0 {
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, 0, layout.content_width, layout.title_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TITLE_BACKGROUND,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (0, 0, layout.content_width, layout.title_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                .await?;
+            for (index, line) in layout.title_lines.iter().enumerate() {
+                let line = JavaLangString::from_rust_string(jvm, line).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (
+                            line,
+                            TITLE_HORIZONTAL_PADDING,
+                            TITLE_VERTICAL_PADDING + index as i32 * FONT_HEIGHT,
+                            LEFT_TOP,
+                        ),
+                    )
+                    .await?;
+            }
+        }
+
+        if layout.ticker_height > 0 {
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, layout.ticker_y, layout.content_width, layout.ticker_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TICKER_BACKGROUND,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (0, layout.ticker_y, layout.content_width, layout.ticker_height),
+                )
+                .await?;
+
+            let ticker: ClassInstanceRef<Ticker> = jvm.get_field(&displayable, "ticker", "Ljavax/microedition/lcdui/Ticker;").await?;
+            let text: ClassInstanceRef<JavaString> = jvm.get_field(&ticker, "text", "Ljava/lang/String;").await?;
+            let text = JavaLangString::to_rust_string(jvm, &text)
+                .await?
+                .replace("\r\n", " ")
+                .replace(['\r', '\n'], " ");
+            let text = JavaLangString::from_rust_string(jvm, &text).await?;
+            let scroll_offset: i32 = jvm.get_field(&ticker, "scrollOffset", "I").await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawString",
+                    "(Ljava/lang/String;III)V",
+                    (text, TITLE_HORIZONTAL_PADDING - scroll_offset, layout.ticker_y + 2, LEFT_TOP),
+                )
+                .await?;
+        }
+
+        if layout.softkey_height > 0 {
+            let command_layout = Self::command_layout(jvm, &displayable).await?;
+            let menu_open: bool = jvm.get_field(&displayable, "commandMenuOpen", "Z").await?;
+            if menu_open && command_layout.remaining.len() > 1 && layout.softkey_y > 0 && layout.content_width > 0 {
+                let index: i32 = jvm.get_field(&displayable, "commandMenuIndex", "I").await?;
+                let index = index.clamp(0, command_layout.remaining.len() as i32 - 1);
+                jvm.put_field(&mut displayable, "commandMenuIndex", "I", index).await?;
+
+                let menu_height = layout
+                    .softkey_y
+                    .min((command_layout.remaining.len() as i32).saturating_mul(MENU_ROW_HEIGHT));
+                let visible_rows = ((menu_height + MENU_ROW_HEIGHT - 1) / MENU_ROW_HEIGHT).min(command_layout.remaining.len() as i32);
+                let first_row = (index - visible_rows + 1)
+                    .max(0)
+                    .min(command_layout.remaining.len() as i32 - visible_rows);
+                let menu_width = layout.content_width.min(180);
+                let menu_y = layout.softkey_y - menu_height;
+                let first_row_height = menu_height - (visible_rows - 1) * MENU_ROW_HEIGHT;
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "setClip",
+                        "(IIII)V",
+                        (0, menu_y, menu_width, menu_height),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "fillRect",
+                        "(IIII)V",
+                        (0, menu_y, menu_width, menu_height),
+                    )
+                    .await?;
+
+                for visible_index in 0..visible_rows {
+                    let command_index = first_row + visible_index;
+                    let (row_y, row_height) = if visible_index == 0 {
+                        (menu_y, first_row_height)
+                    } else {
+                        (menu_y + first_row_height + (visible_index - 1) * MENU_ROW_HEIGHT, MENU_ROW_HEIGHT)
+                    };
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "setClip",
+                            "(IIII)V",
+                            (0, row_y, menu_width, row_height),
+                        )
+                        .await?;
+                    if command_index == index {
+                        let _: () = jvm
+                            .invoke_virtual(
+                                &graphics,
+                                "javax/microedition/lcdui/Graphics",
+                                "setColor",
+                                "(I)V",
+                                (MENU_SELECTION_BACKGROUND,),
+                            )
+                            .await?;
+                        let _: () = jvm
+                            .invoke_virtual(
+                                &graphics,
+                                "javax/microedition/lcdui/Graphics",
+                                "fillRect",
+                                "(IIII)V",
+                                (0, row_y, menu_width, row_height),
+                            )
+                            .await?;
+                        let _: () = jvm
+                            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                            .await?;
+                    } else {
+                        let _: () = jvm
+                            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
+                            .await?;
+                    }
+
+                    let label: ClassInstanceRef<JavaString> = jvm
+                        .invoke_virtual(
+                            &command_layout.remaining[command_index as usize].command,
+                            "javax/microedition/lcdui/Command",
+                            "getLabel",
+                            "()Ljava/lang/String;",
+                            (),
+                        )
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "drawString",
+                            "(Ljava/lang/String;III)V",
+                            (
+                                label,
+                                TITLE_HORIZONTAL_PADDING.min((menu_width - 1).max(0)),
+                                row_y + ((row_height - FONT_HEIGHT) / 2).max(0),
+                                LEFT_TOP,
+                            ),
+                        )
+                        .await?;
+                }
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "setClip",
+                        "(IIII)V",
+                        (0, menu_y, menu_width, menu_height),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawRect",
+                        "(IIII)V",
+                        (0, menu_y, menu_width - 1, menu_height - 1),
+                    )
+                    .await?;
+            }
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, layout.softkey_y, layout.content_width, layout.softkey_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (SOFTKEY_BACKGROUND,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (0, layout.softkey_y, layout.content_width, layout.softkey_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                .await?;
+
+            let middle = layout.content_width / 2;
+            let left_clip_width = (middle - 1).max(0);
+            let right_clip_x = (middle + 1).min(layout.content_width);
+            let right_clip_width = layout.content_width - right_clip_x;
+            if let Some(binding) = command_layout.right {
+                let label: ClassInstanceRef<JavaString> = jvm
+                    .invoke_virtual(
+                        &binding.command,
+                        "javax/microedition/lcdui/Command",
+                        "getLabel",
+                        "()Ljava/lang/String;",
+                        (),
+                    )
+                    .await?;
+                if right_clip_width > 0 {
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "setClip",
+                            "(IIII)V",
+                            (right_clip_x, layout.softkey_y, right_clip_width, layout.softkey_height),
+                        )
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "drawString",
+                            "(Ljava/lang/String;III)V",
+                            (
+                                label,
+                                (layout.content_width - TITLE_HORIZONTAL_PADDING).max(right_clip_x),
+                                layout.softkey_y + 2,
+                                RIGHT_TOP,
+                            ),
+                        )
+                        .await?;
+                }
+            }
+
+            if !command_layout.remaining.is_empty() && left_clip_width > 0 {
+                let label: ClassInstanceRef<JavaString> = if command_layout.remaining.len() == 1 {
+                    let label: ClassInstanceRef<JavaString> = jvm
+                        .invoke_virtual(
+                            &command_layout.remaining[0].command,
+                            "javax/microedition/lcdui/Command",
+                            "getLabel",
+                            "()Ljava/lang/String;",
+                            (),
+                        )
+                        .await?;
+                    if command_layout.remaining[0].command_type == COMMAND_OK && JavaLangString::to_rust_string(jvm, &label).await?.is_empty() {
+                        JavaLangString::from_rust_string(jvm, "OK").await?.into()
+                    } else {
+                        label
+                    }
+                } else {
+                    JavaLangString::from_rust_string(jvm, "Options").await?.into()
+                };
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "setClip",
+                        "(IIII)V",
+                        (0, layout.softkey_y, left_clip_width, layout.softkey_height),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (
+                            label,
+                            TITLE_HORIZONTAL_PADDING.min((left_clip_width - 1).max(0)),
+                            layout.softkey_y + 2,
+                            LEFT_TOP,
+                        ),
+                    )
+                    .await?;
+            }
         }
 
         Ok(())
@@ -381,10 +1349,18 @@ impl Display {
         tracing::debug!("javax.microedition.lcdui.Display::setFullscreen({this:?}, {fullscreen})");
 
         jvm.put_field(&mut this, "isInFullScreenMode", "Z", fullscreen).await?;
-
-        let platform = context.system().platform();
-        let screen = platform.screen();
-        screen.request_redraw().unwrap();
+        Self::ticker_changed(jvm, context, this.clone()).await?;
+        let current: ClassInstanceRef<Displayable> = jvm
+            .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+            .await?;
+        if !current.is_null() {
+            let _: () = jvm
+                .invoke_virtual(&current, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+                .await?;
+        } else {
+            let platform = context.system().platform();
+            platform.screen().request_redraw().unwrap();
+        }
 
         Ok(())
     }
@@ -395,5 +1371,694 @@ impl Display {
         jvm.put_field(&mut this, "paintDisabled", "Z", true).await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec};
+
+    use jvm::{ClassInstanceRef, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
+    use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+    use rustjava_runtime::classes::java::lang::String;
+
+    use test_utils::run_jvm_test;
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_util::Result;
+
+    use crate::{
+        classes::{
+            javax::microedition::lcdui::{Command, CommandListener, Display, Displayable, Graphics, Image},
+            net::wie::{KeyboardEventType, MIDPKeyCode},
+        },
+        get_protos,
+    };
+
+    struct ViewportScreen;
+    struct RecordingCommandListener;
+
+    impl ViewportScreen {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestViewportScreen",
+                parent_class: Some("javax/microedition/lcdui/Screen"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("sizeChanged", "(II)V", Self::size_changed, MethodAccessFlags::PROTECTED),
+                    JavaMethodProto::new(
+                        "handlePaintEvent",
+                        "(Ljavax/microedition/lcdui/Graphics;)V",
+                        Self::handle_paint_event,
+                        MethodAccessFlags::empty(),
+                    ),
+                    JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("callbackCount", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("callbackDepth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("maximumCallbackDepth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastHeight", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("mutateOnFirstCallback", "Z", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("translateX", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("translateY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipX", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipWidth", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("clipHeight", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("keyCount", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastKeyType", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastKeyCode", "I", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/lcdui/Screen", "<init>", "()V", ()).await
+        }
+
+        async fn size_changed(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
+            let callback_count: i32 = jvm.get_field(&this, "callbackCount", "I").await?;
+            let callback_depth: i32 = jvm.get_field(&this, "callbackDepth", "I").await?;
+            let callback_count = callback_count + 1;
+            let callback_depth = callback_depth + 1;
+
+            jvm.put_field(&mut this, "callbackCount", "I", callback_count).await?;
+            jvm.put_field(&mut this, "callbackDepth", "I", callback_depth).await?;
+            jvm.put_field(&mut this, "lastWidth", "I", width).await?;
+            jvm.put_field(&mut this, "lastHeight", "I", height).await?;
+
+            let maximum_depth: i32 = jvm.get_field(&this, "maximumCallbackDepth", "I").await?;
+            if callback_depth > maximum_depth {
+                jvm.put_field(&mut this, "maximumCallbackDepth", "I", callback_depth).await?;
+            }
+
+            let mutate: bool = jvm.get_field(&this, "mutateOnFirstCallback", "Z").await?;
+            if mutate && callback_count == 1 {
+                let title = JavaLangString::from_rust_string(jvm, "Changed\ninside callback").await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &this,
+                        "javax/microedition/lcdui/Displayable",
+                        "setTitle",
+                        "(Ljava/lang/String;)V",
+                        (title,),
+                    )
+                    .await?;
+
+                let label = JavaLangString::from_rust_string(jvm, "Done").await?;
+                let command: ClassInstanceRef<Command> = jvm
+                    .new_class("javax/microedition/lcdui/Command", "(Ljava/lang/String;II)V", (label, 4, 0))
+                    .await?
+                    .into();
+                let _: () = jvm
+                    .invoke_virtual(
+                        &this,
+                        "javax/microedition/lcdui/Displayable",
+                        "addCommand",
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (command,),
+                    )
+                    .await?;
+            }
+
+            jvm.put_field(&mut this, "callbackDepth", "I", callback_depth - 1).await?;
+            Ok(())
+        }
+
+        async fn handle_paint_event(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            graphics: ClassInstanceRef<Graphics>,
+        ) -> JvmResult<()> {
+            let _: () = jvm
+                .invoke_special(
+                    &this,
+                    "javax/microedition/lcdui/Screen",
+                    "handlePaintEvent",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    (graphics.clone(),),
+                )
+                .await?;
+
+            for (field, method) in [
+                ("translateX", "getTranslateX"),
+                ("translateY", "getTranslateY"),
+                ("clipX", "getClipX"),
+                ("clipY", "getClipY"),
+                ("clipWidth", "getClipWidth"),
+                ("clipHeight", "getClipHeight"),
+            ] {
+                let value: i32 = jvm
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", method, "()I", ())
+                    .await?;
+                jvm.put_field(&mut this, field, "I", value).await?;
+            }
+
+            let width: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+                .await?;
+            let height: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+                .await?;
+
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xcc1133,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (-4, -4, 8, 8))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x1188cc,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (width - 2, height - 2, 6, 6),
+                )
+                .await?;
+
+            Ok(())
+        }
+
+        async fn handle_key_event(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            event_type: i32,
+            code: i32,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "keyCount", "I").await?;
+            jvm.put_field(&mut this, "keyCount", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastKeyType", "I", event_type).await?;
+            jvm.put_field(&mut this, "lastKeyCode", "I", code).await
+        }
+    }
+
+    impl RecordingCommandListener {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingCommandListener",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec!["javax/microedition/lcdui/CommandListener"],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "commandAction",
+                        "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                        Self::command_action,
+                        MethodAccessFlags::PUBLIC,
+                    ),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("count", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastCommand", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+        }
+
+        async fn command_action(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            command: ClassInstanceRef<Command>,
+            displayable: ClassInstanceRef<Displayable>,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastCommand", "Ljavax/microedition/lcdui/Command;", command)
+                .await?;
+            jvm.put_field(&mut this, "lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", displayable)
+                .await?;
+
+            Ok(())
+        }
+    }
+
+    fn test_protos() -> Box<[Box<[WieJavaClassProto]>]> {
+        Box::new([
+            get_protos().into(),
+            [ViewportScreen::as_proto(), RecordingCommandListener::as_proto()].into(),
+        ])
+    }
+
+    async fn set_title(jvm: &Jvm, screen: &ClassInstanceRef<ViewportScreen>, title: &str) -> JvmResult<()> {
+        let title = JavaLangString::from_rust_string(jvm, title).await?;
+        jvm.invoke_virtual(
+            screen,
+            "javax/microedition/lcdui/Displayable",
+            "setTitle",
+            "(Ljava/lang/String;)V",
+            (title,),
+        )
+        .await
+    }
+
+    async fn viewport_height(jvm: &Jvm, screen: &ClassInstanceRef<ViewportScreen>) -> JvmResult<i32> {
+        jvm.invoke_virtual(screen, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await
+    }
+
+    async fn make_command(jvm: &Jvm, label: &str, command_type: i32, priority: i32) -> JvmResult<ClassInstanceRef<Command>> {
+        let label = JavaLangString::from_rust_string(jvm, label).await?;
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Command",
+                "(Ljava/lang/String;II)V",
+                (label, command_type, priority),
+            )
+            .await?
+            .into())
+    }
+
+    async fn send_key(jvm: &Jvm, display: &ClassInstanceRef<Display>, event_type: KeyboardEventType, key: MIDPKeyCode) -> JvmResult<()> {
+        jvm.invoke_virtual(
+            display,
+            "javax/microedition/lcdui/Display",
+            "handleKeyEvent",
+            "(II)V",
+            (event_type as i32, key as i32),
+        )
+        .await
+    }
+
+    #[test]
+    fn hidden_and_attached_viewports_follow_live_decorations() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let screen: ClassInstanceRef<ViewportScreen> = jvm.new_class("javax/microedition/lcdui/TestViewportScreen", "()V", ()).await?.into();
+
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&screen, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+                    .await?,
+                320
+            );
+            let undecorated_height = viewport_height(&jvm, &screen).await?;
+            assert_eq!(undecorated_height, 240);
+
+            set_title(&jvm, &screen, "One line").await?;
+            let one_line_height = viewport_height(&jvm, &screen).await?;
+            assert!(one_line_height < undecorated_height);
+
+            set_title(&jvm, &screen, "First line\nSecond line").await?;
+            let explicit_newline_height = viewport_height(&jvm, &screen).await?;
+            assert!(explicit_newline_height < one_line_height);
+
+            set_title(
+                &jvm,
+                &screen,
+                "A deliberately long title whose words must wrap because the available display width is finite and deterministic",
+            )
+            .await?;
+            let wrapped_height = viewport_height(&jvm, &screen).await?;
+            assert!(wrapped_height < one_line_height);
+
+            set_title(&jvm, &screen, "Decorated").await?;
+            let title_height = viewport_height(&jvm, &screen).await?;
+            let command = make_command(&jvm, "Open", 4, 0).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen,
+                    "javax/microedition/lcdui/Displayable",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command.clone(),),
+                )
+                .await?;
+            let fully_decorated_height = viewport_height(&jvm, &screen).await?;
+            assert!(fully_decorated_height < title_height);
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 0);
+
+            let display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (screen.clone(),),
+                )
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 1);
+            assert!(
+                jvm.invoke_virtual::<_, bool>(&screen, "javax/microedition/lcdui/Displayable", "isShown", "()Z", ())
+                    .await?
+            );
+            assert_eq!(viewport_height(&jvm, &screen).await?, fully_decorated_height);
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen,
+                    "javax/microedition/lcdui/Displayable",
+                    "removeCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command.clone(),),
+                )
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 2);
+            assert_eq!(viewport_height(&jvm, &screen).await?, title_height);
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen,
+                    "javax/microedition/lcdui/Displayable",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command,),
+                )
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 3);
+            assert_eq!(viewport_height(&jvm, &screen).await?, fully_decorated_height);
+
+            let replacement: ClassInstanceRef<ViewportScreen> = jvm.new_class("javax/microedition/lcdui/TestViewportScreen", "()V", ()).await?.into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (replacement,),
+                )
+                .await?;
+            assert!(
+                !jvm.invoke_virtual::<_, bool>(&screen, "javax/microedition/lcdui/Displayable", "isShown", "()Z", ())
+                    .await?
+            );
+
+            let null_title = ClassInstanceRef::<String>::new(None);
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen,
+                    "javax/microedition/lcdui/Displayable",
+                    "setTitle",
+                    "(Ljava/lang/String;)V",
+                    (null_title,),
+                )
+                .await?;
+            let detached_height = viewport_height(&jvm, &screen).await?;
+            assert!(detached_height > fully_decorated_height);
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 3);
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (screen.clone(),),
+                )
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 4);
+            assert_eq!(jvm.get_field::<i32>(&screen, "lastHeight", "I").await?, detached_height);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn size_changed_coalesces_callback_decoration_mutation() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let mut screen: ClassInstanceRef<ViewportScreen> = jvm.new_class("javax/microedition/lcdui/TestViewportScreen", "()V", ()).await?.into();
+            jvm.put_field(&mut screen, "mutateOnFirstCallback", "Z", true).await?;
+            let display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (screen.clone(),),
+                )
+                .await?;
+
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackCount", "I").await?, 2);
+            assert_eq!(jvm.get_field::<i32>(&screen, "maximumCallbackDepth", "I").await?, 1);
+            assert_eq!(jvm.get_field::<i32>(&screen, "callbackDepth", "I").await?, 0);
+            assert_eq!(jvm.get_field::<i32>(&screen, "lastWidth", "I").await?, 320);
+            let current_height = viewport_height(&jvm, &screen).await?;
+            assert_eq!(jvm.get_field::<i32>(&screen, "lastHeight", "I").await?, current_height);
+            assert!(current_height < 240);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn screen_paint_uses_content_coordinates_and_renders_chrome_bands() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let screen: ClassInstanceRef<ViewportScreen> = jvm.new_class("javax/microedition/lcdui/TestViewportScreen", "()V", ()).await?.into();
+            set_title(
+                &jvm,
+                &screen,
+                "First title line\nA second title line that is long enough to wrap onto another visible title row",
+            )
+            .await?;
+            let command = make_command(&jvm, "Select", 4, 0).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen,
+                    "javax/microedition/lcdui/Displayable",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command,),
+                )
+                .await?;
+
+            let display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
+            let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xaa22aa,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 320, 240))
+                .await?;
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (screen.clone(),),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
+
+            let translate_x: i32 = jvm.get_field(&screen, "translateX", "I").await?;
+            let translate_y: i32 = jvm.get_field(&screen, "translateY", "I").await?;
+            let clip_width: i32 = jvm.get_field(&screen, "clipWidth", "I").await?;
+            let clip_height: i32 = jvm.get_field(&screen, "clipHeight", "I").await?;
+            assert_eq!(translate_x, 0);
+            assert!(translate_y >= 40, "title newline/wrap must reserve multiple rows");
+            assert_eq!(jvm.get_field::<i32>(&screen, "clipX", "I").await?, 0);
+            assert_eq!(jvm.get_field::<i32>(&screen, "clipY", "I").await?, 0);
+            assert_eq!(clip_width, 320);
+            assert_eq!(clip_height, viewport_height(&jvm, &screen).await?);
+
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getTranslateX", "()I", ())
+                    .await?,
+                0
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getTranslateY", "()I", ())
+                    .await?,
+                0
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+                    .await?,
+                240
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+                    .await?,
+                320
+            );
+
+            let image_ref = Graphics::image(&jvm, &mut graphics).await?;
+            let image = Image::image(&jvm, &image_ref).await?;
+            let rgb = |x, y| {
+                let color = image.get_pixel(x, y);
+                (color.r, color.g, color.b)
+            };
+            assert_eq!(rgb(0, translate_y), (0xcc, 0x11, 0x33));
+            assert_ne!(rgb(0, translate_y - 1), (0xcc, 0x11, 0x33));
+            assert_eq!(rgb(319, translate_y + clip_height - 1), (0x11, 0x88, 0xcc));
+            assert_eq!(rgb(100, translate_y + 20), (0xff, 0xff, 0xff), "Screen must clear stale content pixels");
+            assert_ne!(rgb(319, 0), (0xff, 0xff, 0xff), "title band must be painted in screen coordinates");
+            assert_ne!(rgb(319, 0), (0xaa, 0x22, 0xaa), "title band must replace stale pixels");
+            assert_ne!(
+                rgb(319, translate_y - 1),
+                (0xff, 0xff, 0xff),
+                "title band must remain outside the content clip"
+            );
+            assert_ne!(rgb(319, translate_y - 1), (0xaa, 0x22, 0xaa), "title band must replace stale pixels");
+            assert_ne!(
+                rgb(319, 239),
+                (0xff, 0xff, 0xff),
+                "softkey band must be painted at the bottom of the screen"
+            );
+            assert_ne!(rgb(319, 239), (0xaa, 0x22, 0xaa), "softkey band must replace stale pixels");
+
+            let bright_title_pixels = (0..translate_y - 16)
+                .flat_map(|y| (0..200).map(move |x| (x, y)))
+                .filter(|&(x, y)| {
+                    let (r, g, b) = rgb(x, y);
+                    r > 200 && g > 200 && b > 200
+                })
+                .count();
+            assert!(bright_title_pixels > 20, "wrapped title rows must contain visible glyph pixels");
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn base_displayable_commands_use_direct_softkeys_and_ordered_options() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let screen: ClassInstanceRef<ViewportScreen> = jvm.new_class("javax/microedition/lcdui/TestViewportScreen", "()V", ()).await?.into();
+            let listener: ClassInstanceRef<RecordingCommandListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingCommandListener", "()V", ())
+                .await?
+                .into();
+            let listener_ref: ClassInstanceRef<CommandListener> = JavaValue::from(listener.clone()).into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &screen,
+                    "javax/microedition/lcdui/Displayable",
+                    "setCommandListener",
+                    "(Ljavax/microedition/lcdui/CommandListener;)V",
+                    (listener_ref,),
+                )
+                .await?;
+
+            let low_priority = make_command(&jvm, "Later", 1, 5).await?;
+            let first_tied = make_command(&jvm, "First", 4, 1).await?;
+            let second_tied = make_command(&jvm, "Second", 5, 1).await?;
+            let back = make_command(&jvm, "Back", 2, 2).await?;
+            for command in [&low_priority, &first_tied, &second_tied, &back] {
+                let _: () = jvm
+                    .invoke_virtual(
+                        &screen,
+                        "javax/microedition/lcdui/Displayable",
+                        "addCommand",
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (command.clone(),),
+                    )
+                    .await?;
+            }
+
+            let display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (screen.clone(),),
+                )
+                .await?;
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::RIGHT_SOFT_KEY).await?;
+            assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, 1);
+            let dispatched: ClassInstanceRef<Command> = jvm.get_field(&listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            assert_eq!(dispatched.identity(), back.identity());
+            let target: ClassInstanceRef<Displayable> = jvm
+                .get_field(&listener, "lastDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                .await?;
+            assert_eq!(target.identity(), screen.identity());
+
+            for event_type in [KeyboardEventType::KeyRepeated, KeyboardEventType::KeyReleased] {
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "handleKeyEvent",
+                        "(II)V",
+                        (event_type as i32, MIDPKeyCode::RIGHT_SOFT_KEY as i32),
+                    )
+                    .await?;
+            }
+            assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, 1);
+            assert_eq!(jvm.get_field::<i32>(&screen, "keyCount", "I").await?, 0);
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::KEY_NUM1).await?;
+            assert_eq!(jvm.get_field::<i32>(&screen, "keyCount", "I").await?, 1);
+            assert_eq!(jvm.get_field::<i32>(&screen, "lastKeyCode", "I").await?, MIDPKeyCode::KEY_NUM1 as i32);
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::LEFT_SOFT_KEY).await?;
+            assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, 1);
+
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
+            let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+            let image_ref = Graphics::image(&jvm, &mut graphics).await?;
+            let image = Image::image(&jvm, &image_ref).await?;
+            let menu_band_non_white = (160..222)
+                .flat_map(|y| (0..160).map(move |x| (x, y)))
+                .filter(|&(x, y)| {
+                    let color = image.get_pixel(x, y);
+                    (color.r, color.g, color.b) != (0xff, 0xff, 0xff)
+                })
+                .count();
+            assert!(menu_band_non_white > 100, "open options menu must render above the softkey bar");
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::DOWN).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::FIRE).await?;
+            assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, 2);
+            let dispatched: ClassInstanceRef<Command> = jvm.get_field(&listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            assert_eq!(
+                dispatched.identity(),
+                second_tied.identity(),
+                "equal priorities must retain registration order"
+            );
+            assert_eq!(
+                jvm.get_field::<i32>(&screen, "keyCount", "I").await?,
+                1,
+                "menu keys must not leak to the Displayable"
+            );
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::LEFT_SOFT_KEY).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::RIGHT_SOFT_KEY).await?;
+            assert_eq!(
+                jvm.get_field::<i32>(&listener, "count", "I").await?,
+                2,
+                "right softkey must cancel an open menu"
+            );
+
+            for command in [&low_priority, &second_tied, &back] {
+                let _: () = jvm
+                    .invoke_virtual(
+                        &screen,
+                        "javax/microedition/lcdui/Displayable",
+                        "removeCommand",
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (command.clone(),),
+                    )
+                    .await?;
+            }
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::LEFT_SOFT_KEY).await?;
+            assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, 3);
+            let dispatched: ClassInstanceRef<Command> = jvm.get_field(&listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            assert_eq!(dispatched.identity(), first_tied.identity());
+
+            Ok(())
+        })
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -41,9 +41,9 @@ const COMMAND_EXIT: i32 = 7;
 const LEFT_TOP: i32 = 4 | 16;
 const RIGHT_TOP: i32 = 8 | 16;
 
-pub struct ChromeLayout {
-    pub content_width: i32,
-    pub content_height: i32,
+struct ChromeLayout {
+    content_width: i32,
+    content_height: i32,
     content_x: i32,
     content_y: i32,
     title_height: i32,
@@ -107,6 +107,32 @@ impl Display {
                     MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
                 ),
                 // wie private methods...
+                JavaMethodProto::new(
+                    "transition",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    Self::transition,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("alertChanged", "()V", Self::alert_changed, MethodAccessFlags::empty()),
+                JavaMethodProto::new("tickerChanged", "()V", Self::ticker_changed, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getVisibleTicker",
+                    "()Ljavax/microedition/lcdui/Ticker;",
+                    Self::visible_ticker,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    Self::screen_graphics,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "getContentHeight",
+                    "(Ljavax/microedition/lcdui/Displayable;II)I",
+                    Self::get_content_height,
+                    MethodAccessFlags::STATIC,
+                ),
                 JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::empty()),
@@ -172,7 +198,18 @@ impl Display {
         Ok(())
     }
 
-    pub async fn chrome_layout(
+    async fn get_content_height(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        displayable: ClassInstanceRef<Displayable>,
+        width: i32,
+        height: i32,
+    ) -> JvmResult<i32> {
+        let layout = Self::chrome_layout(jvm, context, &displayable, width, height).await?;
+        Ok(layout.content_height)
+    }
+
+    async fn chrome_layout(
         jvm: &Jvm,
         context: &mut WieJvmContext,
         displayable: &ClassInstanceRef<Displayable>,
@@ -331,7 +368,7 @@ impl Display {
 
     async fn set_current(
         jvm: &Jvm,
-        context: &mut WieJvmContext,
+        _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         displayable: ClassInstanceRef<Displayable>,
     ) -> JvmResult<()> {
@@ -355,12 +392,19 @@ impl Display {
                 .await?;
         }
 
-        Self::transition(jvm, context, this, displayable).await
+        jvm.invoke_virtual(
+            &this,
+            "javax/microedition/lcdui/Display",
+            "transition",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (displayable,),
+        )
+        .await
     }
 
     async fn set_current_alert(
         jvm: &Jvm,
-        context: &mut WieJvmContext,
+        _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         mut alert: ClassInstanceRef<Alert>,
         next_displayable: ClassInstanceRef<Displayable>,
@@ -379,10 +423,17 @@ impl Display {
         jvm.put_field(&mut alert, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", next_displayable)
             .await?;
         let displayable: ClassInstanceRef<Displayable> = JavaValue::from(alert).into();
-        Self::transition(jvm, context, this, displayable).await
+        jvm.invoke_virtual(
+            &this,
+            "javax/microedition/lcdui/Display",
+            "transition",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (displayable,),
+        )
+        .await
     }
 
-    pub async fn transition(
+    async fn transition(
         jvm: &Jvm,
         context: &mut WieJvmContext,
         mut this: ClassInstanceRef<Self>,
@@ -446,7 +497,9 @@ impl Display {
 
         let width: i32 = jvm.get_field(&this, "width", "I").await?;
         let height: i32 = jvm.get_field(&this, "height", "I").await?;
-        let notification_result = Displayable::notify_size_changed(jvm, context, displayable).await;
+        let notification_result: JvmResult<()> = jvm
+            .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "notifySizeChanged", "()V", ())
+            .await;
         let timer_result = Self::schedule_alert_timeout(jvm, context, this.clone(), alert_generation).await;
         let ticker_result = Self::schedule_ticker_tick(jvm, context, this.clone(), ticker_generation).await;
         let repaint_result: JvmResult<()> = jvm
@@ -520,16 +573,16 @@ impl Display {
         Ok(())
     }
 
-    pub async fn alert_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn alert_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
         let generation = generation.wrapping_add(1);
         jvm.put_field(&mut this, "alertGeneration", "I", generation).await?;
         Self::schedule_alert_timeout(jvm, context, this, generation).await
     }
 
-    pub async fn visible_ticker(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Ticker>> {
+    async fn visible_ticker(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Ticker>> {
         let current: ClassInstanceRef<Displayable> = jvm
-            .get_field(this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+            .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
             .await?;
         if current.is_null() {
             return Ok(None.into());
@@ -539,8 +592,8 @@ impl Display {
             return Ok(None.into());
         }
 
-        let width: i32 = jvm.get_field(this, "width", "I").await?;
-        let height: i32 = jvm.get_field(this, "height", "I").await?;
+        let width: i32 = jvm.get_field(&this, "width", "I").await?;
+        let height: i32 = jvm.get_field(&this, "height", "I").await?;
         let layout = Self::chrome_layout(jvm, context, &current, width, height).await?;
         if layout.ticker_height == 0 || layout.content_width == 0 {
             return Ok(None.into());
@@ -548,7 +601,7 @@ impl Display {
         jvm.get_field(&current, "ticker", "Ljavax/microedition/lcdui/Ticker;").await
     }
 
-    pub async fn ticker_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn ticker_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let generation: i32 = jvm.get_field(&this, "tickerGeneration", "I").await?;
         let generation = generation.wrapping_add(1);
         jvm.put_field(&mut this, "tickerGeneration", "I", generation).await?;
@@ -559,7 +612,15 @@ impl Display {
         if jvm.get_field::<i32>(&this, "tickerGeneration", "I").await? != generation {
             return Ok(());
         }
-        let ticker = Self::visible_ticker(jvm, context, &this).await?;
+        let ticker: ClassInstanceRef<Ticker> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Display",
+                "getVisibleTicker",
+                "()Ljavax/microedition/lcdui/Ticker;",
+                (),
+            )
+            .await?;
         if ticker.is_null() {
             return Ok(());
         }
@@ -606,7 +667,15 @@ impl Display {
         if jvm.get_field::<i32>(&this, "tickerGeneration", "I").await? != generation {
             return Ok(());
         }
-        let mut ticker = Self::visible_ticker(jvm, context, &this).await?;
+        let mut ticker: ClassInstanceRef<Ticker> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Display",
+                "getVisibleTicker",
+                "()Ljavax/microedition/lcdui/Ticker;",
+                (),
+            )
+            .await?;
         if ticker.is_null() {
             return Ok(());
         }
@@ -754,7 +823,16 @@ impl Display {
                 .invoke_virtual(&screen_graphics, "javax/microedition/lcdui/Graphics", "reset", "()V", ())
                 .await?;
         } else {
-            if let Err(error) = Displayable::notify_size_changed(jvm, context, current_displayable.clone()).await {
+            let notification_result: JvmResult<()> = jvm
+                .invoke_virtual(
+                    &current_displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "notifySizeChanged",
+                    "()V",
+                    (),
+                )
+                .await;
+            if let Err(error) = notification_result {
                 Self::handle_exception(jvm, error).await?;
             }
 
@@ -1315,8 +1393,8 @@ impl Display {
         Ok(())
     }
 
-    pub async fn screen_graphics(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Graphics>> {
-        jvm.get_field(this, "screenGraphics", "Ljavax/microedition/lcdui/Graphics;").await
+    async fn screen_graphics(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Graphics>> {
+        jvm.get_field(&this, "screenGraphics", "Ljavax/microedition/lcdui/Graphics;").await
     }
 
     async fn handle_exception(jvm: &Jvm, err: JavaError) -> JvmResult<()> {
@@ -1349,7 +1427,9 @@ impl Display {
         tracing::debug!("javax.microedition.lcdui.Display::setFullscreen({this:?}, {fullscreen})");
 
         jvm.put_field(&mut this, "isInFullScreenMode", "Z", fullscreen).await?;
-        Self::ticker_changed(jvm, context, this.clone()).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Display", "tickerChanged", "()V", ())
+            .await?;
         let current: ClassInstanceRef<Displayable> = jvm
             .get_field(&this, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
             .await?;
@@ -1381,7 +1461,6 @@ mod test {
     use jvm::{ClassInstanceRef, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
     use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
     use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-    use rustjava_runtime::classes::java::lang::String;
 
     use test_utils::run_jvm_test;
     use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
@@ -1756,14 +1835,13 @@ mod test {
                     .await?
             );
 
-            let null_title = ClassInstanceRef::<String>::new(None);
             let _: () = jvm
                 .invoke_virtual(
                     &screen,
                     "javax/microedition/lcdui/Displayable",
                     "setTitle",
                     "(Ljava/lang/String;)V",
-                    (null_title,),
+                    (None,),
                 )
                 .await?;
             let detached_height = viewport_height(&jvm, &screen).await?;
@@ -1837,7 +1915,15 @@ mod test {
                 .await?;
 
             let display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
-            let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+            let mut graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
             let _: () = jvm
                 .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xaa22aa,))
                 .await?;
@@ -2007,7 +2093,15 @@ mod test {
             let _: () = jvm
                 .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
                 .await?;
-            let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+            let mut graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
             let image_ref = Graphics::image(&jvm, &mut graphics).await?;
             let image = Image::image(&jvm, &image_ref).await?;
             let menu_band_non_white = (160..222)

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -8,12 +8,9 @@ use rustjava_runtime::classes::java::lang::{Runnable, String as JavaString};
 use wie_backend::Event;
 use wie_jvm_support::{JvmSupport, WieJavaClassProto, WieJvmContext};
 
-use crate::classes::{
-    javax::microedition::{
-        lcdui::{Alert, Command, Displayable, Font, Graphics, Image, Ticker},
-        midlet::MIDlet,
-    },
-    net::wie::{KeyboardEventType, MIDPKeyCode},
+use crate::classes::javax::microedition::{
+    lcdui::{Alert, Displayable, Font, Graphics, Image, Ticker},
+    midlet::MIDlet,
 };
 
 const FONT_HEIGHT: i32 = 12;
@@ -21,25 +18,12 @@ const TITLE_HORIZONTAL_PADDING: i32 = 4;
 const TITLE_VERTICAL_PADDING: i32 = 2;
 const TICKER_HEIGHT: i32 = 16;
 const TICKER_INTERVAL_MS: u64 = 100;
-const TICKER_SCROLL_STEP: i32 = 2;
 const SOFTKEY_HEIGHT: i32 = 18;
-const MENU_ROW_HEIGHT: i32 = 18;
 
 const TITLE_BACKGROUND: i32 = 0x263746;
-const TICKER_BACKGROUND: i32 = 0xdde5ec;
-const SOFTKEY_BACKGROUND: i32 = 0x263746;
-const MENU_SELECTION_BACKGROUND: i32 = 0x2f6f9f;
 const WHITE: i32 = 0xffffff;
-const BLACK: i32 = 0;
-
-const COMMAND_BACK: i32 = 2;
-const COMMAND_CANCEL: i32 = 3;
-const COMMAND_OK: i32 = 4;
-const COMMAND_STOP: i32 = 6;
-const COMMAND_EXIT: i32 = 7;
 
 const LEFT_TOP: i32 = 4 | 16;
-const RIGHT_TOP: i32 = 8 | 16;
 
 struct ChromeLayout {
     content_width: i32,
@@ -52,19 +36,6 @@ struct ChromeLayout {
     ticker_height: i32,
     softkey_y: i32,
     softkey_height: i32,
-}
-
-#[derive(Clone)]
-struct CommandBinding {
-    command: ClassInstanceRef<Command>,
-    command_type: i32,
-    priority: i32,
-    effective_index: i32,
-}
-
-struct CommandLayout {
-    right: Option<CommandBinding>,
-    remaining: Vec<CommandBinding>,
 }
 
 // class javax.microedition.lcdui.Display
@@ -133,6 +104,7 @@ impl Display {
                     Self::get_content_height,
                     MethodAccessFlags::STATIC,
                 ),
+                JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::empty()),
@@ -218,7 +190,9 @@ impl Display {
     ) -> JvmResult<ChromeLayout> {
         let width = width.max(0);
         let height = height.max(0);
-        let fullscreen: bool = jvm.get_field(displayable, "isInFullScreenMode", "Z").await?;
+        let fullscreen: bool = jvm
+            .invoke_virtual(displayable, "javax/microedition/lcdui/Displayable", "isFullScreen", "()Z", ())
+            .await?;
         if fullscreen {
             return Ok(ChromeLayout {
                 content_x: 0,
@@ -237,8 +211,24 @@ impl Display {
         let command_count: i32 = jvm
             .invoke_virtual(displayable, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
             .await?;
-        let ticker: ClassInstanceRef<Ticker> = jvm.get_field(displayable, "ticker", "Ljavax/microedition/lcdui/Ticker;").await?;
-        let title: ClassInstanceRef<JavaString> = jvm.get_field(displayable, "title", "Ljava/lang/String;").await?;
+        let ticker: ClassInstanceRef<Ticker> = jvm
+            .invoke_virtual(
+                displayable,
+                "javax/microedition/lcdui/Displayable",
+                "getTicker",
+                "()Ljavax/microedition/lcdui/Ticker;",
+                (),
+            )
+            .await?;
+        let title: ClassInstanceRef<JavaString> = jvm
+            .invoke_virtual(
+                displayable,
+                "javax/microedition/lcdui/Displayable",
+                "getTitle",
+                "()Ljava/lang/String;",
+                (),
+            )
+            .await?;
         let title_lines = if title.is_null() {
             Vec::new()
         } else {
@@ -277,59 +267,6 @@ impl Display {
             softkey_y: height - softkey_height,
             softkey_height,
         })
-    }
-
-    async fn command_layout(jvm: &Jvm, displayable: &ClassInstanceRef<Displayable>) -> JvmResult<CommandLayout> {
-        let count: i32 = jvm
-            .invoke_virtual(displayable, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
-            .await?;
-        let mut bindings = Vec::with_capacity(count.max(0) as usize);
-        for effective_index in 0..count {
-            let command: ClassInstanceRef<Command> = jvm
-                .invoke_virtual(
-                    displayable,
-                    "javax/microedition/lcdui/Displayable",
-                    "getCommandAt",
-                    "(I)Ljavax/microedition/lcdui/Command;",
-                    (effective_index,),
-                )
-                .await?;
-            let command_type: i32 = jvm
-                .invoke_virtual(&command, "javax/microedition/lcdui/Command", "getCommandType", "()I", ())
-                .await?;
-            let priority: i32 = jvm
-                .invoke_virtual(&command, "javax/microedition/lcdui/Command", "getPriority", "()I", ())
-                .await?;
-            bindings.push(CommandBinding {
-                command,
-                command_type,
-                priority,
-                effective_index,
-            });
-        }
-
-        let right = bindings
-            .iter()
-            .filter(|binding| matches!(binding.command_type, COMMAND_BACK | COMMAND_CANCEL | COMMAND_STOP | COMMAND_EXIT))
-            .min_by_key(|binding| (binding.priority, binding.effective_index))
-            .cloned();
-        let mut remaining = bindings
-            .into_iter()
-            .filter(|binding| right.as_ref().is_none_or(|right| binding.effective_index != right.effective_index))
-            .collect::<Vec<_>>();
-        remaining.sort_by_key(|binding| {
-            (
-                if matches!(binding.command_type, COMMAND_BACK | COMMAND_CANCEL | COMMAND_STOP | COMMAND_EXIT) {
-                    1
-                } else {
-                    0
-                },
-                binding.priority,
-                binding.effective_index,
-            )
-        });
-
-        Ok(CommandLayout { right, remaining })
     }
 
     async fn get_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -387,9 +324,15 @@ impl Display {
                     .exception("java/lang/IllegalArgumentException", "An Alert cannot follow an Alert")
                     .await);
             }
-            let mut alert: ClassInstanceRef<Alert> = JavaValue::from(displayable.clone()).into();
-            jvm.put_field(&mut alert, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", current)
-                .await?;
+            let alert: ClassInstanceRef<Alert> = JavaValue::from(displayable.clone()).into();
+            jvm.invoke_virtual::<_, ()>(
+                &alert,
+                "javax/microedition/lcdui/Alert",
+                "setNextDisplayable",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (current,),
+            )
+            .await?;
         }
 
         jvm.invoke_virtual(
@@ -406,7 +349,7 @@ impl Display {
         jvm: &Jvm,
         _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
-        mut alert: ClassInstanceRef<Alert>,
+        alert: ClassInstanceRef<Alert>,
         next_displayable: ClassInstanceRef<Displayable>,
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Display::setCurrent({this:?}, {alert:?}, {next_displayable:?})");
@@ -420,8 +363,14 @@ impl Display {
                 .await);
         }
 
-        jvm.put_field(&mut alert, "nextDisplayable", "Ljavax/microedition/lcdui/Displayable;", next_displayable)
-            .await?;
+        jvm.invoke_virtual::<_, ()>(
+            &alert,
+            "javax/microedition/lcdui/Alert",
+            "setNextDisplayable",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (next_displayable,),
+        )
+        .await?;
         let displayable: ClassInstanceRef<Displayable> = JavaValue::from(alert).into();
         jvm.invoke_virtual(
             &this,
@@ -492,7 +441,9 @@ impl Display {
                 .await?;
         }
 
-        let fullscreen_mode: bool = jvm.get_field(&displayable, "isInFullScreenMode", "Z").await?;
+        let fullscreen_mode: bool = jvm
+            .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "isFullScreen", "()Z", ())
+            .await?;
         jvm.put_field(&mut this, "isInFullScreenMode", "Z", fullscreen_mode).await?;
 
         let width: i32 = jvm.get_field(&this, "width", "I").await?;
@@ -525,7 +476,15 @@ impl Display {
         if current.is_null() || !jvm.is_instance(&**current, "javax/microedition/lcdui/Alert") {
             return Ok(());
         }
-        let attached_display: ClassInstanceRef<Display> = jvm.get_field(&current, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let attached_display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &current,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if attached_display.is_null() || attached_display.identity() != this.identity() {
             return Ok(());
         }
@@ -587,7 +546,15 @@ impl Display {
         if current.is_null() {
             return Ok(None.into());
         }
-        let attached_display: ClassInstanceRef<Display> = jvm.get_field(&current, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let attached_display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &current,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if attached_display.is_null() || attached_display.identity() != this.identity() {
             return Ok(None.into());
         }
@@ -598,7 +565,14 @@ impl Display {
         if layout.ticker_height == 0 || layout.content_width == 0 {
             return Ok(None.into());
         }
-        jvm.get_field(&current, "ticker", "Ljavax/microedition/lcdui/Ticker;").await
+        jvm.invoke_virtual(
+            &current,
+            "javax/microedition/lcdui/Displayable",
+            "getTicker",
+            "()Ljavax/microedition/lcdui/Ticker;",
+            (),
+        )
+        .await
     }
 
     async fn ticker_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
@@ -624,7 +598,9 @@ impl Display {
         if ticker.is_null() {
             return Ok(());
         }
-        let text: ClassInstanceRef<JavaString> = jvm.get_field(&ticker, "text", "Ljava/lang/String;").await?;
+        let text: ClassInstanceRef<JavaString> = jvm
+            .invoke_virtual(&ticker, "javax/microedition/lcdui/Ticker", "getString", "()Ljava/lang/String;", ())
+            .await?;
         if JavaLangString::to_rust_string(jvm, &text).await?.is_empty() {
             return Ok(());
         }
@@ -667,7 +643,7 @@ impl Display {
         if jvm.get_field::<i32>(&this, "tickerGeneration", "I").await? != generation {
             return Ok(());
         }
-        let mut ticker: ClassInstanceRef<Ticker> = jvm
+        let ticker: ClassInstanceRef<Ticker> = jvm
             .invoke_virtual(
                 &this,
                 "javax/microedition/lcdui/Display",
@@ -679,23 +655,13 @@ impl Display {
         if ticker.is_null() {
             return Ok(());
         }
-        let text: ClassInstanceRef<JavaString> = jvm.get_field(&ticker, "text", "Ljava/lang/String;").await?;
-        let text = JavaLangString::to_rust_string(jvm, &text)
-            .await?
-            .replace("\r\n", " ")
-            .replace(['\r', '\n'], " ");
-        if text.is_empty() {
+        let width: i32 = jvm.get_field(&this, "width", "I").await?;
+        let advanced: bool = jvm
+            .invoke_virtual(&ticker, "javax/microedition/lcdui/Ticker", "advance", "(I)Z", (width,))
+            .await?;
+        if !advanced {
             return Ok(());
         }
-        let offset: i32 = jvm.get_field(&ticker, "scrollOffset", "I").await?;
-        let offset = offset + TICKER_SCROLL_STEP;
-        let offset = if offset >= Font::text_width(context.system().platform().font(), &text) + TITLE_HORIZONTAL_PADDING {
-            let width: i32 = jvm.get_field(&this, "width", "I").await?;
-            TITLE_HORIZONTAL_PADDING - width
-        } else {
-            offset
-        };
-        jvm.put_field(&mut ticker, "scrollOffset", "I", offset).await?;
         let _: () = jvm
             .invoke_virtual(&this, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
             .await?;
@@ -755,7 +721,15 @@ impl Display {
             .await?;
 
         if !current_displayable.is_null() {
-            let result = Self::route_key_event(jvm, &current_displayable, event_type, code).await;
+            let result: JvmResult<()> = jvm
+                .invoke_virtual(
+                    &current_displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "routeKeyEvent",
+                    "(II)V",
+                    (event_type, code),
+                )
+                .await;
 
             if let Err(x) = result {
                 Self::handle_exception(jvm, x).await?;
@@ -777,7 +751,15 @@ impl Display {
         if current.is_null() || !jvm.is_instance(&**current, "javax/microedition/lcdui/Alert") {
             return Ok(());
         }
-        let attached_display: ClassInstanceRef<Display> = jvm.get_field(&current, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let attached_display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &current,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if attached_display.is_null() || attached_display.identity() != this.identity() {
             return Ok(());
         }
@@ -787,6 +769,15 @@ impl Display {
             .await;
         if let Err(error) = result {
             Self::handle_exception(jvm, error).await?;
+        }
+        Ok(())
+    }
+
+    async fn service_repaints(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        if jvm.get_field::<bool>(&this, "repaintPending", "Z").await? {
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
         }
         Ok(())
     }
@@ -901,123 +892,9 @@ impl Display {
         Ok(())
     }
 
-    async fn route_key_event(jvm: &Jvm, displayable: &ClassInstanceRef<Displayable>, event_type: i32, code: i32) -> JvmResult<()> {
-        let mut displayable = displayable.clone();
-        let command_layout = Self::command_layout(jvm, &displayable).await?;
-        let mut menu_open: bool = jvm.get_field(&displayable, "commandMenuOpen", "Z").await?;
-
-        if menu_open && command_layout.remaining.len() < 2 {
-            jvm.put_field(&mut displayable, "commandMenuOpen", "Z", false).await?;
-            jvm.put_field(&mut displayable, "commandMenuIndex", "I", -1).await?;
-            menu_open = false;
-        }
-
-        if menu_open {
-            let pressed = event_type == KeyboardEventType::KeyPressed as i32;
-            let repeated = event_type == KeyboardEventType::KeyRepeated as i32;
-            if code == MIDPKeyCode::UP as i32 || code == MIDPKeyCode::DOWN as i32 {
-                if pressed || repeated {
-                    let index: i32 = jvm.get_field(&displayable, "commandMenuIndex", "I").await?;
-                    let maximum = command_layout.remaining.len() as i32 - 1;
-                    let new_index = if code == MIDPKeyCode::UP as i32 {
-                        (index - 1).max(0)
-                    } else {
-                        (index + 1).min(maximum)
-                    };
-                    if new_index != index {
-                        jvm.put_field(&mut displayable, "commandMenuIndex", "I", new_index).await?;
-                        let _: () = jvm
-                            .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
-                            .await?;
-                    }
-                }
-                return Ok(());
-            }
-
-            if code == MIDPKeyCode::FIRE as i32 || code == MIDPKeyCode::LEFT_SOFT_KEY as i32 {
-                if pressed {
-                    let index: i32 = jvm.get_field(&displayable, "commandMenuIndex", "I").await?;
-                    let command_index = command_layout.remaining[index.clamp(0, command_layout.remaining.len() as i32 - 1) as usize].effective_index;
-                    jvm.put_field(&mut displayable, "commandMenuOpen", "Z", false).await?;
-                    jvm.put_field(&mut displayable, "commandMenuIndex", "I", -1).await?;
-                    let _: () = jvm
-                        .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
-                        .await?;
-                    return jvm
-                        .invoke_virtual(
-                            &displayable,
-                            "javax/microedition/lcdui/Displayable",
-                            "dispatchCommandAt",
-                            "(I)V",
-                            (command_index,),
-                        )
-                        .await;
-                }
-                return Ok(());
-            }
-
-            if code == MIDPKeyCode::RIGHT_SOFT_KEY as i32 {
-                if pressed {
-                    jvm.put_field(&mut displayable, "commandMenuOpen", "Z", false).await?;
-                    jvm.put_field(&mut displayable, "commandMenuIndex", "I", -1).await?;
-                    let _: () = jvm
-                        .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
-                        .await?;
-                }
-                return Ok(());
-            }
-        } else {
-            if code == MIDPKeyCode::RIGHT_SOFT_KEY as i32 {
-                if let Some(binding) = command_layout.right {
-                    if event_type == KeyboardEventType::KeyPressed as i32 {
-                        return jvm
-                            .invoke_virtual(
-                                &displayable,
-                                "javax/microedition/lcdui/Displayable",
-                                "dispatchCommandAt",
-                                "(I)V",
-                                (binding.effective_index,),
-                            )
-                            .await;
-                    }
-                    return Ok(());
-                }
-            } else if code == MIDPKeyCode::LEFT_SOFT_KEY as i32 && !command_layout.remaining.is_empty() {
-                if event_type == KeyboardEventType::KeyPressed as i32 {
-                    if command_layout.remaining.len() == 1 {
-                        return jvm
-                            .invoke_virtual(
-                                &displayable,
-                                "javax/microedition/lcdui/Displayable",
-                                "dispatchCommandAt",
-                                "(I)V",
-                                (command_layout.remaining[0].effective_index,),
-                            )
-                            .await;
-                    }
-                    jvm.put_field(&mut displayable, "commandMenuOpen", "Z", true).await?;
-                    jvm.put_field(&mut displayable, "commandMenuIndex", "I", 0).await?;
-                    let _: () = jvm
-                        .invoke_virtual(&displayable, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
-                        .await?;
-                }
-                return Ok(());
-            }
-        }
-
-        jvm.invoke_virtual(
-            &displayable,
-            "javax/microedition/lcdui/Displayable",
-            "handleKeyEvent",
-            "(II)V",
-            (event_type, code),
-        )
-        .await
-    }
-
     async fn paint_chrome(
         jvm: &Jvm,
-        mut displayable: ClassInstanceRef<Displayable>,
+        displayable: ClassInstanceRef<Displayable>,
         graphics: ClassInstanceRef<Graphics>,
         layout: &ChromeLayout,
     ) -> JvmResult<()> {
@@ -1066,292 +943,36 @@ impl Display {
         }
 
         if layout.ticker_height > 0 {
-            let _: () = jvm
+            let ticker: ClassInstanceRef<Ticker> = jvm
                 .invoke_virtual(
-                    &graphics,
-                    "javax/microedition/lcdui/Graphics",
-                    "setClip",
-                    "(IIII)V",
-                    (0, layout.ticker_y, layout.content_width, layout.ticker_height),
+                    &displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "getTicker",
+                    "()Ljavax/microedition/lcdui/Ticker;",
+                    (),
                 )
                 .await?;
             let _: () = jvm
-                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TICKER_BACKGROUND,))
-                .await?;
-            let _: () = jvm
                 .invoke_virtual(
-                    &graphics,
-                    "javax/microedition/lcdui/Graphics",
-                    "fillRect",
-                    "(IIII)V",
-                    (0, layout.ticker_y, layout.content_width, layout.ticker_height),
-                )
-                .await?;
-
-            let ticker: ClassInstanceRef<Ticker> = jvm.get_field(&displayable, "ticker", "Ljavax/microedition/lcdui/Ticker;").await?;
-            let text: ClassInstanceRef<JavaString> = jvm.get_field(&ticker, "text", "Ljava/lang/String;").await?;
-            let text = JavaLangString::to_rust_string(jvm, &text)
-                .await?
-                .replace("\r\n", " ")
-                .replace(['\r', '\n'], " ");
-            let text = JavaLangString::from_rust_string(jvm, &text).await?;
-            let scroll_offset: i32 = jvm.get_field(&ticker, "scrollOffset", "I").await?;
-            let _: () = jvm
-                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
-                .await?;
-            let _: () = jvm
-                .invoke_virtual(
-                    &graphics,
-                    "javax/microedition/lcdui/Graphics",
-                    "drawString",
-                    "(Ljava/lang/String;III)V",
-                    (text, TITLE_HORIZONTAL_PADDING - scroll_offset, layout.ticker_y + 2, LEFT_TOP),
+                    &ticker,
+                    "javax/microedition/lcdui/Ticker",
+                    "paint",
+                    "(Ljavax/microedition/lcdui/Graphics;III)V",
+                    (graphics.clone(), layout.content_width, layout.ticker_y, layout.ticker_height),
                 )
                 .await?;
         }
 
         if layout.softkey_height > 0 {
-            let command_layout = Self::command_layout(jvm, &displayable).await?;
-            let menu_open: bool = jvm.get_field(&displayable, "commandMenuOpen", "Z").await?;
-            if menu_open && command_layout.remaining.len() > 1 && layout.softkey_y > 0 && layout.content_width > 0 {
-                let index: i32 = jvm.get_field(&displayable, "commandMenuIndex", "I").await?;
-                let index = index.clamp(0, command_layout.remaining.len() as i32 - 1);
-                jvm.put_field(&mut displayable, "commandMenuIndex", "I", index).await?;
-
-                let menu_height = layout
-                    .softkey_y
-                    .min((command_layout.remaining.len() as i32).saturating_mul(MENU_ROW_HEIGHT));
-                let visible_rows = ((menu_height + MENU_ROW_HEIGHT - 1) / MENU_ROW_HEIGHT).min(command_layout.remaining.len() as i32);
-                let first_row = (index - visible_rows + 1)
-                    .max(0)
-                    .min(command_layout.remaining.len() as i32 - visible_rows);
-                let menu_width = layout.content_width.min(180);
-                let menu_y = layout.softkey_y - menu_height;
-                let first_row_height = menu_height - (visible_rows - 1) * MENU_ROW_HEIGHT;
-
-                let _: () = jvm
-                    .invoke_virtual(
-                        &graphics,
-                        "javax/microedition/lcdui/Graphics",
-                        "setClip",
-                        "(IIII)V",
-                        (0, menu_y, menu_width, menu_height),
-                    )
-                    .await?;
-                let _: () = jvm
-                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
-                    .await?;
-                let _: () = jvm
-                    .invoke_virtual(
-                        &graphics,
-                        "javax/microedition/lcdui/Graphics",
-                        "fillRect",
-                        "(IIII)V",
-                        (0, menu_y, menu_width, menu_height),
-                    )
-                    .await?;
-
-                for visible_index in 0..visible_rows {
-                    let command_index = first_row + visible_index;
-                    let (row_y, row_height) = if visible_index == 0 {
-                        (menu_y, first_row_height)
-                    } else {
-                        (menu_y + first_row_height + (visible_index - 1) * MENU_ROW_HEIGHT, MENU_ROW_HEIGHT)
-                    };
-                    let _: () = jvm
-                        .invoke_virtual(
-                            &graphics,
-                            "javax/microedition/lcdui/Graphics",
-                            "setClip",
-                            "(IIII)V",
-                            (0, row_y, menu_width, row_height),
-                        )
-                        .await?;
-                    if command_index == index {
-                        let _: () = jvm
-                            .invoke_virtual(
-                                &graphics,
-                                "javax/microedition/lcdui/Graphics",
-                                "setColor",
-                                "(I)V",
-                                (MENU_SELECTION_BACKGROUND,),
-                            )
-                            .await?;
-                        let _: () = jvm
-                            .invoke_virtual(
-                                &graphics,
-                                "javax/microedition/lcdui/Graphics",
-                                "fillRect",
-                                "(IIII)V",
-                                (0, row_y, menu_width, row_height),
-                            )
-                            .await?;
-                        let _: () = jvm
-                            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
-                            .await?;
-                    } else {
-                        let _: () = jvm
-                            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
-                            .await?;
-                    }
-
-                    let label: ClassInstanceRef<JavaString> = jvm
-                        .invoke_virtual(
-                            &command_layout.remaining[command_index as usize].command,
-                            "javax/microedition/lcdui/Command",
-                            "getLabel",
-                            "()Ljava/lang/String;",
-                            (),
-                        )
-                        .await?;
-                    let _: () = jvm
-                        .invoke_virtual(
-                            &graphics,
-                            "javax/microedition/lcdui/Graphics",
-                            "drawString",
-                            "(Ljava/lang/String;III)V",
-                            (
-                                label,
-                                TITLE_HORIZONTAL_PADDING.min((menu_width - 1).max(0)),
-                                row_y + ((row_height - FONT_HEIGHT) / 2).max(0),
-                                LEFT_TOP,
-                            ),
-                        )
-                        .await?;
-                }
-
-                let _: () = jvm
-                    .invoke_virtual(
-                        &graphics,
-                        "javax/microedition/lcdui/Graphics",
-                        "setClip",
-                        "(IIII)V",
-                        (0, menu_y, menu_width, menu_height),
-                    )
-                    .await?;
-                let _: () = jvm
-                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
-                    .await?;
-                let _: () = jvm
-                    .invoke_virtual(
-                        &graphics,
-                        "javax/microedition/lcdui/Graphics",
-                        "drawRect",
-                        "(IIII)V",
-                        (0, menu_y, menu_width - 1, menu_height - 1),
-                    )
-                    .await?;
-            }
-
             let _: () = jvm
                 .invoke_virtual(
-                    &graphics,
-                    "javax/microedition/lcdui/Graphics",
-                    "setClip",
-                    "(IIII)V",
-                    (0, layout.softkey_y, layout.content_width, layout.softkey_height),
+                    &displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "paintCommands",
+                    "(Ljavax/microedition/lcdui/Graphics;III)V",
+                    (graphics, layout.content_width, layout.softkey_y, layout.softkey_height),
                 )
                 .await?;
-            let _: () = jvm
-                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (SOFTKEY_BACKGROUND,))
-                .await?;
-            let _: () = jvm
-                .invoke_virtual(
-                    &graphics,
-                    "javax/microedition/lcdui/Graphics",
-                    "fillRect",
-                    "(IIII)V",
-                    (0, layout.softkey_y, layout.content_width, layout.softkey_height),
-                )
-                .await?;
-            let _: () = jvm
-                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
-                .await?;
-
-            let middle = layout.content_width / 2;
-            let left_clip_width = (middle - 1).max(0);
-            let right_clip_x = (middle + 1).min(layout.content_width);
-            let right_clip_width = layout.content_width - right_clip_x;
-            if let Some(binding) = command_layout.right {
-                let label: ClassInstanceRef<JavaString> = jvm
-                    .invoke_virtual(
-                        &binding.command,
-                        "javax/microedition/lcdui/Command",
-                        "getLabel",
-                        "()Ljava/lang/String;",
-                        (),
-                    )
-                    .await?;
-                if right_clip_width > 0 {
-                    let _: () = jvm
-                        .invoke_virtual(
-                            &graphics,
-                            "javax/microedition/lcdui/Graphics",
-                            "setClip",
-                            "(IIII)V",
-                            (right_clip_x, layout.softkey_y, right_clip_width, layout.softkey_height),
-                        )
-                        .await?;
-                    let _: () = jvm
-                        .invoke_virtual(
-                            &graphics,
-                            "javax/microedition/lcdui/Graphics",
-                            "drawString",
-                            "(Ljava/lang/String;III)V",
-                            (
-                                label,
-                                (layout.content_width - TITLE_HORIZONTAL_PADDING).max(right_clip_x),
-                                layout.softkey_y + 2,
-                                RIGHT_TOP,
-                            ),
-                        )
-                        .await?;
-                }
-            }
-
-            if !command_layout.remaining.is_empty() && left_clip_width > 0 {
-                let label: ClassInstanceRef<JavaString> = if command_layout.remaining.len() == 1 {
-                    let label: ClassInstanceRef<JavaString> = jvm
-                        .invoke_virtual(
-                            &command_layout.remaining[0].command,
-                            "javax/microedition/lcdui/Command",
-                            "getLabel",
-                            "()Ljava/lang/String;",
-                            (),
-                        )
-                        .await?;
-                    if command_layout.remaining[0].command_type == COMMAND_OK && JavaLangString::to_rust_string(jvm, &label).await?.is_empty() {
-                        JavaLangString::from_rust_string(jvm, "OK").await?.into()
-                    } else {
-                        label
-                    }
-                } else {
-                    JavaLangString::from_rust_string(jvm, "Options").await?.into()
-                };
-                let _: () = jvm
-                    .invoke_virtual(
-                        &graphics,
-                        "javax/microedition/lcdui/Graphics",
-                        "setClip",
-                        "(IIII)V",
-                        (0, layout.softkey_y, left_clip_width, layout.softkey_height),
-                    )
-                    .await?;
-                let _: () = jvm
-                    .invoke_virtual(
-                        &graphics,
-                        "javax/microedition/lcdui/Graphics",
-                        "drawString",
-                        "(Ljava/lang/String;III)V",
-                        (
-                            label,
-                            TITLE_HORIZONTAL_PADDING.min((left_clip_width - 1).max(0)),
-                            layout.softkey_y + 2,
-                            LEFT_TOP,
-                        ),
-                    )
-                    .await?;
-            }
         }
 
         Ok(())

--- a/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
@@ -1,13 +1,43 @@
-use alloc::{format, vec};
+use alloc::{format, vec, vec::Vec};
 
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Graphics, Item, Ticker};
+use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Font, Graphics, Item, Ticker};
+
+use crate::classes::net::wie::{KeyboardEventType, MIDPKeyCode};
+
+const COMMAND_BACK: i32 = 2;
+const COMMAND_CANCEL: i32 = 3;
+const COMMAND_OK: i32 = 4;
+const COMMAND_STOP: i32 = 6;
+const COMMAND_EXIT: i32 = 7;
+
+const MENU_ROW_HEIGHT: i32 = 18;
+const TITLE_HORIZONTAL_PADDING: i32 = 4;
+const SOFTKEY_BACKGROUND: i32 = 0x263746;
+const MENU_SELECTION_BACKGROUND: i32 = 0x2f6f9f;
+const WHITE: i32 = 0xffffff;
+const BLACK: i32 = 0;
+const LEFT_TOP: i32 = 4 | 16;
+const RIGHT_TOP: i32 = 8 | 16;
+
+#[derive(Clone)]
+struct CommandBinding {
+    command: ClassInstanceRef<Command>,
+    command_type: i32,
+    priority: i32,
+    effective_index: i32,
+}
+
+struct CommandLayout {
+    right: Option<CommandBinding>,
+    remaining: Vec<CommandBinding>,
+}
 
 // class javax.microedition.lcdui.Displayable
 pub struct Displayable;
@@ -62,6 +92,20 @@ impl Displayable {
                     Self::set_display,
                     MethodAccessFlags::empty(),
                 ),
+                JavaMethodProto::new(
+                    "getDisplay",
+                    "()Ljavax/microedition/lcdui/Display;",
+                    Self::get_display,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("isFullScreen", "()Z", Self::is_full_screen, MethodAccessFlags::empty()),
+                JavaMethodProto::new("setFullScreen", "(Z)V", Self::set_full_screen, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "dispatchCommand",
+                    "(Ljavax/microedition/lcdui/Command;)Z",
+                    Self::dispatch_command,
+                    MethodAccessFlags::empty(),
+                ),
                 JavaMethodProto::new("requestRepaint", "()V", Self::request_repaint, MethodAccessFlags::empty()),
                 JavaMethodProto::new("decorationChanged", "()V", Self::decoration_changed, MethodAccessFlags::empty()),
                 JavaMethodProto::new("notifySizeChanged", "()V", Self::notify_size_changed, MethodAccessFlags::empty()),
@@ -89,6 +133,13 @@ impl Displayable {
                     "itemStateChanged",
                     "(Ljavax/microedition/lcdui/Item;)V",
                     Self::item_state_changed,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("routeKeyEvent", "(II)V", Self::route_key_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "paintCommands",
+                    "(Ljavax/microedition/lcdui/Graphics;III)V",
+                    Self::paint_commands,
                     MethodAccessFlags::empty(),
                 ),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
@@ -274,6 +325,34 @@ impl Displayable {
         Ok(())
     }
 
+    async fn get_display(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Display>> {
+        jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await
+    }
+
+    async fn is_full_screen(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        jvm.get_field(&this, "isInFullScreenMode", "Z").await
+    }
+
+    async fn set_full_screen(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, mode: bool) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Displayable::setFullScreen({this:?}, {mode})");
+
+        let previous_mode: bool = jvm.get_field(&this, "isInFullScreenMode", "Z").await?;
+        if previous_mode == mode {
+            return Ok(());
+        }
+
+        jvm.put_field(&mut this, "isInFullScreenMode", "Z", mode).await?;
+
+        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if !display.is_null() {
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "setFullscreen", "(Z)V", (mode,))
+                .await?;
+        }
+
+        Ok(())
+    }
+
     async fn request_repaint(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         if !display.is_null() {
@@ -326,6 +405,24 @@ impl Displayable {
         let command: ClassInstanceRef<Command> = jvm
             .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
             .await?;
+        let _: bool = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "dispatchCommand",
+                "(Ljavax/microedition/lcdui/Command;)Z",
+                (command,),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn dispatch_command(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        command: ClassInstanceRef<Command>,
+    ) -> JvmResult<bool> {
         let listener: ClassInstanceRef<CommandListener> = jvm
             .get_field(&this, "commandListener", "Ljavax/microedition/lcdui/CommandListener;")
             .await?;
@@ -341,7 +438,7 @@ impl Displayable {
                 .await?;
         }
 
-        Ok(())
+        Ok(!listener.is_null())
     }
 
     async fn check_item_mutation(
@@ -422,7 +519,13 @@ impl Displayable {
                 return Ok(());
             }
             let current: ClassInstanceRef<Displayable> = jvm
-                .get_field(&display, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getCurrent",
+                    "()Ljavax/microedition/lcdui/Displayable;",
+                    (),
+                )
                 .await?;
             if current.is_null() || current.identity() != this.identity() {
                 return Ok(());
@@ -444,7 +547,13 @@ impl Displayable {
                 return Ok(());
             }
             let callback_current: ClassInstanceRef<Displayable> = jvm
-                .get_field(&callback_display, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                .invoke_virtual(
+                    &callback_display,
+                    "javax/microedition/lcdui/Display",
+                    "getCurrent",
+                    "()Ljavax/microedition/lcdui/Displayable;",
+                    (),
+                )
                 .await?;
             if callback_current.is_null() || callback_current.identity() != this.identity() {
                 jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
@@ -461,7 +570,13 @@ impl Displayable {
                 false
             } else {
                 let active_current: ClassInstanceRef<Displayable> = jvm
-                    .get_field(&active_display, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                    .invoke_virtual(
+                        &active_display,
+                        "javax/microedition/lcdui/Display",
+                        "getCurrent",
+                        "()Ljavax/microedition/lcdui/Displayable;",
+                        (),
+                    )
                     .await?;
                 !active_current.is_null() && active_current.identity() == this.identity()
             };
@@ -479,6 +594,414 @@ impl Displayable {
                 .await;
             jvm.put_field(&mut this, "sizeNotifying", "Z", false).await?;
             result?;
+        }
+
+        Ok(())
+    }
+
+    async fn command_layout(jvm: &Jvm, displayable: &ClassInstanceRef<Displayable>) -> JvmResult<CommandLayout> {
+        let count: i32 = jvm
+            .invoke_virtual(displayable, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        let mut bindings = Vec::with_capacity(count.max(0) as usize);
+        for effective_index in 0..count {
+            let command: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(
+                    displayable,
+                    "javax/microedition/lcdui/Displayable",
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    (effective_index,),
+                )
+                .await?;
+            let command_type: i32 = jvm
+                .invoke_virtual(&command, "javax/microedition/lcdui/Command", "getCommandType", "()I", ())
+                .await?;
+            let priority: i32 = jvm
+                .invoke_virtual(&command, "javax/microedition/lcdui/Command", "getPriority", "()I", ())
+                .await?;
+            bindings.push(CommandBinding {
+                command,
+                command_type,
+                priority,
+                effective_index,
+            });
+        }
+
+        let right = bindings
+            .iter()
+            .filter(|binding| matches!(binding.command_type, COMMAND_BACK | COMMAND_CANCEL | COMMAND_STOP | COMMAND_EXIT))
+            .min_by_key(|binding| (binding.priority, binding.effective_index))
+            .cloned();
+        let mut remaining = bindings
+            .into_iter()
+            .filter(|binding| right.as_ref().is_none_or(|right| binding.effective_index != right.effective_index))
+            .collect::<Vec<_>>();
+        remaining.sort_by_key(|binding| {
+            (
+                if matches!(binding.command_type, COMMAND_BACK | COMMAND_CANCEL | COMMAND_STOP | COMMAND_EXIT) {
+                    1
+                } else {
+                    0
+                },
+                binding.priority,
+                binding.effective_index,
+            )
+        });
+
+        Ok(CommandLayout { right, remaining })
+    }
+
+    async fn route_key_event(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, event_type: i32, code: i32) -> JvmResult<()> {
+        let command_layout = Self::command_layout(jvm, &this).await?;
+        let mut menu_open: bool = jvm.get_field(&this, "commandMenuOpen", "Z").await?;
+
+        if menu_open && command_layout.remaining.len() < 2 {
+            jvm.put_field(&mut this, "commandMenuOpen", "Z", false).await?;
+            jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
+            menu_open = false;
+        }
+
+        if menu_open {
+            let pressed = event_type == KeyboardEventType::KeyPressed as i32;
+            let repeated = event_type == KeyboardEventType::KeyRepeated as i32;
+            if code == MIDPKeyCode::UP as i32 || code == MIDPKeyCode::DOWN as i32 {
+                if pressed || repeated {
+                    let index: i32 = jvm.get_field(&this, "commandMenuIndex", "I").await?;
+                    let maximum = command_layout.remaining.len() as i32 - 1;
+                    let new_index = if code == MIDPKeyCode::UP as i32 {
+                        (index - 1).max(0)
+                    } else {
+                        (index + 1).min(maximum)
+                    };
+                    if new_index != index {
+                        jvm.put_field(&mut this, "commandMenuIndex", "I", new_index).await?;
+                        let _: () = jvm
+                            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                            .await?;
+                    }
+                }
+                return Ok(());
+            }
+
+            if code == MIDPKeyCode::FIRE as i32 || code == MIDPKeyCode::LEFT_SOFT_KEY as i32 {
+                if pressed {
+                    let index: i32 = jvm.get_field(&this, "commandMenuIndex", "I").await?;
+                    let command_index = command_layout.remaining[index.clamp(0, command_layout.remaining.len() as i32 - 1) as usize].effective_index;
+                    jvm.put_field(&mut this, "commandMenuOpen", "Z", false).await?;
+                    jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                        .await?;
+                    return jvm
+                        .invoke_virtual(
+                            &this,
+                            "javax/microedition/lcdui/Displayable",
+                            "dispatchCommandAt",
+                            "(I)V",
+                            (command_index,),
+                        )
+                        .await;
+                }
+                return Ok(());
+            }
+
+            if code == MIDPKeyCode::RIGHT_SOFT_KEY as i32 {
+                if pressed {
+                    jvm.put_field(&mut this, "commandMenuOpen", "Z", false).await?;
+                    jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                        .await?;
+                }
+                return Ok(());
+            }
+        } else {
+            if code == MIDPKeyCode::RIGHT_SOFT_KEY as i32 {
+                if let Some(binding) = command_layout.right {
+                    if event_type == KeyboardEventType::KeyPressed as i32 {
+                        return jvm
+                            .invoke_virtual(
+                                &this,
+                                "javax/microedition/lcdui/Displayable",
+                                "dispatchCommandAt",
+                                "(I)V",
+                                (binding.effective_index,),
+                            )
+                            .await;
+                    }
+                    return Ok(());
+                }
+            } else if code == MIDPKeyCode::LEFT_SOFT_KEY as i32 && !command_layout.remaining.is_empty() {
+                if event_type == KeyboardEventType::KeyPressed as i32 {
+                    if command_layout.remaining.len() == 1 {
+                        return jvm
+                            .invoke_virtual(
+                                &this,
+                                "javax/microedition/lcdui/Displayable",
+                                "dispatchCommandAt",
+                                "(I)V",
+                                (command_layout.remaining[0].effective_index,),
+                            )
+                            .await;
+                    }
+                    jvm.put_field(&mut this, "commandMenuOpen", "Z", true).await?;
+                    jvm.put_field(&mut this, "commandMenuIndex", "I", 0).await?;
+                    let _: () = jvm
+                        .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                        .await?;
+                }
+                return Ok(());
+            }
+        }
+
+        jvm.invoke_virtual(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "handleKeyEvent",
+            "(II)V",
+            (event_type, code),
+        )
+        .await
+    }
+
+    async fn paint_commands(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        width: i32,
+        y: i32,
+        height: i32,
+    ) -> JvmResult<()> {
+        let command_layout = Self::command_layout(jvm, &this).await?;
+        let menu_open: bool = jvm.get_field(&this, "commandMenuOpen", "Z").await?;
+        if menu_open && command_layout.remaining.len() > 1 && y > 0 && width > 0 {
+            let index: i32 = jvm.get_field(&this, "commandMenuIndex", "I").await?;
+            let index = index.clamp(0, command_layout.remaining.len() as i32 - 1);
+            jvm.put_field(&mut this, "commandMenuIndex", "I", index).await?;
+
+            let menu_height = y.min((command_layout.remaining.len() as i32).saturating_mul(MENU_ROW_HEIGHT));
+            let visible_rows = ((menu_height + MENU_ROW_HEIGHT - 1) / MENU_ROW_HEIGHT).min(command_layout.remaining.len() as i32);
+            let first_row = (index - visible_rows + 1)
+                .max(0)
+                .min(command_layout.remaining.len() as i32 - visible_rows);
+            let menu_width = width.min(180);
+            let menu_y = y - menu_height;
+            let first_row_height = menu_height - (visible_rows - 1) * MENU_ROW_HEIGHT;
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, menu_y, menu_width, menu_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (0, menu_y, menu_width, menu_height),
+                )
+                .await?;
+
+            for visible_index in 0..visible_rows {
+                let command_index = first_row + visible_index;
+                let (row_y, row_height) = if visible_index == 0 {
+                    (menu_y, first_row_height)
+                } else {
+                    (menu_y + first_row_height + (visible_index - 1) * MENU_ROW_HEIGHT, MENU_ROW_HEIGHT)
+                };
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "setClip",
+                        "(IIII)V",
+                        (0, row_y, menu_width, row_height),
+                    )
+                    .await?;
+                if command_index == index {
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "setColor",
+                            "(I)V",
+                            (MENU_SELECTION_BACKGROUND,),
+                        )
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(
+                            &graphics,
+                            "javax/microedition/lcdui/Graphics",
+                            "fillRect",
+                            "(IIII)V",
+                            (0, row_y, menu_width, row_height),
+                        )
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+                        .await?;
+                } else {
+                    let _: () = jvm
+                        .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
+                        .await?;
+                }
+
+                let label: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(
+                        &command_layout.remaining[command_index as usize].command,
+                        "javax/microedition/lcdui/Command",
+                        "getLabel",
+                        "()Ljava/lang/String;",
+                        (),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (
+                            label,
+                            TITLE_HORIZONTAL_PADDING.min((menu_width - 1).max(0)),
+                            row_y + ((row_height - Font::HEIGHT) / 2).max(0),
+                            LEFT_TOP,
+                        ),
+                    )
+                    .await?;
+            }
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, menu_y, menu_width, menu_height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawRect",
+                    "(IIII)V",
+                    (0, menu_y, menu_width - 1, menu_height - 1),
+                )
+                .await?;
+        }
+
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "setClip",
+                "(IIII)V",
+                (0, y, width, height),
+            )
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (SOFTKEY_BACKGROUND,))
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "fillRect",
+                "(IIII)V",
+                (0, y, width, height),
+            )
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (WHITE,))
+            .await?;
+
+        let middle = width / 2;
+        let left_clip_width = (middle - 1).max(0);
+        let right_clip_x = (middle + 1).min(width);
+        let right_clip_width = width - right_clip_x;
+        if let Some(binding) = command_layout.right {
+            let label: ClassInstanceRef<String> = jvm
+                .invoke_virtual(
+                    &binding.command,
+                    "javax/microedition/lcdui/Command",
+                    "getLabel",
+                    "()Ljava/lang/String;",
+                    (),
+                )
+                .await?;
+            if right_clip_width > 0 {
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "setClip",
+                        "(IIII)V",
+                        (right_clip_x, y, right_clip_width, height),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (label, (width - TITLE_HORIZONTAL_PADDING).max(right_clip_x), y + 2, RIGHT_TOP),
+                    )
+                    .await?;
+            }
+        }
+
+        if !command_layout.remaining.is_empty() && left_clip_width > 0 {
+            let label: ClassInstanceRef<String> = if command_layout.remaining.len() == 1 {
+                let label: ClassInstanceRef<String> = jvm
+                    .invoke_virtual(
+                        &command_layout.remaining[0].command,
+                        "javax/microedition/lcdui/Command",
+                        "getLabel",
+                        "()Ljava/lang/String;",
+                        (),
+                    )
+                    .await?;
+                if command_layout.remaining[0].command_type == COMMAND_OK && JavaLangString::to_rust_string(jvm, &label).await?.is_empty() {
+                    JavaLangString::from_rust_string(jvm, "OK").await?.into()
+                } else {
+                    label
+                }
+            } else {
+                JavaLangString::from_rust_string(jvm, "Options").await?.into()
+            };
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setClip",
+                    "(IIII)V",
+                    (0, y, left_clip_width, height),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawString",
+                    "(Ljava/lang/String;III)V",
+                    (label, TITLE_HORIZONTAL_PADDING.min((left_clip_width - 1).max(0)), y + 2, LEFT_TOP),
+                )
+                .await?;
         }
 
         Ok(())

--- a/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
@@ -64,6 +64,7 @@ impl Displayable {
                 ),
                 JavaMethodProto::new("requestRepaint", "()V", Self::request_repaint, MethodAccessFlags::empty()),
                 JavaMethodProto::new("decorationChanged", "()V", Self::decoration_changed, MethodAccessFlags::empty()),
+                JavaMethodProto::new("notifySizeChanged", "()V", Self::notify_size_changed, MethodAccessFlags::empty()),
                 JavaMethodProto::new("getCommandCount", "()I", Self::get_command_count, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "getCommandAt",
@@ -152,7 +153,9 @@ impl Displayable {
         jvm.put_field(&mut this, "ticker", "Ljavax/microedition/lcdui/Ticker;", ticker).await?;
         if Self::is_shown(jvm, context, this.clone()).await? {
             let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-            Display::ticker_changed(jvm, context, display).await?;
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "tickerChanged", "()V", ())
+                .await?;
         }
         jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
             .await
@@ -282,14 +285,16 @@ impl Displayable {
         Ok(())
     }
 
-    async fn decoration_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn decoration_changed(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
         jvm.put_field(&mut this, "commandMenuOpen", "Z", false).await?;
         jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
 
         let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         if !display.is_null() {
-            let notification_result = Self::notify_size_changed(jvm, context, this.clone()).await;
+            let notification_result: JvmResult<()> = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "notifySizeChanged", "()V", ())
+                .await;
             let repaint_result: JvmResult<()> = jvm
                 .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
                 .await;
@@ -381,7 +386,7 @@ impl Displayable {
         Ok(height)
     }
 
-    pub async fn live_viewport(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>) -> JvmResult<(i32, i32)> {
+    async fn live_viewport(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>) -> JvmResult<(i32, i32)> {
         let display: ClassInstanceRef<Display> = jvm.get_field(this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
         let (width, height) = if display.is_null() {
             let screen = context.system().platform().screen();
@@ -394,12 +399,19 @@ impl Displayable {
                     .await?,
             )
         };
-        let layout = Display::chrome_layout(jvm, context, this, width, height).await?;
+        let content_height: i32 = jvm
+            .invoke_static(
+                "javax/microedition/lcdui/Display",
+                "getContentHeight",
+                "(Ljavax/microedition/lcdui/Displayable;II)I",
+                (this.clone(), width, height),
+            )
+            .await?;
 
-        Ok((layout.content_width, layout.content_height))
+        Ok((width.max(0), content_height))
     }
 
-    pub async fn notify_size_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn notify_size_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         if jvm.get_field::<bool>(&this, "sizeNotifying", "Z").await? {
             return Ok(());
         }

--- a/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
@@ -3,10 +3,11 @@ use alloc::{format, vec};
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Graphics};
+use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Graphics, Item, Ticker};
 
 // class javax.microedition.lcdui.Displayable
 pub struct Displayable;
@@ -18,11 +19,34 @@ impl Displayable {
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
             methods: vec![
-                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty()),
+                JavaMethodProto::new("getTitle", "()Ljava/lang/String;", Self::get_title, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setTitle", "(Ljava/lang/String;)V", Self::set_title, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "getTicker",
+                    "()Ljavax/microedition/lcdui/Ticker;",
+                    Self::get_ticker,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setTicker",
+                    "(Ljavax/microedition/lcdui/Ticker;)V",
+                    Self::set_ticker,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("isShown", "()Z", Self::is_shown, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "addCommand",
                     "(Ljavax/microedition/lcdui/Command;)V",
                     Self::add_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "removeCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::remove_command,
                     MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new(
@@ -31,13 +55,39 @@ impl Displayable {
                     Self::set_command_listener,
                     MethodAccessFlags::PUBLIC,
                 ),
-                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
-                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
-                // wie private methods...
+                JavaMethodProto::new("sizeChanged", "(II)V", Self::size_changed, MethodAccessFlags::PROTECTED),
                 JavaMethodProto::new(
                     "setDisplay",
                     "(Ljavax/microedition/lcdui/Display;)V",
                     Self::set_display,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("requestRepaint", "()V", Self::request_repaint, MethodAccessFlags::empty()),
+                JavaMethodProto::new("decorationChanged", "()V", Self::decoration_changed, MethodAccessFlags::empty()),
+                JavaMethodProto::new("getCommandCount", "()I", Self::get_command_count, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    Self::get_command_at,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("dispatchCommandAt", "(I)V", Self::dispatch_command_at, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "checkItemMutation",
+                    "(Ljavax/microedition/lcdui/Item;)V",
+                    Self::check_item_mutation,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "itemInvalidated",
+                    "(Ljavax/microedition/lcdui/Item;Z)V",
+                    Self::item_invalidated,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "itemStateChanged",
+                    "(Ljavax/microedition/lcdui/Item;)V",
+                    Self::item_state_changed,
                     MethodAccessFlags::empty(),
                 ),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
@@ -50,40 +100,156 @@ impl Displayable {
                 JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::PROTECTED),
             ],
             fields: vec![
+                JavaFieldProto::new("title", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("ticker", "Ljavax/microedition/lcdui/Ticker;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commands", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commandListener", "Ljavax/microedition/lcdui/CommandListener;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("currentDisplay", "Ljavax/microedition/lcdui/Display;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("notifiedWidth", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("notifiedHeight", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("sizeKnown", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("sizeDirty", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("sizeNotifying", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commandMenuOpen", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commandMenuIndex", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("isInFullScreenMode", "Z", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 
-    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Displayable::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        let commands = jvm.new_class("java/util/Vector", "()V", ()).await?;
+        jvm.put_field(&mut this, "commands", "Ljava/util/Vector;", commands).await?;
+        jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
+        jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
 
         Ok(())
     }
 
-    async fn add_command(
-        _jvm: &Jvm,
+    async fn get_title(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "title", "Ljava/lang/String;").await
+    }
+
+    async fn set_title(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, title: ClassInstanceRef<String>) -> JvmResult<()> {
+        jvm.put_field(&mut this, "title", "Ljava/lang/String;", title).await?;
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn get_ticker(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Ticker>> {
+        jvm.get_field(&this, "ticker", "Ljavax/microedition/lcdui/Ticker;").await
+    }
+
+    async fn set_ticker(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, ticker: ClassInstanceRef<Ticker>) -> JvmResult<()> {
+        let previous: ClassInstanceRef<Ticker> = jvm.get_field(&this, "ticker", "Ljavax/microedition/lcdui/Ticker;").await?;
+        if (previous.is_null() && ticker.is_null()) || (!previous.is_null() && !ticker.is_null() && previous.identity() == ticker.identity()) {
+            return Ok(());
+        }
+        jvm.put_field(&mut this, "ticker", "Ljavax/microedition/lcdui/Ticker;", ticker).await?;
+        if Self::is_shown(jvm, context, this.clone()).await? {
+            let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+            Display::ticker_changed(jvm, context, display).await?;
+        }
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn is_shown(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if display.is_null() {
+            return Ok(false);
+        }
+
+        let current: ClassInstanceRef<Displayable> = jvm
+            .invoke_virtual(
+                &display,
+                "javax/microedition/lcdui/Display",
+                "getCurrent",
+                "()Ljavax/microedition/lcdui/Displayable;",
+                (),
+            )
+            .await?;
+        Ok(!current.is_null() && current.identity() == this.identity())
+    }
+
+    async fn add_command(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, command: ClassInstanceRef<Command>) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Displayable::addCommand({this:?}, {command:?})");
+
+        if command.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Command is null").await);
+        }
+
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        let mut registered = false;
+        for index in 0..command_count {
+            let existing: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                .await?;
+            if existing.identity() == command.identity() {
+                registered = true;
+                break;
+            }
+        }
+        if !registered {
+            let _: () = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (command,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn remove_command(
+        jvm: &Jvm,
         _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         command: ClassInstanceRef<Command>,
     ) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Displayable::addCommand({this:?}, {command:?})");
+        tracing::debug!("javax.microedition.lcdui.Displayable::removeCommand({this:?}, {command:?})");
+
+        if command.is_null() {
+            return Ok(());
+        }
+
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        for index in 0..command_count {
+            let existing: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                .await?;
+            if existing.identity() == command.identity() {
+                let _: () = jvm
+                    .invoke_virtual(&commands, "java/util/Vector", "removeElementAt", "(I)V", (index,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+                    .await?;
+                break;
+            }
+        }
 
         Ok(())
     }
 
     async fn set_command_listener(
-        _jvm: &Jvm,
+        jvm: &Jvm,
         _context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         listener: ClassInstanceRef<CommandListener>,
     ) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Displayable::setCommandListener({this:?}, {listener:?})");
+        jvm.put_field(&mut this, "commandListener", "Ljavax/microedition/lcdui/CommandListener;", listener)
+            .await
+    }
 
+    async fn size_changed(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>, _width: i32, _height: i32) -> JvmResult<()> {
         Ok(())
     }
 
@@ -93,47 +259,221 @@ impl Displayable {
         mut this: ClassInstanceRef<Self>,
         display: ClassInstanceRef<Display>,
     ) -> JvmResult<()> {
-        // tracing hates variable named `display`..
         let log = format!("javax.microedition.lcdui.Displayable::setDisplay({this:?}, {display:?})");
         tracing::debug!("{log}");
 
         jvm.put_field(&mut this, "currentDisplay", "Ljavax/microedition/lcdui/Display;", display)
             .await?;
+        jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
+        jvm.put_field(&mut this, "commandMenuOpen", "Z", false).await?;
+        jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
 
         Ok(())
+    }
+
+    async fn request_repaint(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if !display.is_null() {
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn decoration_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
+        jvm.put_field(&mut this, "commandMenuOpen", "Z", false).await?;
+        jvm.put_field(&mut this, "commandMenuIndex", "I", -1).await?;
+
+        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if !display.is_null() {
+            let notification_result = Self::notify_size_changed(jvm, context, this.clone()).await;
+            let repaint_result: JvmResult<()> = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                .await;
+            notification_result?;
+            repaint_result?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_command_count(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await
+    }
+
+    async fn get_command_at(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        index: i32,
+    ) -> JvmResult<ClassInstanceRef<Command>> {
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+            .await
+    }
+
+    async fn dispatch_command_at(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        let command: ClassInstanceRef<Command> = jvm
+            .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+            .await?;
+        let listener: ClassInstanceRef<CommandListener> = jvm
+            .get_field(&this, "commandListener", "Ljavax/microedition/lcdui/CommandListener;")
+            .await?;
+        if !listener.is_null() {
+            let _: () = jvm
+                .invoke_virtual(
+                    &listener,
+                    "javax/microedition/lcdui/CommandListener",
+                    "commandAction",
+                    "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                    (command, this),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn check_item_mutation(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        _this: ClassInstanceRef<Self>,
+        _item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        Ok(())
+    }
+
+    async fn item_invalidated(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        _this: ClassInstanceRef<Self>,
+        _item: ClassInstanceRef<Item>,
+        _layout_changed: bool,
+    ) -> JvmResult<()> {
+        Ok(())
+    }
+
+    async fn item_state_changed(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        _this: ClassInstanceRef<Self>,
+        _item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        Err(jvm.exception("java/lang/IllegalStateException", "Item is not owned by a Form").await)
     }
 
     async fn get_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("javax.microedition.lcdui.Displayable::getWidth({this:?})");
 
-        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let width = if display.is_null() {
-            context.system().platform().screen().width() as i32
-        } else {
-            jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "getWidth", "()I", ())
-                .await?
-        };
-
+        let (width, _) = Self::live_viewport(jvm, context, &this).await?;
         Ok(width)
     }
 
     async fn get_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
         tracing::debug!("javax.microedition.lcdui.Displayable::getHeight({this:?})");
 
-        let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-        let height = if display.is_null() {
-            context.system().platform().screen().height() as i32
-        } else {
-            jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "getHeight", "()I", ())
-                .await?
-        };
-
+        let (_, height) = Self::live_viewport(jvm, context, &this).await?;
         Ok(height)
+    }
+
+    pub async fn live_viewport(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>) -> JvmResult<(i32, i32)> {
+        let display: ClassInstanceRef<Display> = jvm.get_field(this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let (width, height) = if display.is_null() {
+            let screen = context.system().platform().screen();
+            (screen.width() as i32, screen.height() as i32)
+        } else {
+            (
+                jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "getWidth", "()I", ())
+                    .await?,
+                jvm.invoke_virtual(&display, "javax/microedition/lcdui/Display", "getHeight", "()I", ())
+                    .await?,
+            )
+        };
+        let layout = Display::chrome_layout(jvm, context, this, width, height).await?;
+
+        Ok((layout.content_width, layout.content_height))
+    }
+
+    pub async fn notify_size_changed(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        if jvm.get_field::<bool>(&this, "sizeNotifying", "Z").await? {
+            return Ok(());
+        }
+
+        while jvm.get_field::<bool>(&this, "sizeDirty", "Z").await? {
+            let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+            if display.is_null() {
+                return Ok(());
+            }
+            let current: ClassInstanceRef<Displayable> = jvm
+                .get_field(&display, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                .await?;
+            if current.is_null() || current.identity() != this.identity() {
+                return Ok(());
+            }
+
+            jvm.put_field(&mut this, "sizeDirty", "Z", false).await?;
+
+            let (width, height) = Self::live_viewport(jvm, context, &this).await?;
+            let size_known: bool = jvm.get_field(&this, "sizeKnown", "Z").await?;
+            let notified_width: i32 = jvm.get_field(&this, "notifiedWidth", "I").await?;
+            let notified_height: i32 = jvm.get_field(&this, "notifiedHeight", "I").await?;
+            if size_known && notified_width == width && notified_height == height {
+                continue;
+            }
+
+            let callback_display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+            if callback_display.is_null() || callback_display.identity() != display.identity() {
+                jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
+                return Ok(());
+            }
+            let callback_current: ClassInstanceRef<Displayable> = jvm
+                .get_field(&callback_display, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                .await?;
+            if callback_current.is_null() || callback_current.identity() != this.identity() {
+                jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
+                return Ok(());
+            }
+
+            jvm.put_field(&mut this, "notifiedWidth", "I", width).await?;
+            jvm.put_field(&mut this, "notifiedHeight", "I", height).await?;
+            jvm.put_field(&mut this, "sizeKnown", "Z", true).await?;
+            jvm.put_field(&mut this, "sizeNotifying", "Z", true).await?;
+
+            let active_display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+            let still_current = if active_display.is_null() || active_display.identity() != display.identity() {
+                false
+            } else {
+                let active_current: ClassInstanceRef<Displayable> = jvm
+                    .get_field(&active_display, "currentDisplayable", "Ljavax/microedition/lcdui/Displayable;")
+                    .await?;
+                !active_current.is_null() && active_current.identity() == this.identity()
+            };
+            if !still_current {
+                jvm.put_field(&mut this, "notifiedWidth", "I", notified_width).await?;
+                jvm.put_field(&mut this, "notifiedHeight", "I", notified_height).await?;
+                jvm.put_field(&mut this, "sizeKnown", "Z", size_known).await?;
+                jvm.put_field(&mut this, "sizeNotifying", "Z", false).await?;
+                jvm.put_field(&mut this, "sizeDirty", "Z", true).await?;
+                return Ok(());
+            }
+
+            let result: JvmResult<()> = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "sizeChanged", "(II)V", (width, height))
+                .await;
+            jvm.put_field(&mut this, "sizeNotifying", "Z", false).await?;
+            result?;
+        }
+
+        Ok(())
     }
 
     async fn handle_key_event(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, event_type: i32, code: i32) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Displayable::handleKeyEvent({this:?}, {event_type}, {code})");
-
         Ok(())
     }
 
@@ -144,7 +484,6 @@ impl Displayable {
         graphics: ClassInstanceRef<Graphics>,
     ) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Displayable::handlePaintEvent({this:?}, {graphics:?})");
-
         Ok(())
     }
 
@@ -158,9 +497,8 @@ impl Displayable {
     ) -> JvmResult<()> {
         tracing::debug!(
             "javax.microedition.lcdui.Displayable::handleNotifyEvent({this:?}, {}, {param1}, {param2})",
-            r#type,
+            r#type
         );
-
         Ok(())
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/font.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/font.rs
@@ -1,17 +1,87 @@
-use alloc::{string::String as RustString, vec};
+use alloc::{
+    string::{String as RustString, ToString},
+    vec,
+    vec::Vec,
+};
 
 use jvm::{Array, ClassInstanceRef, JavaChar, Jvm, Result as JvmResult, runtime::JavaLangString};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
-use wie_backend::canvas;
+use wie_backend::{Font as BackendFont, canvas};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 // class javax.microedition.lcdui.Font
 pub struct Font;
 
 impl Font {
+    pub const HEIGHT: i32 = 12;
+
+    pub fn text_width(font: &BackendFont, text: &str) -> i32 {
+        canvas::string_width(font, text, 10.0).ceil() as i32
+    }
+
+    pub fn minimum_width(font: &BackendFont, text: &str) -> i32 {
+        text.chars()
+            .filter(|character| *character != '\n')
+            .map(|character| Self::text_width(font, &character.to_string()))
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn preferred_width(font: &BackendFont, text: &str) -> i32 {
+        text.split('\n').map(|line| Self::text_width(font, line)).max().unwrap_or(0)
+    }
+
+    pub fn wrap(font: &BackendFont, text: &str, maximum_width: Option<i32>) -> Vec<RustString> {
+        let mut lines = Vec::new();
+        for paragraph in text.split('\n') {
+            let characters = paragraph.chars().collect::<Vec<_>>();
+            if characters.is_empty() {
+                lines.push(RustString::new());
+                continue;
+            }
+
+            let Some(maximum_width) = maximum_width else {
+                lines.push(paragraph.to_string());
+                continue;
+            };
+            let maximum_width = maximum_width.max(1);
+            let mut start = 0;
+            while start < characters.len() {
+                let mut end = start;
+                let mut width = 0;
+                let mut word_boundary = None;
+                while end < characters.len() {
+                    let character_width = Self::text_width(font, &characters[end].to_string());
+                    if end > start && width + character_width > maximum_width {
+                        break;
+                    }
+                    width += character_width;
+                    end += 1;
+                    if characters[end - 1].is_whitespace() {
+                        word_boundary = Some(end);
+                    }
+                }
+
+                let split = if end == characters.len() {
+                    end
+                } else {
+                    word_boundary.filter(|boundary| *boundary > start).unwrap_or(end.max(start + 1))
+                };
+                let line = characters[start..split].iter().collect::<RustString>();
+                lines.push(line.trim_end().to_string());
+                start = split;
+                while start < characters.len() && characters[start].is_whitespace() {
+                    start += 1;
+                }
+            }
+        }
+
+        lines
+    }
+
     pub fn as_proto() -> WieJavaClassProto {
         WieJavaClassProto {
             name: "javax/microedition/lcdui/Font",
@@ -126,7 +196,7 @@ impl Font {
     async fn get_height(_: &Jvm, _: &mut WieJvmContext) -> JvmResult<i32> {
         tracing::warn!("stub javax.microedition.lcdui.Font::getHeight");
 
-        Ok(12) // TODO: hardcoded
+        Ok(Self::HEIGHT) // TODO: hardcoded
     }
 
     async fn get_default_font(jvm: &Jvm, _: &mut WieJvmContext) -> JvmResult<ClassInstanceRef<Self>> {
@@ -191,5 +261,30 @@ impl Font {
         let string = RustString::from_utf16(&chars).unwrap();
 
         Ok(canvas::string_width(context.system().platform().font(), &string, 10.0) as _)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_utils::TestPlatform;
+    use wie_backend::Platform;
+
+    use super::*;
+
+    #[test]
+    fn preserves_explicit_newlines_and_prefers_word_boundaries() {
+        let platform = TestPlatform::new();
+        let width = Font::text_width(platform.font(), "alpha ");
+        assert_eq!(
+            Font::wrap(platform.font(), "alpha beta\n\ngamma", Some(width)),
+            ["alpha", "beta", "", "gamma"]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_character_boundaries_for_long_words() {
+        let platform = TestPlatform::new();
+        let width = Font::text_width(platform.font(), "ab");
+        assert_eq!(Font::wrap(platform.font(), "abcdef", Some(width)), ["ab", "cd", "ef"]);
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/font.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/font.rs
@@ -1,15 +1,11 @@
-use alloc::{
-    string::{String as RustString, ToString},
-    vec,
-    vec::Vec,
-};
+use alloc::{string::String as RustString, vec};
 
 use jvm::{Array, ClassInstanceRef, JavaChar, Jvm, Result as JvmResult, runtime::JavaLangString};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
-use wie_backend::{Font as BackendFont, canvas};
+use wie_backend::canvas::string_width;
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 // class javax.microedition.lcdui.Font
@@ -17,70 +13,6 @@ pub struct Font;
 
 impl Font {
     pub const HEIGHT: i32 = 12;
-
-    pub fn text_width(font: &BackendFont, text: &str) -> i32 {
-        canvas::string_width(font, text, 10.0).ceil() as i32
-    }
-
-    pub fn minimum_width(font: &BackendFont, text: &str) -> i32 {
-        text.chars()
-            .filter(|character| *character != '\n')
-            .map(|character| Self::text_width(font, &character.to_string()))
-            .max()
-            .unwrap_or(0)
-    }
-
-    pub fn preferred_width(font: &BackendFont, text: &str) -> i32 {
-        text.split('\n').map(|line| Self::text_width(font, line)).max().unwrap_or(0)
-    }
-
-    pub fn wrap(font: &BackendFont, text: &str, maximum_width: Option<i32>) -> Vec<RustString> {
-        let mut lines = Vec::new();
-        for paragraph in text.split('\n') {
-            let characters = paragraph.chars().collect::<Vec<_>>();
-            if characters.is_empty() {
-                lines.push(RustString::new());
-                continue;
-            }
-
-            let Some(maximum_width) = maximum_width else {
-                lines.push(paragraph.to_string());
-                continue;
-            };
-            let maximum_width = maximum_width.max(1);
-            let mut start = 0;
-            while start < characters.len() {
-                let mut end = start;
-                let mut width = 0;
-                let mut word_boundary = None;
-                while end < characters.len() {
-                    let character_width = Self::text_width(font, &characters[end].to_string());
-                    if end > start && width + character_width > maximum_width {
-                        break;
-                    }
-                    width += character_width;
-                    end += 1;
-                    if characters[end - 1].is_whitespace() {
-                        word_boundary = Some(end);
-                    }
-                }
-
-                let split = if end == characters.len() {
-                    end
-                } else {
-                    word_boundary.filter(|boundary| *boundary > start).unwrap_or(end.max(start + 1))
-                };
-                let line = characters[start..split].iter().collect::<RustString>();
-                lines.push(line.trim_end().to_string());
-                start = split;
-                while start < characters.len() && characters[start].is_whitespace() {
-                    start += 1;
-                }
-            }
-        }
-
-        lines
-    }
 
     pub fn as_proto() -> WieJavaClassProto {
         WieJavaClassProto {
@@ -220,7 +152,7 @@ impl Font {
 
         let string = JavaLangString::to_rust_string(jvm, &string).await?;
 
-        Ok(canvas::string_width(context.system().platform().font(), &string, 10.0) as _)
+        Ok(string_width(context.system().platform().font(), &string, 10.0) as _)
     }
 
     async fn substring_width(
@@ -236,7 +168,7 @@ impl Font {
         let string = JavaLangString::to_rust_string(jvm, &string).await?;
         let substring = string.chars().skip(offset as usize).take(len as usize).collect::<RustString>();
 
-        Ok(canvas::string_width(context.system().platform().font(), &substring, 10.0) as _)
+        Ok(string_width(context.system().platform().font(), &substring, 10.0) as _)
     }
 
     async fn char_width(_: &Jvm, context: &mut WieJvmContext, _: ClassInstanceRef<Self>, char: JavaChar) -> JvmResult<i32> {
@@ -244,7 +176,7 @@ impl Font {
 
         let string = RustString::from_utf16(&[char]).unwrap();
 
-        Ok(canvas::string_width(context.system().platform().font(), &string, 10.0) as _)
+        Ok(string_width(context.system().platform().font(), &string, 10.0) as _)
     }
 
     async fn chars_width(
@@ -260,31 +192,6 @@ impl Font {
         let chars = jvm.load_array(&chars, offset as _, len as _).await?;
         let string = RustString::from_utf16(&chars).unwrap();
 
-        Ok(canvas::string_width(context.system().platform().font(), &string, 10.0) as _)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use test_utils::TestPlatform;
-    use wie_backend::Platform;
-
-    use super::*;
-
-    #[test]
-    fn preserves_explicit_newlines_and_prefers_word_boundaries() {
-        let platform = TestPlatform::new();
-        let width = Font::text_width(platform.font(), "alpha ");
-        assert_eq!(
-            Font::wrap(platform.font(), "alpha beta\n\ngamma", Some(width)),
-            ["alpha", "beta", "", "gamma"]
-        );
-    }
-
-    #[test]
-    fn falls_back_to_character_boundaries_for_long_words() {
-        let platform = TestPlatform::new();
-        let width = Font::text_width(platform.font(), "ab");
-        assert_eq!(Font::wrap(platform.font(), "abcdef", Some(width)), ["ab", "cd", "ef"]);
+        Ok(string_width(context.system().platform().font(), &string, 10.0) as _)
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -17,7 +17,9 @@ use crate::classes::{
 
 struct ItemRect {
     item: ClassInstanceRef<Item>,
+    x: i32,
     y: i32,
+    width: i32,
     height: i32,
 }
 
@@ -195,16 +197,32 @@ impl Form {
     }
 
     async fn layout_items(jvm: &Jvm, items: &[ClassInstanceRef<Item>], width: i32) -> JvmResult<Vec<ItemRect>> {
+        let width = width.max(0);
         let mut rows = Vec::with_capacity(items.len());
         let mut y = 0i32;
+        let mut alignment = 1;
         for item in items {
+            let layout: i32 = jvm.invoke_virtual(item, "javax/microedition/lcdui/Item", "getLayout", "()I", ()).await?;
+            if layout & 3 != 0 {
+                alignment = layout & 3;
+            }
+            let item_width: i32 = jvm
+                .invoke_virtual(item, "javax/microedition/lcdui/Item", "measureWidth", "(I)I", (width,))
+                .await?;
+            let x = match alignment {
+                2 => width - item_width,
+                3 => (width - item_width) / 2,
+                _ => 0,
+            };
             let height: i32 = jvm
-                .invoke_virtual(item, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (width.max(0),))
+                .invoke_virtual(item, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (item_width,))
                 .await?;
             let height = height.max(1);
             rows.push(ItemRect {
                 item: item.clone(),
+                x,
                 y,
+                width: item_width,
                 height,
             });
             y = y.saturating_add(height);
@@ -217,7 +235,6 @@ impl Form {
         _context: &mut WieJvmContext,
         this: &mut ClassInstanceRef<Self>,
         rows: &[ItemRect],
-        width: i32,
         viewport_height: i32,
     ) -> JvmResult<()> {
         let viewport_height = viewport_height.max(0);
@@ -239,7 +256,7 @@ impl Form {
                         "javax/microedition/lcdui/Item",
                         "getFocusBounds",
                         "(II)[I",
-                        (width, row.height),
+                        (row.width, row.height),
                     )
                     .await?;
                 let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
@@ -316,7 +333,7 @@ impl Form {
             .invoke_special(this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
             .await?;
         let rows = Self::layout_items(jvm, &items, width).await?;
-        Self::update_scroll(jvm, context, this, &rows, width, height).await
+        Self::update_scroll(jvm, context, this, &rows, height).await
     }
 
     async fn focused_item(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Item>> {
@@ -722,7 +739,7 @@ impl Form {
                         "javax/microedition/lcdui/Item",
                         "getFocusBounds",
                         "(II)[I",
-                        (width, row.height),
+                        (row.width, row.height),
                     )
                     .await?;
                 let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
@@ -871,7 +888,7 @@ impl Form {
             .await?;
         let items = Self::load_items(jvm, &this).await?;
         let rows = Self::layout_items(jvm, &items, width).await?;
-        Self::update_scroll(jvm, context, &mut this, &rows, width, height).await?;
+        Self::update_scroll(jvm, context, &mut this, &rows, height).await?;
 
         let scroll: i32 = jvm.get_field(&this, "scrollY", "I").await?;
         let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
@@ -886,7 +903,14 @@ impl Form {
                     "javax/microedition/lcdui/Item",
                     "paintItem",
                     "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
-                    (graphics.clone(), 0, row.y - scroll, width, row.height, index as i32 == focus_index),
+                    (
+                        graphics.clone(),
+                        row.x,
+                        row.y - scroll,
+                        row.width,
+                        row.height,
+                        index as i32 == focus_index,
+                    ),
                 )
                 .await?;
         }
@@ -912,7 +936,7 @@ mod test {
         classes::{
             javax::microedition::lcdui::{
                 ChoiceGroup, Command, CommandListener, Display, Displayable, Form, Gauge, Graphics, Image, Item, ItemCommandListener,
-                ItemStateListener,
+                ItemStateListener, StringItem,
             },
             javax::microedition::midlet::MIDlet,
             net::wie::{EventQueue, KeyboardEventType, MIDPKeyCode},
@@ -1472,6 +1496,129 @@ mod test {
     }
 
     #[test]
+    fn form_paints_items_at_their_allocated_width_and_alignment() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let text = JavaLangString::from_rust_string(&jvm, "alpha beta gamma delta epsilon").await?;
+            let item: ClassInstanceRef<StringItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/StringItem",
+                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                    (None, text),
+                )
+                .await?
+                .into();
+            let _: () = jvm
+                .invoke_virtual(&item, "javax/microedition/lcdui/Item", "setPreferredSize", "(II)V", (40, -1))
+                .await?;
+            let height: i32 = jvm
+                .invoke_virtual(&item, "javax/microedition/lcdui/Item", "getPreferredHeight", "()I", ())
+                .await?;
+            let following = recording_item(&jvm, 4, 0x225522, false).await?;
+            let form = form_with_items(
+                &jvm,
+                vec![JavaValue::from(item.clone()).into(), JavaValue::from(following.clone()).into()],
+            )
+            .await?;
+            let display = show_form(&jvm, &form, 80, 240).await?;
+            let mut graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
+            let expected: ClassInstanceRef<Image> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Image",
+                    "createImage",
+                    "(II)Ljavax/microedition/lcdui/Image;",
+                    (80, height),
+                )
+                .await?;
+            let expected_graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &expected,
+                    "javax/microedition/lcdui/Image",
+                    "getGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
+
+            for (layout, x) in [(0, 0), (1, 0), (2, 40), (3, 20), (3 | 0x800, 20), (2 | 0x400, 40)] {
+                let _: () = jvm
+                    .invoke_virtual(&item, "javax/microedition/lcdui/Item", "setLayout", "(I)V", (layout,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&expected_graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xffffff,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &expected_graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "fillRect",
+                        "(IIII)V",
+                        (0, 0, 80, height),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &item,
+                        "javax/microedition/lcdui/Item",
+                        "paintItem",
+                        "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                        (expected_graphics.clone(), x, 0, 40, height, false),
+                    )
+                    .await?;
+                let actual = Graphics::image(&jvm, &mut graphics).await?;
+                let actual = Image::image(&jvm, &actual).await?;
+                let expected_pixels = Image::image(&jvm, &expected).await?;
+                for y in 0..height {
+                    for x in 0..80 {
+                        let actual = actual.get_pixel(x, y);
+                        let expected = expected_pixels.get_pixel(x, y);
+                        assert_eq!(
+                            (actual.r, actual.g, actual.b),
+                            (expected.r, expected.g, expected.b),
+                            "layout={layout}, x={x}, y={y}"
+                        );
+                    }
+                }
+                assert_eq!(jvm.get_field::<i32>(&following, "lastPaintY", "I").await?, height);
+            }
+
+            let _: () = jvm
+                .invoke_virtual(&following, "javax/microedition/lcdui/Item", "setPreferredSize", "(II)V", (40, -1))
+                .await?;
+            for (layout, x, width) in [(0, 40, 40), (3, 20, 40), (0x800, 0, 80), (1 | 0x400, 0, 40)] {
+                let _: () = jvm
+                    .invoke_virtual(&following, "javax/microedition/lcdui/Item", "setLayout", "(I)V", (layout,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                    .await?;
+                let actual = Graphics::image(&jvm, &mut graphics).await?;
+                let actual = Image::image(&jvm, &actual).await?;
+                for column in 0..80 {
+                    let color = actual.get_pixel(column, height);
+                    let expected = if (x..x + width).contains(&column) {
+                        (0x22, 0x55, 0x22)
+                    } else {
+                        (0xff, 0xff, 0xff)
+                    };
+                    assert_eq!((color.r, color.g, color.b), expected, "layout={layout}, x={column}");
+                }
+            }
+            Ok(())
+        })
+    }
+
+    #[test]
     fn form_reveals_oversized_choice_groups_and_scrolls_the_final_element() -> Result<()> {
         run_jvm_test(test_protos(), |jvm| async move {
             for choice_type in [1, 4] {
@@ -1525,10 +1672,13 @@ mod test {
                     .await?;
                 let image = Graphics::image(&jvm, &mut graphics).await?;
                 let pixels = Image::image(&jvm, &image).await?;
+                let choice_width: i32 = jvm
+                    .invoke_virtual(&choice, "javax/microedition/lcdui/Item", "measureWidth", "(I)I", (320,))
+                    .await?;
                 assert_eq!(
                     (0..240)
                         .filter(|y| {
-                            let pixel = pixels.get_pixel(200, *y);
+                            let pixel = pixels.get_pixel(choice_width - 3, *y);
                             (pixel.r, pixel.g, pixel.b) == (0xdc, 0xec, 0xf7)
                         })
                         .count(),

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -1,13 +1,25 @@
-use alloc::vec;
+use alloc::{vec, vec::Vec};
 
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
-use jvm_class_proto::JavaMethodProto;
-use jvm_types::{ClassAccessFlags, MethodAccessFlags};
-use rustjava_runtime::classes::java::lang::String;
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::Item;
+use crate::classes::{
+    javax::microedition::{
+        lcdui::{Command, Display, Displayable, Graphics, Image, ImageItem, Item, ItemStateListener, StringItem},
+        midlet::MIDlet,
+    },
+    net::wie::{ItemStateEvent, KeyboardEventType, MIDPKeyCode},
+};
+
+struct ItemRect {
+    item: ClassInstanceRef<Item>,
+    y: i32,
+    height: i32,
+}
 
 // class javax.microedition.lcdui.Form
 pub struct Form;
@@ -20,10 +32,73 @@ impl Form {
             interfaces: vec![],
             methods: vec![
                 JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;[Ljavax/microedition/lcdui/Item;)V",
+                    Self::init_with_items,
+                    MethodAccessFlags::PUBLIC,
+                ),
                 JavaMethodProto::new("append", "(Ljavax/microedition/lcdui/Item;)I", Self::append, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("append", "(Ljava/lang/String;)I", Self::append_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "append",
+                    "(Ljavax/microedition/lcdui/Image;)I",
+                    Self::append_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("insert", "(ILjavax/microedition/lcdui/Item;)V", Self::insert, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("set", "(ILjavax/microedition/lcdui/Item;)V", Self::set, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("get", "(I)Ljavax/microedition/lcdui/Item;", Self::get, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("delete", "(I)V", Self::delete, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("deleteAll", "()V", Self::delete_all, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("size", "()I", Self::size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "setItemStateListener",
+                    "(Ljavax/microedition/lcdui/ItemStateListener;)V",
+                    Self::set_item_state_listener,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getWidth", "()I", Self::get_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getHeight", "()I", Self::get_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getCommandCount", "()I", Self::get_command_count, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    Self::get_command_at,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("dispatchCommandAt", "(I)V", Self::dispatch_command_at, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "itemInvalidated",
+                    "(Ljavax/microedition/lcdui/Item;Z)V",
+                    Self::item_invalidated,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "itemStateChanged",
+                    "(Ljavax/microedition/lcdui/Item;)V",
+                    Self::item_state_changed,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "handlePaintEvent",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    Self::handle_paint_event,
+                    MethodAccessFlags::empty(),
+                ),
             ],
-            fields: vec![],
+            fields: vec![
+                JavaFieldProto::new("items", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new(
+                    "itemStateListener",
+                    "Ljavax/microedition/lcdui/ItemStateListener;",
+                    FieldAccessFlags::PRIVATE,
+                ),
+                JavaFieldProto::new("focusIndex", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("scrollY", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("contentScrolling", "Z", FieldAccessFlags::PRIVATE),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }
@@ -31,20 +106,1804 @@ impl Form {
     async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, title: ClassInstanceRef<String>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Form::<init>({this:?}, {title:?})");
 
+        let items = ClassInstanceRef::<Array<ClassInstanceRef<Item>>>::new(None);
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Form",
+            "<init>",
+            "(Ljava/lang/String;[Ljavax/microedition/lcdui/Item;)V",
+            (title, items),
+        )
+        .await
+    }
+
+    async fn init_with_items(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        title: ClassInstanceRef<String>,
+        initial_items: ClassInstanceRef<Array<ClassInstanceRef<Item>>>,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Form::<init>({this:?}, {title:?}, {initial_items:?})");
+
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Screen", "<init>", "()V", ()).await?;
+        let items: ClassInstanceRef<Vector> = jvm.new_class("java/util/Vector", "()V", ()).await?.into();
+        jvm.put_field(&mut this, "items", "Ljava/util/Vector;", items.clone()).await?;
+        jvm.put_field(&mut this, "focusIndex", "I", -1).await?;
+        jvm.put_field(&mut this, "scrollY", "I", 0).await?;
+        jvm.put_field(&mut this, "contentScrolling", "Z", false).await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "setTitle",
+                "(Ljava/lang/String;)V",
+                (title,),
+            )
+            .await?;
+
+        if initial_items.is_null() {
+            return Ok(());
+        }
+
+        let item_count = jvm.array_length(&initial_items).await?;
+        let mut initial_items: Vec<ClassInstanceRef<Item>> = jvm.load_array(&initial_items, 0, item_count).await?;
+        for (index, item) in initial_items.iter().enumerate() {
+            if item.is_null() {
+                return Err(jvm.exception("java/lang/NullPointerException", "Form item is null").await);
+            }
+            let owner: ClassInstanceRef<Displayable> = jvm.get_field(item, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+            if !owner.is_null() || initial_items[..index].iter().any(|previous| previous.identity() == item.identity()) {
+                return Err(jvm.exception("java/lang/IllegalStateException", "Form item already has an owner").await);
+            }
+        }
+
+        for item in &mut initial_items {
+            jvm.put_field(item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&items, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (item.clone(),))
+                .await?;
+        }
+
+        Self::normalize_layout_state(jvm, context, &mut this, -1).await?;
+        Ok(())
+    }
+
+    async fn checked_item(jvm: &Jvm, this: &ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<Item>> {
+        let items: ClassInstanceRef<Vector> = jvm.get_field(this, "items", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
+        if index < 0 || index >= size {
+            return Err(jvm
+                .exception("java/lang/IndexOutOfBoundsException", "Form item index is out of bounds")
+                .await);
+        }
+        jvm.invoke_virtual(&items, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+            .await
+    }
+
+    async fn load_items(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<Vec<ClassInstanceRef<Item>>> {
+        let items: ClassInstanceRef<Vector> = jvm.get_field(this, "items", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
+        let mut result = Vec::with_capacity(size as usize);
+        for index in 0..size {
+            result.push(
+                jvm.invoke_virtual(&items, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                    .await?,
+            );
+        }
+        Ok(result)
+    }
+
+    async fn layout_items(jvm: &Jvm, items: &[ClassInstanceRef<Item>], width: i32) -> JvmResult<Vec<ItemRect>> {
+        let mut rows = Vec::with_capacity(items.len());
+        let mut y = 0i32;
+        for item in items {
+            let height: i32 = jvm
+                .invoke_virtual(item, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (width.max(0),))
+                .await?;
+            let height = height.max(1);
+            rows.push(ItemRect {
+                item: item.clone(),
+                y,
+                height,
+            });
+            y = y.saturating_add(height);
+        }
+        Ok(rows)
+    }
+
+    async fn update_scroll(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: &mut ClassInstanceRef<Self>,
+        rows: &[ItemRect],
+        width: i32,
+        viewport_height: i32,
+    ) -> JvmResult<()> {
+        let viewport_height = viewport_height.max(0);
+        let content_height = rows.last().map(|row| row.y.saturating_add(row.height)).unwrap_or(0);
+        let maximum_scroll = content_height.saturating_sub(viewport_height).max(0);
+        let mut scroll: i32 = jvm.get_field(this, "scrollY", "I").await?;
+        scroll = scroll.clamp(0, maximum_scroll);
+
+        let focus_index: i32 = jvm.get_field(this, "focusIndex", "I").await?;
+        let content_scrolling: bool = jvm.get_field(this, "contentScrolling", "Z").await?;
+        if !content_scrolling
+            && focus_index >= 0
+            && let Some(row) = rows.get(focus_index as usize)
+        {
+            let (top, bottom) = if row.height > viewport_height {
+                Item::focus_bounds(jvm, context, &row.item, width, row.height).await?
+            } else {
+                (0, row.height)
+            };
+            let top = row.y.saturating_add(top);
+            let bottom = row.y.saturating_add(bottom);
+            if bottom - top > viewport_height || top < scroll {
+                scroll = top;
+            } else if bottom > scroll.saturating_add(viewport_height) {
+                scroll = bottom.saturating_sub(viewport_height);
+            }
+            scroll = scroll.clamp(0, maximum_scroll);
+        }
+
+        jvm.put_field(this, "scrollY", "I", scroll).await
+    }
+
+    async fn normalize_layout_state(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: &mut ClassInstanceRef<Self>,
+        preferred_focus: i32,
+    ) -> JvmResult<()> {
+        jvm.put_field(this, "contentScrolling", "Z", false).await?;
+        let items = Self::load_items(jvm, this).await?;
+        if items.is_empty() {
+            jvm.put_field(this, "focusIndex", "I", -1).await?;
+            return jvm.put_field(this, "scrollY", "I", 0).await;
+        }
+
+        let mut focus_index = -1;
+        if preferred_focus < 0 {
+            for (index, item) in items.iter().enumerate() {
+                if jvm
+                    .invoke_virtual::<_, bool>(item, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ())
+                    .await?
+                {
+                    focus_index = index as i32;
+                    break;
+                }
+            }
+        } else {
+            let preferred_focus = preferred_focus.min(items.len() as i32 - 1) as usize;
+            for (index, item) in items.iter().enumerate().skip(preferred_focus) {
+                if jvm
+                    .invoke_virtual::<_, bool>(item, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ())
+                    .await?
+                {
+                    focus_index = index as i32;
+                    break;
+                }
+            }
+            if focus_index < 0 {
+                for index in (0..preferred_focus).rev() {
+                    if jvm
+                        .invoke_virtual::<_, bool>(&items[index], "javax/microedition/lcdui/Item", "isFocusable", "()Z", ())
+                        .await?
+                    {
+                        focus_index = index as i32;
+                        break;
+                    }
+                }
+            }
+        }
+
+        jvm.put_field(this, "focusIndex", "I", focus_index).await?;
+        let width: i32 = jvm
+            .invoke_special(this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await?;
+        let height: i32 = jvm
+            .invoke_special(this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await?;
+        let rows = Self::layout_items(jvm, &items, width).await?;
+        Self::update_scroll(jvm, context, this, &rows, width, height).await
+    }
+
+    async fn focused_item(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Item>> {
+        let focus_index: i32 = jvm.get_field(this, "focusIndex", "I").await?;
+        if focus_index < 0 {
+            return Ok(ClassInstanceRef::new(None));
+        }
+        Self::checked_item(jvm, this, focus_index).await
+    }
+
+    async fn append(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, item: ClassInstanceRef<Item>) -> JvmResult<i32> {
+        tracing::debug!("javax.microedition.lcdui.Form::append({this:?}, {item:?})");
+
+        let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
+        let index: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Form",
+                "insert",
+                "(ILjavax/microedition/lcdui/Item;)V",
+                (index, item),
+            )
+            .await?;
+        Ok(index)
+    }
+
+    async fn append_string(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<i32> {
+        tracing::debug!("javax.microedition.lcdui.Form::append({this:?}, {text:?})");
+
+        if text.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Form string is null").await);
+        }
+        let label = ClassInstanceRef::<String>::new(None);
+        let item: ClassInstanceRef<StringItem> = jvm
+            .new_class(
+                "javax/microedition/lcdui/StringItem",
+                "(Ljava/lang/String;Ljava/lang/String;)V",
+                (label, text),
+            )
+            .await?
+            .into();
+        jvm.invoke_virtual(
+            &this,
+            "javax/microedition/lcdui/Form",
+            "append",
+            "(Ljavax/microedition/lcdui/Item;)I",
+            (item,),
+        )
+        .await
+    }
+
+    async fn append_image(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, image: ClassInstanceRef<Image>) -> JvmResult<i32> {
+        tracing::debug!("javax.microedition.lcdui.Form::append({this:?}, {image:?})");
+
+        if image.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Form image is null").await);
+        }
+        let label = ClassInstanceRef::<String>::new(None);
+        let alt_text = ClassInstanceRef::<String>::new(None);
+        let item: ClassInstanceRef<ImageItem> = jvm
+            .new_class(
+                "javax/microedition/lcdui/ImageItem",
+                "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
+                (label, image, 0, alt_text),
+            )
+            .await?
+            .into();
+        jvm.invoke_virtual(
+            &this,
+            "javax/microedition/lcdui/Form",
+            "append",
+            "(Ljavax/microedition/lcdui/Item;)I",
+            (item,),
+        )
+        .await
+    }
+
+    async fn insert(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        index: i32,
+        mut item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
+        if index < 0 || index > size {
+            return Err(jvm
+                .exception("java/lang/IndexOutOfBoundsException", "Form insert index is out of bounds")
+                .await);
+        }
+        if item.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Form item is null").await);
+        }
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&item, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        if !owner.is_null() {
+            return Err(jvm.exception("java/lang/IllegalStateException", "Form item already has an owner").await);
+        }
+
+        jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(&items, "java/util/Vector", "insertElementAt", "(Ljava/lang/Object;I)V", (item, index))
+            .await?;
+        let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+        let preferred_focus = if focus_index >= index { focus_index + 1 } else { focus_index };
+        Self::normalize_layout_state(jvm, context, &mut this, preferred_focus).await?;
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn set(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        index: i32,
+        mut item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        let mut old_item = Self::checked_item(jvm, &this, index).await?;
+        if item.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Form item is null").await);
+        }
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&item, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        if !owner.is_null() {
+            return Err(jvm.exception("java/lang/IllegalStateException", "Form item already has an owner").await);
+        }
+
+        let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
+        jvm.put_field(
+            &mut old_item,
+            "owner",
+            "Ljavax/microedition/lcdui/Displayable;",
+            ClassInstanceRef::<Displayable>::new(None),
+        )
+        .await?;
+        jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(&items, "java/util/Vector", "setElementAt", "(Ljava/lang/Object;I)V", (item, index))
+            .await?;
+        let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+        Self::normalize_layout_state(jvm, context, &mut this, focus_index).await?;
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn get(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<ClassInstanceRef<Item>> {
+        Self::checked_item(jvm, &this, index).await
+    }
+
+    async fn delete(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
+        let mut item = Self::checked_item(jvm, &this, index).await?;
+        let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
+        let _: ClassInstanceRef<Item> = jvm
+            .invoke_virtual(&items, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (index,))
+            .await?;
+        jvm.put_field(
+            &mut item,
+            "owner",
+            "Ljavax/microedition/lcdui/Displayable;",
+            ClassInstanceRef::<Displayable>::new(None),
+        )
+        .await?;
+
+        let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
+        let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+        let preferred_focus = if size == 0 {
+            -1
+        } else if focus_index > index {
+            focus_index - 1
+        } else {
+            focus_index.min(size - 1)
+        };
+        Self::normalize_layout_state(jvm, context, &mut this, preferred_focus).await?;
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn delete_all(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
+        let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
+        if size == 0 {
+            return Ok(());
+        }
+        for index in 0..size {
+            let mut item: ClassInstanceRef<Item> = jvm
+                .invoke_virtual(&items, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                .await?;
+            jvm.put_field(
+                &mut item,
+                "owner",
+                "Ljavax/microedition/lcdui/Displayable;",
+                ClassInstanceRef::<Displayable>::new(None),
+            )
+            .await?;
+        }
+        let _: () = jvm.invoke_virtual(&items, "java/util/Vector", "removeAllElements", "()V", ()).await?;
+        jvm.put_field(&mut this, "focusIndex", "I", -1).await?;
+        jvm.put_field(&mut this, "scrollY", "I", 0).await?;
+        jvm.put_field(&mut this, "contentScrolling", "Z", false).await?;
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await
+    }
+
+    async fn set_item_state_listener(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        listener: ClassInstanceRef<ItemStateListener>,
+    ) -> JvmResult<()> {
+        jvm.put_field(&mut this, "itemStateListener", "Ljavax/microedition/lcdui/ItemStateListener;", listener)
+            .await
+    }
+
+    async fn get_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await
+    }
+
+    async fn get_height(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await
+    }
+
+    async fn get_command_count(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let displayable_count: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+            .await?;
+        let item = Self::focused_item(jvm, &this).await?;
+        if item.is_null() {
+            return Ok(displayable_count);
+        }
+
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&item, "commands", "Ljava/util/Vector;").await?;
+        let item_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        Ok(item_count + displayable_count)
+    }
+
+    async fn get_command_at(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        index: i32,
+    ) -> JvmResult<ClassInstanceRef<Command>> {
+        let item = Self::focused_item(jvm, &this).await?;
+        if !item.is_null() {
+            let commands: ClassInstanceRef<Vector> = jvm.get_field(&item, "commands", "Ljava/util/Vector;").await?;
+            let item_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+            if index < item_count {
+                return jvm
+                    .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                    .await;
+            }
+            return jvm
+                .invoke_special(
+                    &this,
+                    "javax/microedition/lcdui/Displayable",
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    (index - item_count,),
+                )
+                .await;
+        }
+
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Displayable",
+            "getCommandAt",
+            "(I)Ljavax/microedition/lcdui/Command;",
+            (index,),
+        )
+        .await
+    }
+
+    async fn dispatch_command_at(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
+        let item = Self::focused_item(jvm, &this).await?;
+        if !item.is_null() {
+            let commands: ClassInstanceRef<Vector> = jvm.get_field(&item, "commands", "Ljava/util/Vector;").await?;
+            let count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+            if index < count {
+                let command: ClassInstanceRef<Command> = jvm
+                    .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                    .await?;
+                return jvm
+                    .invoke_virtual(
+                        &item,
+                        "javax/microedition/lcdui/Item",
+                        "dispatchCommand",
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (command,),
+                    )
+                    .await;
+            }
+            return jvm
+                .invoke_special(
+                    &this,
+                    "javax/microedition/lcdui/Displayable",
+                    "dispatchCommandAt",
+                    "(I)V",
+                    (index - count,),
+                )
+                .await;
+        }
+
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Displayable", "dispatchCommandAt", "(I)V", (index,))
+            .await
+    }
+
+    async fn item_invalidated(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        _item: ClassInstanceRef<Item>,
+        _layout_changed: bool,
+    ) -> JvmResult<()> {
+        let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+        Self::normalize_layout_state(jvm, context, &mut this, focus_index).await?;
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+            .await
+    }
+
+    async fn item_state_changed(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        let mut display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        if display.is_null() {
+            let midlet: ClassInstanceRef<MIDlet> = jvm
+                .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                .await?;
+            display = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Display",
+                    "getDisplay",
+                    "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
+                    (midlet,),
+                )
+                .await?;
+        }
+
+        let event: ClassInstanceRef<ItemStateEvent> = jvm
+            .new_class(
+                "net/wie/ItemStateEvent",
+                "(Ljavax/microedition/lcdui/Form;Ljavax/microedition/lcdui/Item;)V",
+                (this, item),
+            )
+            .await?
+            .into();
+        jvm.invoke_virtual(
+            &display,
+            "javax/microedition/lcdui/Display",
+            "callSerially",
+            "(Ljava/lang/Runnable;)V",
+            (event,),
+        )
+        .await
+    }
+
+    async fn handle_key_event(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, event_type: i32, code: i32) -> JvmResult<()> {
+        let pressed = event_type == KeyboardEventType::KeyPressed as i32;
+        let repeated = event_type == KeyboardEventType::KeyRepeated as i32;
+        if !pressed && !repeated {
+            return Ok(());
+        }
+
+        let vertical = code == MIDPKeyCode::UP as i32 || code == MIDPKeyCode::DOWN as i32;
+        let mut scroll_context = (0, 0, 0);
+        if vertical {
+            let items = Self::load_items(jvm, &this).await?;
+            let width: i32 = jvm
+                .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+                .await?;
+            let viewport_height: i32 = jvm
+                .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+                .await?;
+            let viewport_height = viewport_height.max(0);
+            let rows = Self::layout_items(jvm, &items, width).await?;
+            let content_height = rows.last().map(|row| row.y.saturating_add(row.height)).unwrap_or(0);
+            let maximum_scroll = content_height.saturating_sub(viewport_height).max(0);
+            let mut scroll: i32 = jvm.get_field(&this, "scrollY", "I").await?;
+            scroll = scroll.clamp(0, maximum_scroll);
+            jvm.put_field(&mut this, "scrollY", "I", scroll).await?;
+
+            if jvm.get_field::<bool>(&this, "contentScrolling", "Z").await? {
+                let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+                let focus_visible = focus_index >= 0
+                    && rows
+                        .get(focus_index as usize)
+                        .is_some_and(|row| row.y < scroll.saturating_add(viewport_height) && row.y.saturating_add(row.height) > scroll);
+                if !focus_visible {
+                    let step = viewport_height.max(1);
+                    let new_scroll = if code == MIDPKeyCode::UP as i32 {
+                        scroll.saturating_sub(step).max(0)
+                    } else {
+                        scroll.saturating_add(step).min(maximum_scroll)
+                    };
+                    if new_scroll != scroll {
+                        jvm.put_field(&mut this, "scrollY", "I", new_scroll).await?;
+                        let _: () = jvm
+                            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                            .await?;
+                    }
+                    return Ok(());
+                }
+            }
+
+            let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+            if focus_index >= 0
+                && let Some(row) = rows.get(focus_index as usize)
+                && row.height > viewport_height
+            {
+                let (top, bottom) = Item::focus_bounds(jvm, context, &row.item, width, row.height).await?;
+                let top = row.y.saturating_add(top);
+                let bottom = row.y.saturating_add(bottom);
+                // Read an oversized active span before moving focus, including inside an open popup.
+                if bottom - top > viewport_height {
+                    let new_scroll = if code == MIDPKeyCode::UP as i32 && scroll > top {
+                        scroll.saturating_sub(viewport_height.max(1)).max(top)
+                    } else if code == MIDPKeyCode::DOWN as i32 && scroll.saturating_add(viewport_height) < bottom {
+                        scroll.saturating_add(viewport_height.max(1)).min(bottom - viewport_height)
+                    } else {
+                        scroll
+                    }
+                    .clamp(0, maximum_scroll);
+                    if new_scroll != scroll {
+                        jvm.put_field(&mut this, "scrollY", "I", new_scroll).await?;
+                        jvm.put_field(&mut this, "contentScrolling", "Z", true).await?;
+                        return jvm
+                            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                            .await;
+                    }
+                }
+            }
+            scroll_context = (viewport_height, scroll, maximum_scroll);
+        }
+
+        let item = Self::focused_item(jvm, &this).await?;
+        let directional = matches!(
+            code,
+            x if x == MIDPKeyCode::UP as i32
+                || x == MIDPKeyCode::DOWN as i32
+                || x == MIDPKeyCode::LEFT as i32
+                || x == MIDPKeyCode::RIGHT as i32
+        );
+        if !item.is_null() && (pressed || directional) {
+            let result: i32 = jvm
+                .invoke_virtual(&item, "javax/microedition/lcdui/Item", "handleItemKey", "(I)I", (code,))
+                .await?;
+            if result & Item::INPUT_CHANGED != 0 {
+                let _: () = jvm
+                    .invoke_virtual(
+                        &this,
+                        "javax/microedition/lcdui/Displayable",
+                        "itemStateChanged",
+                        "(Ljavax/microedition/lcdui/Item;)V",
+                        (item.clone(),),
+                    )
+                    .await?;
+            }
+            if result & Item::INPUT_HANDLED != 0 {
+                return Ok(());
+            }
+        }
+
+        if pressed && code == MIDPKeyCode::FIRE as i32 && !item.is_null() {
+            let default_command: ClassInstanceRef<Command> = jvm.get_field(&item, "defaultCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            if !default_command.is_null() {
+                return jvm
+                    .invoke_virtual(
+                        &item,
+                        "javax/microedition/lcdui/Item",
+                        "dispatchCommand",
+                        "(Ljavax/microedition/lcdui/Command;)V",
+                        (default_command,),
+                    )
+                    .await;
+            }
+            return Ok(());
+        }
+
+        if code != MIDPKeyCode::UP as i32 && code != MIDPKeyCode::DOWN as i32 {
+            return Ok(());
+        }
+
+        let items = Self::load_items(jvm, &this).await?;
+        let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+        let mut next_focus = None;
+        if code == MIDPKeyCode::UP as i32 {
+            for index in (0..focus_index.max(0) as usize).rev() {
+                if jvm
+                    .invoke_virtual::<_, bool>(&items[index], "javax/microedition/lcdui/Item", "isFocusable", "()Z", ())
+                    .await?
+                {
+                    next_focus = Some(index);
+                    break;
+                }
+            }
+        } else {
+            for (index, item) in items.iter().enumerate().skip(focus_index.saturating_add(1).max(0) as usize) {
+                if jvm
+                    .invoke_virtual::<_, bool>(item, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ())
+                    .await?
+                {
+                    next_focus = Some(index);
+                    break;
+                }
+            }
+        }
+
+        if let Some(index) = next_focus {
+            Self::normalize_layout_state(jvm, context, &mut this, index as i32).await?;
+            return jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "decorationChanged", "()V", ())
+                .await;
+        }
+
+        let (viewport_height, scroll, maximum_scroll) = scroll_context;
+        let step = viewport_height.max(1);
+        let new_scroll = if code == MIDPKeyCode::UP as i32 {
+            scroll.saturating_sub(step).max(0)
+        } else {
+            scroll.saturating_add(step).min(maximum_scroll)
+        };
+        if new_scroll != scroll {
+            jvm.put_field(&mut this, "scrollY", "I", new_scroll).await?;
+            jvm.put_field(&mut this, "contentScrolling", "Z", true).await?;
+            return jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "requestRepaint", "()V", ())
+                .await;
+        }
 
         Ok(())
     }
 
-    async fn append(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, item: ClassInstanceRef<Item>) -> JvmResult<i32> {
-        tracing::warn!("stub javax.microedition.lcdui.Form::append({this:?}, {item:?})");
+    async fn handle_paint_event(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+    ) -> JvmResult<()> {
+        let _: () = jvm
+            .invoke_special(
+                &this,
+                "javax/microedition/lcdui/Screen",
+                "handlePaintEvent",
+                "(Ljavax/microedition/lcdui/Graphics;)V",
+                (graphics.clone(),),
+            )
+            .await?;
+        let width: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await?;
+        let height: i32 = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await?;
+        let items = Self::load_items(jvm, &this).await?;
+        let rows = Self::layout_items(jvm, &items, width).await?;
+        Self::update_scroll(jvm, context, &mut this, &rows, width, height).await?;
 
-        Ok(0)
+        let scroll: i32 = jvm.get_field(&this, "scrollY", "I").await?;
+        let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
+        let viewport_bottom = scroll.saturating_add(height.max(0));
+        for (index, row) in rows.iter().enumerate() {
+            if row.y.saturating_add(row.height) <= scroll || row.y >= viewport_bottom {
+                continue;
+            }
+            let _: () = jvm
+                .invoke_virtual(
+                    &row.item,
+                    "javax/microedition/lcdui/Item",
+                    "paintItem",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    (graphics.clone(), 0, row.y - scroll, width, row.height, index as i32 == focus_index),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec, vec::Vec};
+
+    use jvm::{Array, ClassInstanceRef, JavaError, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
+    use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+    use rustjava_runtime::classes::java::lang::String;
+
+    use test_utils::run_jvm_test;
+    use wie_backend::{Event, KeyCode};
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_util::Result;
+
+    use crate::{
+        classes::{
+            javax::microedition::lcdui::{
+                ChoiceGroup, Command, CommandListener, Display, Displayable, Form, Gauge, Graphics, Image, Item, ItemCommandListener,
+                ItemStateListener,
+            },
+            javax::microedition::midlet::MIDlet,
+            net::wie::{EventQueue, KeyboardEventType, MIDPKeyCode},
+        },
+        get_protos,
+    };
+
+    struct RecordingFormItem;
+    struct RecordingFormItemStateListener;
+    struct RecordingFormItemCommandListener;
+    struct RecordingFormCommandListener;
+    struct RecordingFormMidlet;
+    struct BackendEventInjector;
+
+    impl RecordingFormItem {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingFormItem",
+                parent_class: Some("javax/microedition/lcdui/Item"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "(IIZ)V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
+                    JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
+                    JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
+                    JavaMethodProto::new(
+                        "preferredContentHeight",
+                        "(I)I",
+                        Self::preferred_content_height,
+                        MethodAccessFlags::empty(),
+                    ),
+                    JavaMethodProto::new(
+                        "paintContent",
+                        "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                        Self::paint_content,
+                        MethodAccessFlags::empty(),
+                    ),
+                    JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("contentHeight", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("paintColor", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("focusable", "Z", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("paintCount", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastPaintY", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastFocused", "Z", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            content_height: i32,
+            paint_color: i32,
+            focusable: bool,
+        ) -> JvmResult<()> {
+            let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
+            jvm.put_field(&mut this, "contentHeight", "I", content_height).await?;
+            jvm.put_field(&mut this, "paintColor", "I", paint_color).await?;
+            jvm.put_field(&mut this, "focusable", "Z", focusable).await?;
+            jvm.put_field(&mut this, "lastPaintY", "I", -1).await
+        }
+
+        async fn minimum_content_width(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+            Ok(1)
+        }
+
+        async fn minimum_content_height(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+            jvm.get_field(&this, "contentHeight", "I").await
+        }
+
+        async fn preferred_content_width(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+            Ok(32)
+        }
+
+        async fn preferred_content_height(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, _width: i32) -> JvmResult<i32> {
+            jvm.get_field(&this, "contentHeight", "I").await
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn paint_content(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            graphics: ClassInstanceRef<Graphics>,
+            x: i32,
+            y: i32,
+            width: i32,
+            height: i32,
+            focused: bool,
+        ) -> JvmResult<()> {
+            let paint_count: i32 = jvm.get_field(&this, "paintCount", "I").await?;
+            let color: i32 = jvm.get_field(&this, "paintColor", "I").await?;
+            jvm.put_field(&mut this, "paintCount", "I", paint_count + 1).await?;
+            jvm.put_field(&mut this, "lastPaintY", "I", y).await?;
+            jvm.put_field(&mut this, "lastFocused", "Z", focused).await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+                .await?;
+            jvm.invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "fillRect",
+                "(IIII)V",
+                (x, y, width, height),
+            )
+            .await
+        }
+
+        async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+            if jvm.get_field::<bool>(&this, "focusable", "Z").await? {
+                return Ok(true);
+            }
+            jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ()).await
+        }
     }
 
-    async fn append_string(_jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, str: ClassInstanceRef<String>) -> JvmResult<i32> {
-        tracing::warn!("stub javax.microedition.lcdui.Form::append({this:?}, {str:?})");
+    impl RecordingFormItemStateListener {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingFormItemStateListener",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec!["javax/microedition/lcdui/ItemStateListener"],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "itemStateChanged",
+                        "(Ljavax/microedition/lcdui/Item;)V",
+                        Self::item_state_changed,
+                        MethodAccessFlags::PUBLIC,
+                    ),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("count", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastItem", "Ljavax/microedition/lcdui/Item;", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
 
-        Ok(0)
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+        }
+
+        async fn item_state_changed(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            item: ClassInstanceRef<Item>,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastItem", "Ljavax/microedition/lcdui/Item;", item).await
+        }
+    }
+
+    impl RecordingFormItemCommandListener {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingFormItemCommandListener",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec!["javax/microedition/lcdui/ItemCommandListener"],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "commandAction",
+                        "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
+                        Self::command_action,
+                        MethodAccessFlags::PUBLIC,
+                    ),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("count", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastCommand", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastItem", "Ljavax/microedition/lcdui/Item;", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+        }
+
+        async fn command_action(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            command: ClassInstanceRef<Command>,
+            item: ClassInstanceRef<Item>,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastCommand", "Ljavax/microedition/lcdui/Command;", command)
+                .await?;
+            jvm.put_field(&mut this, "lastItem", "Ljavax/microedition/lcdui/Item;", item).await
+        }
+    }
+
+    impl RecordingFormCommandListener {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingFormCommandListener",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec!["javax/microedition/lcdui/CommandListener"],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new(
+                        "commandAction",
+                        "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                        Self::command_action,
+                        MethodAccessFlags::PUBLIC,
+                    ),
+                ],
+                fields: vec![
+                    JavaFieldProto::new("count", "I", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastCommand", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PUBLIC),
+                ],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await
+        }
+
+        async fn command_action(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            mut this: ClassInstanceRef<Self>,
+            command: ClassInstanceRef<Command>,
+            displayable: ClassInstanceRef<Displayable>,
+        ) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastCommand", "Ljavax/microedition/lcdui/Command;", command)
+                .await?;
+            jvm.put_field(&mut this, "lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", displayable)
+                .await
+        }
+    }
+
+    impl RecordingFormMidlet {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestRecordingFormMidlet",
+                parent_class: Some("javax/microedition/midlet/MIDlet"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("startApp", "()V", Self::start_app, MethodAccessFlags::PROTECTED),
+                ],
+                fields: vec![],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/midlet/MIDlet", "<init>", "()V", ()).await
+        }
+
+        async fn start_app(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            Ok(())
+        }
+    }
+
+    impl BackendEventInjector {
+        fn as_proto() -> WieJavaClassProto {
+            JavaClassProto {
+                name: "javax/microedition/lcdui/TestBackendEventInjector",
+                parent_class: Some("java/lang/Object"),
+                interfaces: vec![],
+                methods: vec![JavaMethodProto::new(
+                    "enqueueOrderingInputs",
+                    "()V",
+                    Self::enqueue_ordering_inputs,
+                    MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC,
+                )],
+                fields: vec![],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn enqueue_ordering_inputs(_jvm: &Jvm, context: &mut WieJvmContext) -> JvmResult<()> {
+            let mut queue = context.system().event_queue();
+            queue.push(Event::Keydown(KeyCode::LEFT));
+            queue.push(Event::Keydown(KeyCode::RIGHT));
+            queue.push(Event::Keydown(KeyCode::RIGHT));
+            queue.push(Event::Keydown(KeyCode::DOWN));
+            queue.push(Event::Keydown(KeyCode::RIGHT));
+            queue.push(Event::Keydown(KeyCode::LEFT_SOFT_KEY));
+            queue.push(Event::Redraw);
+            Ok(())
+        }
+    }
+
+    fn test_protos() -> Box<[Box<[WieJavaClassProto]>]> {
+        Box::new([
+            get_protos().into(),
+            [
+                RecordingFormItem::as_proto(),
+                RecordingFormItemStateListener::as_proto(),
+                RecordingFormItemCommandListener::as_proto(),
+                RecordingFormCommandListener::as_proto(),
+                RecordingFormMidlet::as_proto(),
+                BackendEventInjector::as_proto(),
+            ]
+            .into(),
+        ])
+    }
+
+    async fn recording_item(jvm: &Jvm, height: i32, color: i32, focusable: bool) -> JvmResult<ClassInstanceRef<RecordingFormItem>> {
+        Ok(jvm
+            .new_class("javax/microedition/lcdui/TestRecordingFormItem", "(IIZ)V", (height, color, focusable))
+            .await?
+            .into())
+    }
+
+    async fn form_with_items(jvm: &Jvm, items: Vec<ClassInstanceRef<Item>>) -> JvmResult<ClassInstanceRef<Form>> {
+        let mut array: ClassInstanceRef<Array<ClassInstanceRef<Item>>> =
+            jvm.instantiate_array("[Ljavax/microedition/lcdui/Item;", items.len()).await?.into();
+        jvm.store_array(&mut array, 0, items).await?;
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Form",
+                "(Ljava/lang/String;[Ljavax/microedition/lcdui/Item;)V",
+                (ClassInstanceRef::<String>::new(None), array),
+            )
+            .await?
+            .into())
+    }
+
+    async fn make_command(jvm: &Jvm, label: &str, command_type: i32, priority: i32) -> JvmResult<ClassInstanceRef<Command>> {
+        Ok(jvm
+            .new_class(
+                "javax/microedition/lcdui/Command",
+                "(Ljava/lang/String;II)V",
+                (JavaLangString::from_rust_string(jvm, label).await?, command_type, priority),
+            )
+            .await?
+            .into())
+    }
+
+    async fn show_form(jvm: &Jvm, form: &ClassInstanceRef<Form>, width: i32, height: i32) -> JvmResult<ClassInstanceRef<Display>> {
+        let mut display: ClassInstanceRef<Display> = jvm.new_class("javax/microedition/lcdui/Display", "()V", ()).await?.into();
+        jvm.put_field(&mut display, "width", "I", width).await?;
+        jvm.put_field(&mut display, "height", "I", height).await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &display,
+                "javax/microedition/lcdui/Display",
+                "setCurrent",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (form.clone(),),
+            )
+            .await?;
+        Ok(display)
+    }
+
+    async fn send_key(jvm: &Jvm, display: &ClassInstanceRef<Display>, event_type: KeyboardEventType, key: MIDPKeyCode) -> JvmResult<()> {
+        jvm.invoke_virtual(
+            display,
+            "javax/microedition/lcdui/Display",
+            "handleKeyEvent",
+            "(II)V",
+            (event_type as i32, key as i32),
+        )
+        .await
+    }
+
+    #[test]
+    fn form_rejects_duplicate_ownership_and_releases_removed_items() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let first = recording_item(&jvm, 8, 0x114411, false).await?;
+            let second = recording_item(&jvm, 8, 0x225522, false).await?;
+            let duplicate = form_with_items(&jvm, vec![JavaValue::from(first.clone()).into(), JavaValue::from(first.clone()).into()]).await;
+            let Err(JavaError::JavaException(exception)) = duplicate else {
+                panic!("Form accepted a duplicate Item");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/IllegalStateException"));
+
+            // A failed constructor must not acquire ownership of its earlier Items.
+            let source = form_with_items(&jvm, vec![JavaValue::from(first.clone()).into()]).await?;
+            let destination = form_with_items(&jvm, vec![]).await?;
+            let invalid: JvmResult<i32> = jvm
+                .invoke_virtual(
+                    &destination,
+                    "javax/microedition/lcdui/Form",
+                    "append",
+                    "(Ljavax/microedition/lcdui/Item;)I",
+                    (first.clone(),),
+                )
+                .await;
+            let Err(JavaError::JavaException(exception)) = invalid else {
+                panic!("Form accepted another Form's Item");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/IllegalStateException"));
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&destination, "javax/microedition/lcdui/Form", "size", "()I", ())
+                    .await?,
+                0
+            );
+            let retained: ClassInstanceRef<Item> = jvm
+                .invoke_virtual(
+                    &source,
+                    "javax/microedition/lcdui/Form",
+                    "get",
+                    "(I)Ljavax/microedition/lcdui/Item;",
+                    (0,),
+                )
+                .await?;
+            assert_eq!(retained.identity(), first.identity());
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &source,
+                    "javax/microedition/lcdui/Form",
+                    "set",
+                    "(ILjavax/microedition/lcdui/Item;)V",
+                    (0, second.clone()),
+                )
+                .await?;
+            let index: i32 = jvm
+                .invoke_virtual(
+                    &destination,
+                    "javax/microedition/lcdui/Form",
+                    "append",
+                    "(Ljavax/microedition/lcdui/Item;)I",
+                    (first.clone(),),
+                )
+                .await?;
+            assert_eq!(index, 0);
+            let _: () = jvm
+                .invoke_virtual(&source, "javax/microedition/lcdui/Form", "delete", "(I)V", (0,))
+                .await?;
+            let index: i32 = jvm
+                .invoke_virtual(
+                    &destination,
+                    "javax/microedition/lcdui/Form",
+                    "append",
+                    "(Ljavax/microedition/lcdui/Item;)I",
+                    (second.clone(),),
+                )
+                .await?;
+            assert_eq!(index, 1);
+            let _: () = jvm
+                .invoke_virtual(&destination, "javax/microedition/lcdui/Form", "deleteAll", "()V", ())
+                .await?;
+            let reused = form_with_items(&jvm, vec![JavaValue::from(first).into(), JavaValue::from(second).into()]).await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&reused, "javax/microedition/lcdui/Form", "size", "()I", ())
+                    .await?,
+                2
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn form_normalizes_focus_across_construction_and_item_mutations() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let first = recording_item(&jvm, 8, 0x110000, false).await?;
+            let focused = recording_item(&jvm, 8, 0x220000, true).await?;
+            let candidate = recording_item(&jvm, 8, 0x330000, false).await?;
+            let later = recording_item(&jvm, 8, 0x440000, true).await?;
+            let form = form_with_items(
+                &jvm,
+                vec![
+                    JavaValue::from(first).into(),
+                    JavaValue::from(focused.clone()).into(),
+                    JavaValue::from(candidate.clone()).into(),
+                    JavaValue::from(later.clone()).into(),
+                ],
+            )
+            .await?;
+            assert_eq!(jvm.get_field::<i32>(&form, "focusIndex", "I").await?, 1);
+
+            let inserted = recording_item(&jvm, 8, 0x550000, true).await?;
+            let inserted_item: ClassInstanceRef<Item> = JavaValue::from(inserted.clone()).into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Form",
+                    "insert",
+                    "(ILjavax/microedition/lcdui/Item;)V",
+                    (0, inserted_item),
+                )
+                .await?;
+            assert_eq!(
+                jvm.get_field::<i32>(&form, "focusIndex", "I").await?,
+                2,
+                "insertion must preserve the focused Item"
+            );
+
+            let _: () = jvm.invoke_virtual(&form, "javax/microedition/lcdui/Form", "delete", "(I)V", (2,)).await?;
+            assert_eq!(
+                jvm.get_field::<i32>(&form, "focusIndex", "I").await?,
+                3,
+                "deleting focus must select the next focusable Item"
+            );
+
+            let replacement = recording_item(&jvm, 8, 0x660000, false).await?;
+            let replacement_item: ClassInstanceRef<Item> = JavaValue::from(replacement).into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Form",
+                    "set",
+                    "(ILjavax/microedition/lcdui/Item;)V",
+                    (3, replacement_item),
+                )
+                .await?;
+            assert_eq!(
+                jvm.get_field::<i32>(&form, "focusIndex", "I").await?,
+                0,
+                "focus must fall back to the preceding focusable Item"
+            );
+
+            let _: () = jvm.invoke_virtual(&form, "javax/microedition/lcdui/Form", "delete", "(I)V", (0,)).await?;
+            assert_eq!(jvm.get_field::<i32>(&form, "focusIndex", "I").await?, -1);
+
+            let command = make_command(&jvm, "Focus", 8, 0).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &candidate,
+                    "javax/microedition/lcdui/Item",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command.clone(),),
+                )
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&form, "focusIndex", "I").await?, 1);
+
+            let display = show_form(&jvm, &form, 60, 40).await?;
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
+            assert!(jvm.get_field::<bool>(&candidate, "lastFocused", "Z").await?);
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &candidate,
+                    "javax/microedition/lcdui/Item",
+                    "removeCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command,),
+                )
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&form, "focusIndex", "I").await?, -1);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn form_reveals_oversized_choice_groups_and_scrolls_the_final_element() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            for choice_type in [1, 4] {
+                let choice: ClassInstanceRef<ChoiceGroup> = jvm
+                    .new_class(
+                        "javax/microedition/lcdui/ChoiceGroup",
+                        "(Ljava/lang/String;I)V",
+                        (JavaLangString::from_rust_string(&jvm, "Options\nChoices").await?, choice_type),
+                    )
+                    .await?
+                    .into();
+                for index in 0..30 {
+                    let text = if index == 10 { "Choice\ncontinued" } else { "Choice" };
+                    let _: i32 = jvm
+                        .invoke_virtual(
+                            &choice,
+                            "javax/microedition/lcdui/ChoiceGroup",
+                            "append",
+                            "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;)I",
+                            (JavaLangString::from_rust_string(&jvm, text).await?, ClassInstanceRef::<Image>::new(None)),
+                        )
+                        .await?;
+                }
+                let form = form_with_items(&jvm, vec![JavaValue::from(choice.clone()).into()]).await?;
+                let display = show_form(&jvm, &form, 320, 240).await?;
+                if choice_type == 4 {
+                    send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::FIRE).await?;
+                }
+                for index in 1..30 {
+                    send_key(&jvm, &display, KeyboardEventType::KeyRepeated, MIDPKeyCode::DOWN).await?;
+                    assert_eq!(jvm.get_field::<i32>(&choice, "highlightedIndex", "I").await?, index);
+                }
+                let scroll: i32 = jvm.get_field(&form, "scrollY", "I").await?;
+                assert!(scroll > 0, "the final choice must be revealed even without a following Item");
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                    .await?;
+                assert_eq!(
+                    jvm.get_field::<i32>(&form, "scrollY", "I").await?,
+                    scroll,
+                    "paint must preserve the reveal"
+                );
+                let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+                let image = Graphics::image(&jvm, &mut graphics).await?;
+                let pixels = Image::image(&jvm, &image).await?;
+                assert_eq!(
+                    (0..240)
+                        .filter(|y| {
+                            let pixel = pixels.get_pixel(200, *y);
+                            (pixel.r, pixel.g, pixel.b) == (0xdc, 0xec, 0xf7)
+                        })
+                        .count(),
+                    if choice_type == 1 { 13 } else { 14 },
+                    "the active element must be fully visible (the inline Item border covers its last pixel)"
+                );
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &choice,
+                        "javax/microedition/lcdui/ChoiceGroup",
+                        "set",
+                        "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
+                        (
+                            29,
+                            JavaLangString::from_rust_string(&jvm, &"line\n".repeat(30)).await?,
+                            ClassInstanceRef::<Image>::new(None),
+                        ),
+                    )
+                    .await?;
+                let top: i32 = jvm.get_field(&form, "scrollY", "I").await?;
+                send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::DOWN).await?;
+                assert_eq!(jvm.get_field::<i32>(&choice, "highlightedIndex", "I").await?, 29);
+                assert!(
+                    jvm.get_field::<i32>(&form, "scrollY", "I").await? > top,
+                    "the tall final element's tail must be reachable"
+                );
+                let tail: i32 = jvm.get_field(&form, "scrollY", "I").await?;
+                send_key(&jvm, &display, KeyboardEventType::KeyRepeated, MIDPKeyCode::DOWN).await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                    .await?;
+                assert!(
+                    jvm.get_field::<i32>(&form, "scrollY", "I").await? >= tail,
+                    "boundary input and paint must not reset scrolling"
+                );
+                send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::UP).await?;
+                assert_eq!(jvm.get_field::<i32>(&choice, "highlightedIndex", "I").await?, 29);
+                for _ in 0..30 {
+                    send_key(&jvm, &display, KeyboardEventType::KeyRepeated, MIDPKeyCode::UP).await?;
+                }
+                assert_eq!(jvm.get_field::<i32>(&choice, "highlightedIndex", "I").await?, 0);
+                let _: () = jvm
+                    .invoke_virtual(&choice, "javax/microedition/lcdui/ChoiceGroup", "deleteAll", "()V", ())
+                    .await?;
+                assert_eq!(
+                    jvm.get_field::<i32>(&form, "scrollY", "I").await?,
+                    0,
+                    "content shrink must clamp scrolling"
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn form_scrolls_content_without_focusable_items() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let first = recording_item(&jvm, 9, 0x114411, false).await?;
+            let tall = recording_item(&jvm, 25, 0x225522, false).await?;
+            let last = recording_item(&jvm, 8, 0x336633, false).await?;
+            let form = form_with_items(
+                &jvm,
+                vec![JavaValue::from(first).into(), JavaValue::from(tall).into(), JavaValue::from(last).into()],
+            )
+            .await?;
+            let display = show_form(&jvm, &form, 40, 10).await?;
+            assert_eq!(jvm.get_field::<i32>(&form, "focusIndex", "I").await?, -1);
+
+            for _ in 0..8 {
+                send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::DOWN).await?;
+            }
+            assert_eq!(jvm.get_field::<i32>(&form, "scrollY", "I").await?, 32);
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                .await?;
+            assert_eq!(
+                jvm.get_field::<i32>(&form, "scrollY", "I").await?,
+                32,
+                "paint must preserve content scrolling when no Item can take focus"
+            );
+            for _ in 0..8 {
+                send_key(&jvm, &display, KeyboardEventType::KeyRepeated, MIDPKeyCode::UP).await?;
+            }
+            assert_eq!(jvm.get_field::<i32>(&form, "scrollY", "I").await?, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn focused_item_default_and_menu_commands_dispatch_to_the_item_listener() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let item = recording_item(&jvm, 10, 0x225522, true).await?;
+            let item_listener: ClassInstanceRef<RecordingFormItemCommandListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingFormItemCommandListener", "()V", ())
+                .await?
+                .into();
+            let item_listener_ref: ClassInstanceRef<ItemCommandListener> = JavaValue::from(item_listener.clone()).into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/Item",
+                    "setItemCommandListener",
+                    "(Ljavax/microedition/lcdui/ItemCommandListener;)V",
+                    (item_listener_ref,),
+                )
+                .await?;
+            let menu_command = make_command(&jvm, "Item menu", 8, 0).await?;
+            let default_command = make_command(&jvm, "Item default", 8, 1).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/Item",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (menu_command.clone(),),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/Item",
+                    "setDefaultCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (default_command.clone(),),
+                )
+                .await?;
+
+            let form = form_with_items(&jvm, vec![JavaValue::from(item.clone()).into()]).await?;
+            let display_listener: ClassInstanceRef<RecordingFormCommandListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingFormCommandListener", "()V", ())
+                .await?
+                .into();
+            let display_listener_ref: ClassInstanceRef<CommandListener> = JavaValue::from(display_listener.clone()).into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Displayable",
+                    "setCommandListener",
+                    "(Ljavax/microedition/lcdui/CommandListener;)V",
+                    (display_listener_ref,),
+                )
+                .await?;
+            let screen_command = make_command(&jvm, "Screen", 1, 2).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Displayable",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (screen_command.clone(),),
+                )
+                .await?;
+
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&form, "javax/microedition/lcdui/Displayable", "getCommandCount", "()I", ())
+                    .await?,
+                3
+            );
+
+            let display = show_form(&jvm, &form, 120, 80).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::FIRE).await?;
+            assert_eq!(jvm.get_field::<i32>(&item_listener, "count", "I").await?, 1);
+            let dispatched: ClassInstanceRef<Command> = jvm.get_field(&item_listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            assert_eq!(dispatched.identity(), default_command.identity());
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::LEFT_SOFT_KEY).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::FIRE).await?;
+            assert_eq!(jvm.get_field::<i32>(&item_listener, "count", "I").await?, 2);
+            let dispatched: ClassInstanceRef<Command> = jvm.get_field(&item_listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            assert_eq!(dispatched.identity(), menu_command.identity());
+            assert_eq!(jvm.get_field::<i32>(&display_listener, "count", "I").await?, 0);
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::LEFT_SOFT_KEY).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::DOWN).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::DOWN).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::FIRE).await?;
+            assert_eq!(jvm.get_field::<i32>(&display_listener, "count", "I").await?, 1);
+            let dispatched: ClassInstanceRef<Command> = jvm
+                .get_field(&display_listener, "lastCommand", "Ljavax/microedition/lcdui/Command;")
+                .await?;
+            assert_eq!(dispatched.identity(), screen_command.identity());
+            assert_eq!(jvm.get_field::<i32>(&item_listener, "count", "I").await?, 2);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn duplicate_effective_command_occurrences_dispatch_to_the_selected_owner() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let item = recording_item(&jvm, 10, 0x225522, true).await?;
+            let item_listener: ClassInstanceRef<RecordingFormItemCommandListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingFormItemCommandListener", "()V", ())
+                .await?
+                .into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/Item",
+                    "setItemCommandListener",
+                    "(Ljavax/microedition/lcdui/ItemCommandListener;)V",
+                    (ClassInstanceRef::<ItemCommandListener>::from(JavaValue::from(item_listener.clone())),),
+                )
+                .await?;
+
+            let shared = make_command(&jvm, "Shared", 2, 0).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/Item",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (shared.clone(),),
+                )
+                .await?;
+            let form = form_with_items(&jvm, vec![JavaValue::from(item.clone()).into()]).await?;
+            let form_listener: ClassInstanceRef<RecordingFormCommandListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingFormCommandListener", "()V", ())
+                .await?
+                .into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Displayable",
+                    "setCommandListener",
+                    "(Ljavax/microedition/lcdui/CommandListener;)V",
+                    (ClassInstanceRef::<CommandListener>::from(JavaValue::from(form_listener.clone())),),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Displayable",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (shared.clone(),),
+                )
+                .await?;
+
+            let display = show_form(&jvm, &form, 120, 80).await?;
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::RIGHT_SOFT_KEY).await?;
+            assert_eq!(jvm.get_field::<i32>(&item_listener, "count", "I").await?, 1);
+            assert_eq!(jvm.get_field::<i32>(&form_listener, "count", "I").await?, 0);
+
+            send_key(&jvm, &display, KeyboardEventType::KeyPressed, MIDPKeyCode::LEFT_SOFT_KEY).await?;
+            assert_eq!(jvm.get_field::<i32>(&item_listener, "count", "I").await?, 1);
+            assert_eq!(jvm.get_field::<i32>(&form_listener, "count", "I").await?, 1);
+            let item_command: ClassInstanceRef<Command> = jvm.get_field(&item_listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            let form_command: ClassInstanceRef<Command> = jvm.get_field(&form_listener, "lastCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            assert_eq!(item_command.identity(), shared.identity());
+            assert_eq!(form_command.identity(), shared.identity());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn serial_item_callbacks_run_before_the_next_backend_input_and_command() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let midlet: ClassInstanceRef<RecordingFormMidlet> =
+                jvm.new_class("javax/microedition/lcdui/TestRecordingFormMidlet", "()V", ()).await?.into();
+            let midlet: ClassInstanceRef<MIDlet> = JavaValue::from(midlet).into();
+            let display = MIDlet::display(&jvm, &midlet).await?;
+
+            let first: ClassInstanceRef<Gauge> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/Gauge",
+                    "(Ljava/lang/String;ZII)V",
+                    (ClassInstanceRef::<String>::new(None), true, 1, 0),
+                )
+                .await?
+                .into();
+            let second: ClassInstanceRef<Gauge> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/Gauge",
+                    "(Ljava/lang/String;ZII)V",
+                    (ClassInstanceRef::<String>::new(None), true, 1, 0),
+                )
+                .await?
+                .into();
+            let form = form_with_items(&jvm, vec![JavaValue::from(first.clone()).into(), JavaValue::from(second.clone()).into()]).await?;
+            let state_listener: ClassInstanceRef<RecordingFormItemStateListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingFormItemStateListener", "()V", ())
+                .await?
+                .into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Form",
+                    "setItemStateListener",
+                    "(Ljavax/microedition/lcdui/ItemStateListener;)V",
+                    (ClassInstanceRef::<ItemStateListener>::from(JavaValue::from(state_listener.clone())),),
+                )
+                .await?;
+            let command_listener: ClassInstanceRef<RecordingFormCommandListener> = jvm
+                .new_class("javax/microedition/lcdui/TestRecordingFormCommandListener", "()V", ())
+                .await?
+                .into();
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Displayable",
+                    "setCommandListener",
+                    "(Ljavax/microedition/lcdui/CommandListener;)V",
+                    (ClassInstanceRef::<CommandListener>::from(JavaValue::from(command_listener.clone())),),
+                )
+                .await?;
+            let command = make_command(&jvm, "Apply", 1, 0).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &form,
+                    "javax/microedition/lcdui/Displayable",
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command,),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "setCurrent",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    (form.clone(),),
+                )
+                .await?;
+
+            let _: () = jvm
+                .invoke_virtual(&first, "javax/microedition/lcdui/Gauge", "setValue", "(I)V", (0,))
+                .await?;
+            let event_queue: ClassInstanceRef<EventQueue> = jvm
+                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                .await?;
+            let event: ClassInstanceRef<Array<i32>> = jvm.instantiate_array("I", 4).await?.into();
+            let _: () = jvm
+                .invoke_static("javax/microedition/lcdui/TestBackendEventInjector", "enqueueOrderingInputs", "()V", ())
+                .await?;
+
+            for (key, delivered_count) in [
+                (MIDPKeyCode::LEFT, 0),
+                (MIDPKeyCode::RIGHT, 0),
+                (MIDPKeyCode::RIGHT, 1),
+                (MIDPKeyCode::DOWN, 1),
+                (MIDPKeyCode::RIGHT, 1),
+                (MIDPKeyCode::LEFT_SOFT_KEY, 2),
+            ] {
+                let _: () = jvm
+                    .invoke_virtual(&event_queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                    .await?;
+                assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?[2], key as i32);
+                assert_eq!(jvm.get_field::<i32>(&state_listener, "count", "I").await?, delivered_count);
+                assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 0);
+                if delivered_count > 0 {
+                    let delivered: ClassInstanceRef<Item> = jvm.get_field(&state_listener, "lastItem", "Ljavax/microedition/lcdui/Item;").await?;
+                    assert_eq!(
+                        delivered.identity(),
+                        if delivered_count == 1 { first.identity() } else { second.identity() }
+                    );
+                }
+                let _: () = jvm
+                    .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event.clone(),))
+                    .await?;
+                assert_eq!(
+                    jvm.get_field::<i32>(&state_listener, "count", "I").await?,
+                    delivered_count,
+                    "ItemStateListener must not run inside the input handler"
+                );
+            }
+            let _: () = jvm
+                .invoke_virtual(&event_queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event,))
+                .await?;
+            assert_eq!(jvm.get_field::<i32>(&state_listener, "count", "I").await?, 2);
+            assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 1);
+            Ok(())
+        })
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -106,13 +106,12 @@ impl Form {
     async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, title: ClassInstanceRef<String>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Form::<init>({this:?}, {title:?})");
 
-        let items = ClassInstanceRef::<Array<ClassInstanceRef<Item>>>::new(None);
         jvm.invoke_special(
             &this,
             "javax/microedition/lcdui/Form",
             "<init>",
             "(Ljava/lang/String;[Ljavax/microedition/lcdui/Item;)V",
-            (title, items),
+            (title, None),
         )
         .await
     }
@@ -215,7 +214,7 @@ impl Form {
 
     async fn update_scroll(
         jvm: &Jvm,
-        context: &mut WieJvmContext,
+        _context: &mut WieJvmContext,
         this: &mut ClassInstanceRef<Self>,
         rows: &[ItemRect],
         width: i32,
@@ -234,7 +233,17 @@ impl Form {
             && let Some(row) = rows.get(focus_index as usize)
         {
             let (top, bottom) = if row.height > viewport_height {
-                Item::focus_bounds(jvm, context, &row.item, width, row.height).await?
+                let bounds: ClassInstanceRef<Array<i32>> = jvm
+                    .invoke_virtual(
+                        &row.item,
+                        "javax/microedition/lcdui/Item",
+                        "getFocusBounds",
+                        "(II)[I",
+                        (width, row.height),
+                    )
+                    .await?;
+                let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
+                (bounds[0], bounds[1])
             } else {
                 (0, row.height)
             };
@@ -313,7 +322,7 @@ impl Form {
     async fn focused_item(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Item>> {
         let focus_index: i32 = jvm.get_field(this, "focusIndex", "I").await?;
         if focus_index < 0 {
-            return Ok(ClassInstanceRef::new(None));
+            return Ok(None.into());
         }
         Self::checked_item(jvm, this, focus_index).await
     }
@@ -341,12 +350,11 @@ impl Form {
         if text.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "Form string is null").await);
         }
-        let label = ClassInstanceRef::<String>::new(None);
         let item: ClassInstanceRef<StringItem> = jvm
             .new_class(
                 "javax/microedition/lcdui/StringItem",
                 "(Ljava/lang/String;Ljava/lang/String;)V",
-                (label, text),
+                (None, text),
             )
             .await?
             .into();
@@ -366,13 +374,11 @@ impl Form {
         if image.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "Form image is null").await);
         }
-        let label = ClassInstanceRef::<String>::new(None);
-        let alt_text = ClassInstanceRef::<String>::new(None);
         let item: ClassInstanceRef<ImageItem> = jvm
             .new_class(
                 "javax/microedition/lcdui/ImageItem",
                 "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
-                (label, image, 0, alt_text),
+                (None, image, 0, None),
             )
             .await?
             .into();
@@ -437,13 +443,8 @@ impl Form {
         }
 
         let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
-        jvm.put_field(
-            &mut old_item,
-            "owner",
-            "Ljavax/microedition/lcdui/Displayable;",
-            ClassInstanceRef::<Displayable>::new(None),
-        )
-        .await?;
+        jvm.put_field(&mut old_item, "owner", "Ljavax/microedition/lcdui/Displayable;", None)
+            .await?;
         jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
             .await?;
         let _: () = jvm
@@ -465,13 +466,7 @@ impl Form {
         let _: ClassInstanceRef<Item> = jvm
             .invoke_virtual(&items, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (index,))
             .await?;
-        jvm.put_field(
-            &mut item,
-            "owner",
-            "Ljavax/microedition/lcdui/Displayable;",
-            ClassInstanceRef::<Displayable>::new(None),
-        )
-        .await?;
+        jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", None).await?;
 
         let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
         let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
@@ -497,13 +492,7 @@ impl Form {
             let mut item: ClassInstanceRef<Item> = jvm
                 .invoke_virtual(&items, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
                 .await?;
-            jvm.put_field(
-                &mut item,
-                "owner",
-                "Ljavax/microedition/lcdui/Displayable;",
-                ClassInstanceRef::<Displayable>::new(None),
-            )
-            .await?;
+            jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", None).await?;
         }
         let _: () = jvm.invoke_virtual(&items, "java/util/Vector", "removeAllElements", "()V", ()).await?;
         jvm.put_field(&mut this, "focusIndex", "I", -1).await?;
@@ -727,9 +716,18 @@ impl Form {
                 && let Some(row) = rows.get(focus_index as usize)
                 && row.height > viewport_height
             {
-                let (top, bottom) = Item::focus_bounds(jvm, context, &row.item, width, row.height).await?;
-                let top = row.y.saturating_add(top);
-                let bottom = row.y.saturating_add(bottom);
+                let bounds: ClassInstanceRef<Array<i32>> = jvm
+                    .invoke_virtual(
+                        &row.item,
+                        "javax/microedition/lcdui/Item",
+                        "getFocusBounds",
+                        "(II)[I",
+                        (width, row.height),
+                    )
+                    .await?;
+                let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
+                let top = row.y.saturating_add(bounds[0]);
+                let bottom = row.y.saturating_add(bounds[1]);
                 // Read an oversized active span before moving focus, including inside an open popup.
                 if bottom - top > viewport_height {
                     let new_scroll = if code == MIDPKeyCode::UP as i32 && scroll > top {
@@ -904,7 +902,6 @@ mod test {
     use jvm::{Array, ClassInstanceRef, JavaError, JavaValue, Jvm, Result as JvmResult, runtime::JavaLangString};
     use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
     use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-    use rustjava_runtime::classes::java::lang::String;
 
     use test_utils::run_jvm_test;
     use wie_backend::{Event, KeyCode};
@@ -1246,7 +1243,7 @@ mod test {
             .new_class(
                 "javax/microedition/lcdui/Form",
                 "(Ljava/lang/String;[Ljavax/microedition/lcdui/Item;)V",
-                (ClassInstanceRef::<String>::new(None), array),
+                (None, array),
             )
             .await?
             .into())
@@ -1494,7 +1491,7 @@ mod test {
                             "javax/microedition/lcdui/ChoiceGroup",
                             "append",
                             "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;)I",
-                            (JavaLangString::from_rust_string(&jvm, text).await?, ClassInstanceRef::<Image>::new(None)),
+                            (JavaLangString::from_rust_string(&jvm, text).await?, None),
                         )
                         .await?;
                 }
@@ -1517,7 +1514,15 @@ mod test {
                     scroll,
                     "paint must preserve the reveal"
                 );
-                let mut graphics = Display::screen_graphics(&jvm, &display).await?;
+                let mut graphics: ClassInstanceRef<Graphics> = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "getScreenGraphics",
+                        "()Ljavax/microedition/lcdui/Graphics;",
+                        (),
+                    )
+                    .await?;
                 let image = Graphics::image(&jvm, &mut graphics).await?;
                 let pixels = Image::image(&jvm, &image).await?;
                 assert_eq!(
@@ -1537,11 +1542,7 @@ mod test {
                         "javax/microedition/lcdui/ChoiceGroup",
                         "set",
                         "(ILjava/lang/String;Ljavax/microedition/lcdui/Image;)V",
-                        (
-                            29,
-                            JavaLangString::from_rust_string(&jvm, &"line\n".repeat(30)).await?,
-                            ClassInstanceRef::<Image>::new(None),
-                        ),
+                        (29, JavaLangString::from_rust_string(&jvm, &"line\n".repeat(30)).await?, None),
                     )
                     .await?;
                 let top: i32 = jvm.get_field(&form, "scrollY", "I").await?;
@@ -1792,19 +1793,11 @@ mod test {
             let display = MIDlet::display(&jvm, &midlet).await?;
 
             let first: ClassInstanceRef<Gauge> = jvm
-                .new_class(
-                    "javax/microedition/lcdui/Gauge",
-                    "(Ljava/lang/String;ZII)V",
-                    (ClassInstanceRef::<String>::new(None), true, 1, 0),
-                )
+                .new_class("javax/microedition/lcdui/Gauge", "(Ljava/lang/String;ZII)V", (None, true, 1, 0))
                 .await?
                 .into();
             let second: ClassInstanceRef<Gauge> = jvm
-                .new_class(
-                    "javax/microedition/lcdui/Gauge",
-                    "(Ljava/lang/String;ZII)V",
-                    (ClassInstanceRef::<String>::new(None), true, 1, 0),
-                )
+                .new_class("javax/microedition/lcdui/Gauge", "(Ljava/lang/String;ZII)V", (None, true, 1, 0))
                 .await?
                 .into();
             let form = form_with_items(&jvm, vec![JavaValue::from(first.clone()).into(), JavaValue::from(second.clone()).into()]).await?;

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -82,6 +82,12 @@ impl Form {
                     Self::item_state_changed,
                     MethodAccessFlags::empty(),
                 ),
+                JavaMethodProto::new(
+                    "dispatchItemStateChanged",
+                    "(Ljavax/microedition/lcdui/Item;)V",
+                    Self::dispatch_item_state_changed,
+                    MethodAccessFlags::empty(),
+                ),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "handlePaintEvent",
@@ -148,20 +154,34 @@ impl Form {
         }
 
         let item_count = jvm.array_length(&initial_items).await?;
-        let mut initial_items: Vec<ClassInstanceRef<Item>> = jvm.load_array(&initial_items, 0, item_count).await?;
+        let initial_items: Vec<ClassInstanceRef<Item>> = jvm.load_array(&initial_items, 0, item_count).await?;
         for (index, item) in initial_items.iter().enumerate() {
             if item.is_null() {
                 return Err(jvm.exception("java/lang/NullPointerException", "Form item is null").await);
             }
-            let owner: ClassInstanceRef<Displayable> = jvm.get_field(item, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+            let owner: ClassInstanceRef<Displayable> = jvm
+                .invoke_virtual(
+                    item,
+                    "javax/microedition/lcdui/Item",
+                    "getOwner",
+                    "()Ljavax/microedition/lcdui/Displayable;",
+                    (),
+                )
+                .await?;
             if !owner.is_null() || initial_items[..index].iter().any(|previous| previous.identity() == item.identity()) {
                 return Err(jvm.exception("java/lang/IllegalStateException", "Form item already has an owner").await);
             }
         }
 
-        for item in &mut initial_items {
-            jvm.put_field(item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
-                .await?;
+        for item in &initial_items {
+            jvm.invoke_virtual::<_, ()>(
+                item,
+                "javax/microedition/lcdui/Item",
+                "setOwner",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (this.clone(),),
+            )
+            .await?;
             let _: () = jvm
                 .invoke_virtual(&items, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (item.clone(),))
                 .await?;
@@ -414,7 +434,7 @@ impl Form {
         context: &mut WieJvmContext,
         mut this: ClassInstanceRef<Self>,
         index: i32,
-        mut item: ClassInstanceRef<Item>,
+        item: ClassInstanceRef<Item>,
     ) -> JvmResult<()> {
         let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
         let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
@@ -426,13 +446,27 @@ impl Form {
         if item.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "Form item is null").await);
         }
-        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&item, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        let owner: ClassInstanceRef<Displayable> = jvm
+            .invoke_virtual(
+                &item,
+                "javax/microedition/lcdui/Item",
+                "getOwner",
+                "()Ljavax/microedition/lcdui/Displayable;",
+                (),
+            )
+            .await?;
         if !owner.is_null() {
             return Err(jvm.exception("java/lang/IllegalStateException", "Form item already has an owner").await);
         }
 
-        jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
-            .await?;
+        jvm.invoke_virtual::<_, ()>(
+            &item,
+            "javax/microedition/lcdui/Item",
+            "setOwner",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (this.clone(),),
+        )
+        .await?;
         let _: () = jvm
             .invoke_virtual(&items, "java/util/Vector", "insertElementAt", "(Ljava/lang/Object;I)V", (item, index))
             .await?;
@@ -448,22 +482,42 @@ impl Form {
         context: &mut WieJvmContext,
         mut this: ClassInstanceRef<Self>,
         index: i32,
-        mut item: ClassInstanceRef<Item>,
+        item: ClassInstanceRef<Item>,
     ) -> JvmResult<()> {
-        let mut old_item = Self::checked_item(jvm, &this, index).await?;
+        let old_item = Self::checked_item(jvm, &this, index).await?;
         if item.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "Form item is null").await);
         }
-        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&item, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        let owner: ClassInstanceRef<Displayable> = jvm
+            .invoke_virtual(
+                &item,
+                "javax/microedition/lcdui/Item",
+                "getOwner",
+                "()Ljavax/microedition/lcdui/Displayable;",
+                (),
+            )
+            .await?;
         if !owner.is_null() {
             return Err(jvm.exception("java/lang/IllegalStateException", "Form item already has an owner").await);
         }
 
         let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
-        jvm.put_field(&mut old_item, "owner", "Ljavax/microedition/lcdui/Displayable;", None)
-            .await?;
-        jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", this.clone())
-            .await?;
+        jvm.invoke_virtual::<_, ()>(
+            &old_item,
+            "javax/microedition/lcdui/Item",
+            "setOwner",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (None,),
+        )
+        .await?;
+        jvm.invoke_virtual::<_, ()>(
+            &item,
+            "javax/microedition/lcdui/Item",
+            "setOwner",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (this.clone(),),
+        )
+        .await?;
         let _: () = jvm
             .invoke_virtual(&items, "java/util/Vector", "setElementAt", "(Ljava/lang/Object;I)V", (item, index))
             .await?;
@@ -478,12 +532,19 @@ impl Form {
     }
 
     async fn delete(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
-        let mut item = Self::checked_item(jvm, &this, index).await?;
+        let item = Self::checked_item(jvm, &this, index).await?;
         let items: ClassInstanceRef<Vector> = jvm.get_field(&this, "items", "Ljava/util/Vector;").await?;
         let _: ClassInstanceRef<Item> = jvm
             .invoke_virtual(&items, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (index,))
             .await?;
-        jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", None).await?;
+        jvm.invoke_virtual::<_, ()>(
+            &item,
+            "javax/microedition/lcdui/Item",
+            "setOwner",
+            "(Ljavax/microedition/lcdui/Displayable;)V",
+            (None,),
+        )
+        .await?;
 
         let size: i32 = jvm.invoke_virtual(&items, "java/util/Vector", "size", "()I", ()).await?;
         let focus_index: i32 = jvm.get_field(&this, "focusIndex", "I").await?;
@@ -506,10 +567,17 @@ impl Form {
             return Ok(());
         }
         for index in 0..size {
-            let mut item: ClassInstanceRef<Item> = jvm
+            let item: ClassInstanceRef<Item> = jvm
                 .invoke_virtual(&items, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
                 .await?;
-            jvm.put_field(&mut item, "owner", "Ljavax/microedition/lcdui/Displayable;", None).await?;
+            jvm.invoke_virtual::<_, ()>(
+                &item,
+                "javax/microedition/lcdui/Item",
+                "setOwner",
+                "(Ljavax/microedition/lcdui/Displayable;)V",
+                (None,),
+            )
+            .await?;
         }
         let _: () = jvm.invoke_virtual(&items, "java/util/Vector", "removeAllElements", "()V", ()).await?;
         jvm.put_field(&mut this, "focusIndex", "I", -1).await?;
@@ -553,8 +621,9 @@ impl Form {
             return Ok(displayable_count);
         }
 
-        let commands: ClassInstanceRef<Vector> = jvm.get_field(&item, "commands", "Ljava/util/Vector;").await?;
-        let item_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        let item_count: i32 = jvm
+            .invoke_virtual(&item, "javax/microedition/lcdui/Item", "getCommandCount", "()I", ())
+            .await?;
         Ok(item_count + displayable_count)
     }
 
@@ -566,11 +635,18 @@ impl Form {
     ) -> JvmResult<ClassInstanceRef<Command>> {
         let item = Self::focused_item(jvm, &this).await?;
         if !item.is_null() {
-            let commands: ClassInstanceRef<Vector> = jvm.get_field(&item, "commands", "Ljava/util/Vector;").await?;
-            let item_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+            let item_count: i32 = jvm
+                .invoke_virtual(&item, "javax/microedition/lcdui/Item", "getCommandCount", "()I", ())
+                .await?;
             if index < item_count {
                 return jvm
-                    .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                    .invoke_virtual(
+                        &item,
+                        "javax/microedition/lcdui/Item",
+                        "getCommandAt",
+                        "(I)Ljavax/microedition/lcdui/Command;",
+                        (index,),
+                    )
                     .await;
             }
             return jvm
@@ -597,11 +673,18 @@ impl Form {
     async fn dispatch_command_at(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, index: i32) -> JvmResult<()> {
         let item = Self::focused_item(jvm, &this).await?;
         if !item.is_null() {
-            let commands: ClassInstanceRef<Vector> = jvm.get_field(&item, "commands", "Ljava/util/Vector;").await?;
-            let count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+            let count: i32 = jvm
+                .invoke_virtual(&item, "javax/microedition/lcdui/Item", "getCommandCount", "()I", ())
+                .await?;
             if index < count {
                 let command: ClassInstanceRef<Command> = jvm
-                    .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                    .invoke_virtual(
+                        &item,
+                        "javax/microedition/lcdui/Item",
+                        "getCommandAt",
+                        "(I)Ljavax/microedition/lcdui/Command;",
+                        (index,),
+                    )
                     .await?;
                 return jvm
                     .invoke_virtual(
@@ -647,7 +730,15 @@ impl Form {
         this: ClassInstanceRef<Self>,
         item: ClassInstanceRef<Item>,
     ) -> JvmResult<()> {
-        let mut display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+        let mut display: ClassInstanceRef<Display> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Displayable",
+                "getDisplay",
+                "()Ljavax/microedition/lcdui/Display;",
+                (),
+            )
+            .await?;
         if display.is_null() {
             let midlet: ClassInstanceRef<MIDlet> = jvm
                 .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
@@ -676,6 +767,29 @@ impl Form {
             "callSerially",
             "(Ljava/lang/Runnable;)V",
             (event,),
+        )
+        .await
+    }
+
+    async fn dispatch_item_state_changed(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        let listener: ClassInstanceRef<ItemStateListener> = jvm
+            .get_field(&this, "itemStateListener", "Ljavax/microedition/lcdui/ItemStateListener;")
+            .await?;
+        if listener.is_null() {
+            return Ok(());
+        }
+
+        jvm.invoke_virtual(
+            &listener,
+            "javax/microedition/lcdui/ItemStateListener",
+            "itemStateChanged",
+            "(Ljavax/microedition/lcdui/Item;)V",
+            (item,),
         )
         .await
     }
@@ -796,19 +910,9 @@ impl Form {
         }
 
         if pressed && code == MIDPKeyCode::FIRE as i32 && !item.is_null() {
-            let default_command: ClassInstanceRef<Command> = jvm.get_field(&item, "defaultCommand", "Ljavax/microedition/lcdui/Command;").await?;
-            if !default_command.is_null() {
-                return jvm
-                    .invoke_virtual(
-                        &item,
-                        "javax/microedition/lcdui/Item",
-                        "dispatchCommand",
-                        "(Ljavax/microedition/lcdui/Command;)V",
-                        (default_command,),
-                    )
-                    .await;
-            }
-            return Ok(());
+            return jvm
+                .invoke_virtual(&item, "javax/microedition/lcdui/Item", "dispatchDefaultCommand", "()V", ())
+                .await;
         }
 
         if code != MIDPKeyCode::UP as i32 && code != MIDPKeyCode::DOWN as i32 {

--- a/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
@@ -76,21 +76,36 @@ impl Gauge {
                 JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
             ],
-            fields: [
-                "INDEFINITE",
-                "CONTINUOUS_IDLE",
-                "INCREMENTAL_IDLE",
-                "CONTINUOUS_RUNNING",
-                "INCREMENTAL_UPDATING",
-            ]
-            .into_iter()
-            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-            .chain([
+            fields: vec![
+                JavaFieldProto::new(
+                    "INDEFINITE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "CONTINUOUS_IDLE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "INCREMENTAL_IDLE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "CONTINUOUS_RUNNING",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "INCREMENTAL_UPDATING",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
                 JavaFieldProto::new("interactive", "Z", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("maxValue", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("value", "I", FieldAccessFlags::PRIVATE),
-            ])
-            .collect(),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }

--- a/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
@@ -95,15 +95,13 @@ impl Gauge {
     }
 
     async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
-        for (name, value) in [
-            ("INDEFINITE", -1),
-            ("CONTINUOUS_IDLE", 0),
-            ("INCREMENTAL_IDLE", 1),
-            ("CONTINUOUS_RUNNING", 2),
-            ("INCREMENTAL_UPDATING", 3),
-        ] {
-            jvm.put_static_field("javax/microedition/lcdui/Gauge", name, "I", value).await?;
-        }
+        jvm.put_static_field("javax/microedition/lcdui/Gauge", "INDEFINITE", "I", -1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Gauge", "CONTINUOUS_IDLE", "I", 0).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Gauge", "INCREMENTAL_IDLE", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Gauge", "CONTINUOUS_RUNNING", "I", 2)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/Gauge", "INCREMENTAL_UPDATING", "I", 3)
+            .await?;
 
         Ok(())
     }
@@ -167,7 +165,8 @@ impl Gauge {
         };
         jvm.put_field(&mut this, "maxValue", "I", max_value).await?;
         jvm.put_field(&mut this, "value", "I", value).await?;
-        Item::invalidate(jvm, &this, false).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+            .await
     }
 
     async fn get_value(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -184,7 +183,8 @@ impl Gauge {
 
         jvm.put_field(&mut this, "value", "I", if max_value == -1 { value } else { value.clamp(0, max_value) })
             .await?;
-        Item::invalidate(jvm, &this, false).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+            .await
     }
 
     async fn is_interactive(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
@@ -365,7 +365,9 @@ impl Gauge {
         }
 
         jvm.put_field(&mut this, "value", "I", new_value).await?;
-        Item::invalidate(jvm, &this, false).await?;
+        let _: () = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+            .await?;
         Ok(Item::INPUT_HANDLED | Item::INPUT_CHANGED)
     }
 }
@@ -375,7 +377,6 @@ mod test {
     use alloc::boxed::Box;
 
     use jvm::{ClassInstanceRef, JavaError, Result as JvmResult};
-    use rustjava_runtime::classes::java::lang::String;
     use test_utils::run_jvm_test;
     use wie_util::Result;
 
@@ -390,11 +391,7 @@ mod test {
     fn gauge_clamps_input_and_renders_value_and_focus() -> Result<()> {
         run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
             let gauge: ClassInstanceRef<Gauge> = jvm
-                .new_class(
-                    "javax/microedition/lcdui/Gauge",
-                    "(Ljava/lang/String;ZII)V",
-                    (ClassInstanceRef::<String>::new(None), true, 2, 1),
-                )
+                .new_class("javax/microedition/lcdui/Gauge", "(Ljava/lang/String;ZII)V", (None, true, 2, 1))
                 .await?
                 .into();
             for (key, result, value) in [
@@ -455,11 +452,7 @@ mod test {
             assert_ne!((fill.r, fill.g, fill.b), (track.r, track.g, track.b));
 
             let indicator: ClassInstanceRef<Gauge> = jvm
-                .new_class(
-                    "javax/microedition/lcdui/Gauge",
-                    "(Ljava/lang/String;ZII)V",
-                    (ClassInstanceRef::<String>::new(None), false, 10, 7),
-                )
+                .new_class("javax/microedition/lcdui/Gauge", "(Ljava/lang/String;ZII)V", (None, false, 10, 7))
                 .await?
                 .into();
             for (maximum, expected) in [(5, 5), (-1, 0), (10, 0)] {

--- a/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
@@ -1,0 +1,478 @@
+use alloc::vec;
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::{lang::String, util::Vector};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::{
+    javax::microedition::lcdui::{Command, Graphics, Item, ItemCommandListener},
+    net::wie::MIDPKeyCode,
+};
+
+const GAUGE_MINIMUM_WIDTH: i32 = 24;
+const GAUGE_PREFERRED_WIDTH: i32 = 96;
+const GAUGE_HEIGHT: i32 = 12;
+const TRACK_BACKGROUND: i32 = 0xd2dae1;
+const TRACK_BORDER: i32 = 0x596773;
+const TRACK_FILL: i32 = 0x2f7eb8;
+
+// class javax.microedition.lcdui.Gauge
+pub struct Gauge;
+
+impl Gauge {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/Gauge",
+            parent_class: Some("javax/microedition/lcdui/Item"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;ZII)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMaxValue", "()I", Self::get_max_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setMaxValue", "(I)V", Self::set_max_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getValue", "()I", Self::get_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setValue", "(I)V", Self::set_value, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("isInteractive", "()Z", Self::is_interactive, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setLabel", "(Ljava/lang/String;)V", Self::set_label, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setLayout", "(I)V", Self::set_layout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::add_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setItemCommandListener",
+                    "(Ljavax/microedition/lcdui/ItemCommandListener;)V",
+                    Self::set_item_command_listener,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("setPreferredSize", "(II)V", Self::set_preferred_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "setDefaultCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::set_default_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "preferredContentHeight",
+                    "(I)I",
+                    Self::preferred_content_height,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "paintContent",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    Self::paint_content,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
+            ],
+            fields: [
+                "INDEFINITE",
+                "CONTINUOUS_IDLE",
+                "INCREMENTAL_IDLE",
+                "CONTINUOUS_RUNNING",
+                "INCREMENTAL_UPDATING",
+            ]
+            .into_iter()
+            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
+            .chain([
+                JavaFieldProto::new("interactive", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("maxValue", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("value", "I", FieldAccessFlags::PRIVATE),
+            ])
+            .collect(),
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        for (name, value) in [
+            ("INDEFINITE", -1),
+            ("CONTINUOUS_IDLE", 0),
+            ("INCREMENTAL_IDLE", 1),
+            ("CONTINUOUS_RUNNING", 2),
+            ("INCREMENTAL_UPDATING", 3),
+        ] {
+            jvm.put_static_field("javax/microedition/lcdui/Gauge", name, "I", value).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn init(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        label: ClassInstanceRef<String>,
+        interactive: bool,
+        max_value: i32,
+        initial_value: i32,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Gauge::<init>({this:?}, {label:?}, {interactive}, {max_value}, {initial_value})");
+
+        if max_value <= 0 && (interactive || max_value != -1) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid Gauge maximum value").await);
+        }
+        if max_value == -1 && !(0..=3).contains(&initial_value) {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "Invalid indefinite Gauge state")
+                .await);
+        }
+
+        let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        jvm.put_field(&mut this, "interactive", "Z", interactive).await?;
+        jvm.put_field(&mut this, "maxValue", "I", max_value).await?;
+        jvm.put_field(
+            &mut this,
+            "value",
+            "I",
+            if max_value == -1 {
+                initial_value
+            } else {
+                initial_value.clamp(0, max_value)
+            },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn get_max_value(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "maxValue", "I").await
+    }
+
+    async fn set_max_value(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, max_value: i32) -> JvmResult<()> {
+        let interactive: bool = jvm.get_field(&this, "interactive", "Z").await?;
+        if max_value <= 0 && (interactive || max_value != -1) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid Gauge maximum value").await);
+        }
+
+        let old_max: i32 = jvm.get_field(&this, "maxValue", "I").await?;
+        let old_value: i32 = jvm.get_field(&this, "value", "I").await?;
+        let value = match (old_max, max_value) {
+            (-1, -1) => old_value,
+            (-1, _) => 0,
+            (_, -1) => 0,
+            (_, _) => old_value.min(max_value),
+        };
+        jvm.put_field(&mut this, "maxValue", "I", max_value).await?;
+        jvm.put_field(&mut this, "value", "I", value).await?;
+        Item::invalidate(jvm, &this, false).await
+    }
+
+    async fn get_value(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "value", "I").await
+    }
+
+    async fn set_value(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, value: i32) -> JvmResult<()> {
+        let max_value: i32 = jvm.get_field(&this, "maxValue", "I").await?;
+        if max_value == -1 && !(0..=3).contains(&value) {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "Invalid indefinite Gauge state")
+                .await);
+        }
+
+        jvm.put_field(&mut this, "value", "I", if max_value == -1 { value } else { value.clamp(0, max_value) })
+            .await?;
+        Item::invalidate(jvm, &this, false).await
+    }
+
+    async fn is_interactive(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        jvm.get_field(&this, "interactive", "Z").await
+    }
+
+    async fn set_label(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, label: ClassInstanceRef<String>) -> JvmResult<()> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "setLabel", "(Ljava/lang/String;)V", (label,))
+            .await
+    }
+
+    async fn set_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, layout: i32) -> JvmResult<()> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "setLayout", "(I)V", (layout,))
+            .await
+    }
+
+    async fn add_command(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, command: ClassInstanceRef<Command>) -> JvmResult<()> {
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Item",
+            "addCommand",
+            "(Ljavax/microedition/lcdui/Command;)V",
+            (command,),
+        )
+        .await
+    }
+
+    async fn set_item_command_listener(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        listener: ClassInstanceRef<ItemCommandListener>,
+    ) -> JvmResult<()> {
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Item",
+            "setItemCommandListener",
+            "(Ljavax/microedition/lcdui/ItemCommandListener;)V",
+            (listener,),
+        )
+        .await
+    }
+
+    async fn set_preferred_size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "setPreferredSize", "(II)V", (width, height))
+            .await
+    }
+
+    async fn set_default_command(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        command: ClassInstanceRef<Command>,
+    ) -> JvmResult<()> {
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/Item",
+            "setDefaultCommand",
+            "(Ljavax/microedition/lcdui/Command;)V",
+            (command,),
+        )
+        .await
+    }
+
+    async fn minimum_content_width(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(GAUGE_MINIMUM_WIDTH)
+    }
+
+    async fn minimum_content_height(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(GAUGE_HEIGHT)
+    }
+
+    async fn preferred_content_width(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(GAUGE_PREFERRED_WIDTH)
+    }
+
+    async fn preferred_content_height(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>, _width: i32) -> JvmResult<i32> {
+        Ok(GAUGE_HEIGHT)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_content(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        _focused: bool,
+    ) -> JvmResult<()> {
+        if width <= 0 || height <= 0 {
+            return Ok(());
+        }
+
+        let track_x = x + 2.min(width);
+        let track_width = (width - 4).max(1);
+        let track_height = 8.min(height).max(1);
+        let track_y = y + (height - track_height) / 2;
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TRACK_BACKGROUND,))
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "fillRect",
+                "(IIII)V",
+                (track_x, track_y, track_width, track_height),
+            )
+            .await?;
+
+        let max_value: i32 = jvm.get_field(&this, "maxValue", "I").await?;
+        let value: i32 = jvm.get_field(&this, "value", "I").await?;
+        let (fill_x, fill_width) = if max_value > 0 {
+            (track_x, track_width.saturating_mul(value) / max_value)
+        } else {
+            match value {
+                1 => (track_x, (track_width / 4).max(1)),
+                2 => (track_x + track_width / 3, (track_width / 3).max(1)),
+                3 => (track_x, (track_width * 2 / 3).max(1)),
+                _ => (track_x, 0),
+            }
+        };
+        if fill_width > 0 {
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TRACK_FILL,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "fillRect",
+                    "(IIII)V",
+                    (fill_x, track_y, fill_width.min(track_width), track_height),
+                )
+                .await?;
+        }
+
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TRACK_BORDER,))
+            .await?;
+        jvm.invoke_virtual(
+            &graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawRect",
+            "(IIII)V",
+            (track_x, track_y, track_width - 1, track_height - 1),
+        )
+        .await
+    }
+
+    async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        if jvm.get_field::<bool>(&this, "interactive", "Z").await? {
+            return Ok(true);
+        }
+
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        Ok(jvm.invoke_virtual::<_, i32>(&commands, "java/util/Vector", "size", "()I", ()).await? > 0)
+    }
+
+    async fn handle_item_key(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, key: i32) -> JvmResult<i32> {
+        let interactive: bool = jvm.get_field(&this, "interactive", "Z").await?;
+        if !interactive || (key != MIDPKeyCode::LEFT as i32 && key != MIDPKeyCode::RIGHT as i32) {
+            return Ok(0);
+        }
+
+        let max_value: i32 = jvm.get_field(&this, "maxValue", "I").await?;
+        let value: i32 = jvm.get_field(&this, "value", "I").await?;
+        let new_value = if key == MIDPKeyCode::LEFT as i32 {
+            value.saturating_sub(1).max(0)
+        } else {
+            value.saturating_add(1).min(max_value)
+        };
+        if new_value == value {
+            return Ok(Item::INPUT_HANDLED);
+        }
+
+        jvm.put_field(&mut this, "value", "I", new_value).await?;
+        Item::invalidate(jvm, &this, false).await?;
+        Ok(Item::INPUT_HANDLED | Item::INPUT_CHANGED)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use jvm::{ClassInstanceRef, JavaError, Result as JvmResult};
+    use rustjava_runtime::classes::java::lang::String;
+    use test_utils::run_jvm_test;
+    use wie_util::Result;
+
+    use crate::{
+        classes::javax::microedition::lcdui::{Gauge, Graphics, Image, Item},
+        get_protos,
+    };
+
+    use crate::classes::net::wie::MIDPKeyCode;
+
+    #[test]
+    fn gauge_clamps_input_and_renders_value_and_focus() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let gauge: ClassInstanceRef<Gauge> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/Gauge",
+                    "(Ljava/lang/String;ZII)V",
+                    (ClassInstanceRef::<String>::new(None), true, 2, 1),
+                )
+                .await?
+                .into();
+            for (key, result, value) in [
+                (MIDPKeyCode::LEFT, Item::INPUT_HANDLED | Item::INPUT_CHANGED, 0),
+                (MIDPKeyCode::LEFT, Item::INPUT_HANDLED, 0),
+                (MIDPKeyCode::RIGHT, Item::INPUT_HANDLED | Item::INPUT_CHANGED, 1),
+            ] {
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&gauge, "javax/microedition/lcdui/Item", "handleItemKey", "(I)I", (key as i32,))
+                        .await?,
+                    result
+                );
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&gauge, "javax/microedition/lcdui/Gauge", "getValue", "()I", ())
+                        .await?,
+                    value
+                );
+            }
+            let invalid: JvmResult<()> = jvm
+                .invoke_virtual(&gauge, "javax/microedition/lcdui/Gauge", "setMaxValue", "(I)V", (-1,))
+                .await;
+            let Err(JavaError::JavaException(exception)) = invalid else {
+                panic!("interactive Gauge accepted INDEFINITE");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/IllegalArgumentException"));
+
+            let image: ClassInstanceRef<Image> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Image",
+                    "createImage",
+                    "(II)Ljavax/microedition/lcdui/Image;",
+                    (90, 30),
+                )
+                .await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &image,
+                    "javax/microedition/lcdui/Image",
+                    "getGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &gauge,
+                    "javax/microedition/lcdui/Item",
+                    "paintItem",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    (graphics, 4, 4, 80, 20, true),
+                )
+                .await?;
+            let pixels = Image::image(&jvm, &image).await?;
+            let focus = pixels.get_pixel(4, 4);
+            assert_eq!((focus.r, focus.g, focus.b), (0x2f, 0x6f, 0x9f));
+            let fill = pixels.get_pixel(10, 14);
+            let track = pixels.get_pixel(78, 14);
+            assert_ne!((fill.r, fill.g, fill.b), (track.r, track.g, track.b));
+
+            let indicator: ClassInstanceRef<Gauge> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/Gauge",
+                    "(Ljava/lang/String;ZII)V",
+                    (ClassInstanceRef::<String>::new(None), false, 10, 7),
+                )
+                .await?
+                .into();
+            for (maximum, expected) in [(5, 5), (-1, 0), (10, 0)] {
+                let _: () = jvm
+                    .invoke_virtual(&indicator, "javax/microedition/lcdui/Gauge", "setMaxValue", "(I)V", (maximum,))
+                    .await?;
+                assert_eq!(
+                    jvm.invoke_virtual::<_, i32>(&indicator, "javax/microedition/lcdui/Gauge", "getValue", "()I", ())
+                        .await?,
+                    expected
+                );
+            }
+            Ok(())
+        })
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/gauge.rs
@@ -3,7 +3,7 @@ use alloc::vec;
 use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
-use rustjava_runtime::classes::java::{lang::String, util::Vector};
+use rustjava_runtime::classes::java::lang::String;
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
@@ -72,6 +72,7 @@ impl Gauge {
                     Self::paint_content,
                     MethodAccessFlags::empty(),
                 ),
+                JavaMethodProto::new("canBeAlertIndicator", "()Z", Self::can_be_alert_indicator, MethodAccessFlags::empty()),
                 JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
             ],
@@ -127,7 +128,9 @@ impl Gauge {
         }
 
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
-        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        let _: () = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Item", "setLabel", "(Ljava/lang/String;)V", (label,))
+            .await?;
         jvm.put_field(&mut this, "interactive", "Z", interactive).await?;
         jvm.put_field(&mut this, "maxValue", "I", max_value).await?;
         jvm.put_field(
@@ -338,13 +341,20 @@ impl Gauge {
         .await
     }
 
+    async fn can_be_alert_indicator(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        if jvm.get_field::<bool>(&this, "interactive", "Z").await? {
+            return Ok(false);
+        }
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "canBeAlertIndicator", "()Z", ())
+            .await
+    }
+
     async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
         if jvm.get_field::<bool>(&this, "interactive", "Z").await? {
             return Ok(true);
         }
 
-        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
-        Ok(jvm.invoke_virtual::<_, i32>(&commands, "java/util/Vector", "size", "()I", ()).await? > 0)
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ()).await
     }
 
     async fn handle_item_key(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, key: i32) -> JvmResult<i32> {

--- a/wie-midp/src/classes/javax/microedition/lcdui/graphics.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/graphics.rs
@@ -125,6 +125,7 @@ impl Graphics {
                 JavaFieldProto::new("translateY", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("color", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("xorMode", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("font", "Ljavax/microedition/lcdui/Font;", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
@@ -166,16 +167,18 @@ impl Graphics {
         jvm.put_field(&mut this, "translateY", "I", 0).await?;
         jvm.put_field(&mut this, "color", "I", 0).await?;
         jvm.put_field(&mut this, "xorMode", "Z", false).await?;
+        let font: ClassInstanceRef<Font> = jvm
+            .invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+            .await?;
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", font).await?;
 
         Ok(())
     }
 
     async fn get_font(jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Graphics>) -> JvmResult<ClassInstanceRef<Font>> {
-        tracing::warn!("stub javax.microedition.lcdui.Graphics::getFont({this:?})");
+        tracing::debug!("javax.microedition.lcdui.Graphics::getFont({this:?})");
 
-        let instance = jvm.new_class("javax/microedition/lcdui/Font", "()V", []).await?;
-
-        Ok(instance.into())
+        jvm.get_field(&this, "font", "Ljavax/microedition/lcdui/Font;").await
     }
 
     async fn set_color(jvm: &Jvm, _: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, rgb: i32) -> JvmResult<()> {
@@ -204,10 +207,16 @@ impl Graphics {
         Ok(())
     }
 
-    async fn set_font(_jvm: &Jvm, _: &mut WieJvmContext, this: ClassInstanceRef<Graphics>, font: ClassInstanceRef<Font>) -> JvmResult<()> {
-        tracing::warn!("stub javax.microedition.lcdui.Graphics::setFont({this:?}, {font:?})");
+    async fn set_font(jvm: &Jvm, _: &mut WieJvmContext, mut this: ClassInstanceRef<Graphics>, font: ClassInstanceRef<Font>) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Graphics::setFont({this:?}, {font:?})");
 
-        Ok(())
+        let font = if font.is_null() {
+            jvm.invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await?
+        } else {
+            font
+        };
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", font).await
     }
 
     async fn set_clip(

--- a/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
@@ -146,8 +146,12 @@ impl ImageItem {
 
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
         let display_image = Self::snapshot(jvm, &image).await?;
-        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
-        jvm.put_field(&mut this, "layout", "I", layout).await?;
+        let _: () = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Item", "setLabel", "(Ljava/lang/String;)V", (label,))
+            .await?;
+        let _: () = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Item", "setLayout", "(I)V", (layout,))
+            .await?;
         jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
         jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
             .await?;
@@ -200,7 +204,7 @@ impl ImageItem {
     }
 
     async fn get_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
-        jvm.get_field(&this, "layout", "I").await
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "getLayout", "()I", ()).await
     }
 
     async fn set_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, layout: i32) -> JvmResult<()> {
@@ -342,7 +346,7 @@ impl ImageItem {
             return Ok(());
         }
 
-        let layout: i32 = jvm.get_field(&this, "layout", "I").await?;
+        let layout: i32 = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "getLayout", "()I", ()).await?;
         let image_x = match layout & 0x3 {
             2 => content_x + content_width - image_width,
             3 => content_x + (content_width - image_width) / 2,

--- a/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
@@ -5,6 +5,7 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
+use wie_backend::text_layout::{minimum_width, wrap};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::lcdui::{Font, Graphics, Image, Item};
@@ -69,23 +70,42 @@ impl ImageItem {
                 JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
             ],
-            fields: [
-                "LAYOUT_DEFAULT",
-                "LAYOUT_LEFT",
-                "LAYOUT_RIGHT",
-                "LAYOUT_CENTER",
-                "LAYOUT_NEWLINE_BEFORE",
-                "LAYOUT_NEWLINE_AFTER",
-            ]
-            .into_iter()
-            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-            .chain([
+            fields: vec![
+                JavaFieldProto::new(
+                    "LAYOUT_DEFAULT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_LEFT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_RIGHT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_CENTER",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_NEWLINE_BEFORE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_NEWLINE_AFTER",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
                 JavaFieldProto::new("image", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("displayImage", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("altText", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("appearanceMode", "I", FieldAccessFlags::PRIVATE),
-            ])
-            .collect(),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }
@@ -228,7 +248,7 @@ impl ImageItem {
         let alt_width = Self::alt_text(jvm, &this)
             .await?
             .as_deref()
-            .map(|text| Font::minimum_width(context.system().platform().font(), text))
+            .map(|text| minimum_width(context.system().platform().font(), text, 10.0))
             .filter(|width| *width > 0);
         Ok(image_width.min(alt_width.unwrap_or(image_width)) + Item::appearance_inset(appearance_mode) * 2)
     }
@@ -240,7 +260,7 @@ impl ImageItem {
         let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
         let alt_height = Self::alt_text(jvm, &this)
             .await?
-            .map(|alt_text| Font::wrap(context.system().platform().font(), &alt_text, None).len() as i32 * Font::HEIGHT)
+            .map(|alt_text| wrap(context.system().platform().font(), &alt_text, 10.0, None).len() as i32 * Font::HEIGHT)
             .filter(|height| *height > 0);
         Ok(image_height.min(alt_height.unwrap_or(image_height)) + Item::appearance_inset(appearance_mode) * 2)
     }
@@ -268,7 +288,7 @@ impl ImageItem {
             return Ok(image_height + inset * 2);
         };
         let wrap_width = if appearance_mode == 2 { None } else { Some(available_width.max(1)) };
-        Ok(Font::wrap(context.system().platform().font(), &alt_text, wrap_width).len() as i32 * Font::HEIGHT + inset * 2)
+        Ok(wrap(context.system().platform().font(), &alt_text, 10.0, wrap_width).len() as i32 * Font::HEIGHT + inset * 2)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -324,9 +344,14 @@ impl ImageItem {
                 .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
                 .await?;
             let wrap_width = if appearance_mode == 2 { None } else { Some(content_width.max(1)) };
-            for (index, line) in Font::wrap(context.system().platform().font(), alt_text.as_deref().unwrap_or_default(), wrap_width)
-                .iter()
-                .enumerate()
+            for (index, line) in wrap(
+                context.system().platform().font(),
+                alt_text.as_deref().unwrap_or_default(),
+                10.0,
+                wrap_width,
+            )
+            .iter()
+            .enumerate()
             {
                 let line_y = content_y + index as i32 * Font::HEIGHT;
                 if line_y >= content_y + content_height {

--- a/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
@@ -91,16 +91,16 @@ impl ImageItem {
     }
 
     async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
-        for (name, value) in [
-            ("LAYOUT_DEFAULT", 0),
-            ("LAYOUT_LEFT", 1),
-            ("LAYOUT_RIGHT", 2),
-            ("LAYOUT_CENTER", 3),
-            ("LAYOUT_NEWLINE_BEFORE", 0x100),
-            ("LAYOUT_NEWLINE_AFTER", 0x200),
-        ] {
-            jvm.put_static_field("javax/microedition/lcdui/ImageItem", name, "I", value).await?;
-        }
+        jvm.put_static_field("javax/microedition/lcdui/ImageItem", "LAYOUT_DEFAULT", "I", 0)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/ImageItem", "LAYOUT_LEFT", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/ImageItem", "LAYOUT_RIGHT", "I", 2).await?;
+        jvm.put_static_field("javax/microedition/lcdui/ImageItem", "LAYOUT_CENTER", "I", 3)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/ImageItem", "LAYOUT_NEWLINE_BEFORE", "I", 0x100)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/ImageItem", "LAYOUT_NEWLINE_AFTER", "I", 0x200)
+            .await?;
 
         Ok(())
     }
@@ -159,7 +159,7 @@ impl ImageItem {
 
     async fn snapshot(jvm: &Jvm, image: &ClassInstanceRef<Image>) -> JvmResult<ClassInstanceRef<Image>> {
         if image.is_null() {
-            Ok(ClassInstanceRef::new(None))
+            Ok(None.into())
         } else {
             jvm.invoke_static(
                 "javax/microedition/lcdui/Image",
@@ -180,7 +180,8 @@ impl ImageItem {
         jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
         jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
             .await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_alt_text(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
@@ -194,7 +195,8 @@ impl ImageItem {
         alt_text: ClassInstanceRef<String>,
     ) -> JvmResult<()> {
         jvm.put_field(&mut this, "altText", "Ljava/lang/String;", alt_text).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -281,7 +283,14 @@ impl ImageItem {
             return Ok(());
         };
         let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
-        Item::paint_appearance(jvm, &graphics, x, y, width, height, appearance_mode).await?;
+        let _: () = jvm
+            .invoke_static(
+                "javax/microedition/lcdui/Item",
+                "paintAppearance",
+                "(Ljavax/microedition/lcdui/Graphics;IIIII)V",
+                (graphics.clone(), x, y, width, height, appearance_mode),
+            )
+            .await?;
 
         let inset = Item::appearance_inset(appearance_mode);
         let content_x = x + inset;
@@ -465,7 +474,7 @@ mod test {
                 .new_class(
                     "javax/microedition/lcdui/ImageItem",
                     "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
-                    (ClassInstanceRef::<String>::new(None), source.clone(), 2, alt_text.clone()),
+                    (None, source.clone(), 2, alt_text.clone()),
                 )
                 .await?
                 .into();
@@ -516,7 +525,7 @@ mod test {
                 .new_class(
                     "javax/microedition/lcdui/ImageItem",
                     "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
-                    (ClassInstanceRef::<String>::new(None), oversized_source, 1, alt_text),
+                    (None, oversized_source, 1, alt_text),
                 )
                 .await?
                 .into();

--- a/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/image_item.rs
@@ -1,0 +1,551 @@
+use alloc::{string::String as RustString, vec};
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::lang::String;
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::lcdui::{Font, Graphics, Image, Item};
+
+const LEFT_TOP: i32 = 4 | 16;
+
+// class javax.microedition.lcdui.ImageItem
+pub struct ImageItem;
+
+impl ImageItem {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/ImageItem",
+            parent_class: Some("javax/microedition/lcdui/Item"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
+                    Self::init,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;I)V",
+                    Self::init_with_appearance,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "getImage",
+                    "()Ljavax/microedition/lcdui/Image;",
+                    Self::get_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setImage",
+                    "(Ljavax/microedition/lcdui/Image;)V",
+                    Self::set_image,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getAltText", "()Ljava/lang/String;", Self::get_alt_text, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setAltText", "(Ljava/lang/String;)V", Self::set_alt_text, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getLayout", "()I", Self::get_layout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setLayout", "(I)V", Self::set_layout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getAppearanceMode", "()I", Self::get_appearance_mode, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "preferredContentHeight",
+                    "(I)I",
+                    Self::preferred_content_height,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "paintContent",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    Self::paint_content,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
+            ],
+            fields: [
+                "LAYOUT_DEFAULT",
+                "LAYOUT_LEFT",
+                "LAYOUT_RIGHT",
+                "LAYOUT_CENTER",
+                "LAYOUT_NEWLINE_BEFORE",
+                "LAYOUT_NEWLINE_AFTER",
+            ]
+            .into_iter()
+            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
+            .chain([
+                JavaFieldProto::new("image", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("displayImage", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("altText", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("appearanceMode", "I", FieldAccessFlags::PRIVATE),
+            ])
+            .collect(),
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        for (name, value) in [
+            ("LAYOUT_DEFAULT", 0),
+            ("LAYOUT_LEFT", 1),
+            ("LAYOUT_RIGHT", 2),
+            ("LAYOUT_CENTER", 3),
+            ("LAYOUT_NEWLINE_BEFORE", 0x100),
+            ("LAYOUT_NEWLINE_AFTER", 0x200),
+        ] {
+            jvm.put_static_field("javax/microedition/lcdui/ImageItem", name, "I", value).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn init(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        label: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+        layout: i32,
+        alt_text: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/ImageItem",
+            "<init>",
+            "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;I)V",
+            (label, image, layout, alt_text, 0),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn init_with_appearance(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        label: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+        layout: i32,
+        alt_text: ClassInstanceRef<String>,
+        appearance_mode: i32,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.ImageItem::<init>({this:?}, {label:?}, {image:?}, {layout}, {alt_text:?}, {appearance_mode})");
+
+        if layout & !0x7f33 != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid ImageItem layout").await);
+        }
+        if !(0..=2).contains(&appearance_mode) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid appearance mode").await);
+        }
+
+        let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
+        let display_image = Self::snapshot(jvm, &image).await?;
+        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        jvm.put_field(&mut this, "layout", "I", layout).await?;
+        jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
+        jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
+            .await?;
+        jvm.put_field(&mut this, "altText", "Ljava/lang/String;", alt_text).await?;
+        jvm.put_field(&mut this, "appearanceMode", "I", appearance_mode).await?;
+
+        Ok(())
+    }
+
+    async fn snapshot(jvm: &Jvm, image: &ClassInstanceRef<Image>) -> JvmResult<ClassInstanceRef<Image>> {
+        if image.is_null() {
+            Ok(ClassInstanceRef::new(None))
+        } else {
+            jvm.invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(Ljavax/microedition/lcdui/Image;)Ljavax/microedition/lcdui/Image;",
+                (image.clone(),),
+            )
+            .await
+        }
+    }
+
+    async fn get_image(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Image>> {
+        jvm.get_field(&this, "image", "Ljavax/microedition/lcdui/Image;").await
+    }
+
+    async fn set_image(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, image: ClassInstanceRef<Image>) -> JvmResult<()> {
+        let display_image = Self::snapshot(jvm, &image).await?;
+        jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
+        jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
+            .await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_alt_text(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "altText", "Ljava/lang/String;").await
+    }
+
+    async fn set_alt_text(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        alt_text: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        jvm.put_field(&mut this, "altText", "Ljava/lang/String;", alt_text).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "layout", "I").await
+    }
+
+    async fn set_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, layout: i32) -> JvmResult<()> {
+        if layout & !0x7f33 != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid ImageItem layout").await);
+        }
+
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "setLayout", "(I)V", (layout,))
+            .await
+    }
+
+    async fn get_appearance_mode(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "appearanceMode", "I").await
+    }
+
+    async fn minimum_content_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let Some((_image, image_width, _image_height)) = Self::display_image(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        let alt_width = Self::alt_text(jvm, &this)
+            .await?
+            .as_deref()
+            .map(|text| Font::minimum_width(context.system().platform().font(), text))
+            .filter(|width| *width > 0);
+        Ok(image_width.min(alt_width.unwrap_or(image_width)) + Item::appearance_inset(appearance_mode) * 2)
+    }
+
+    async fn minimum_content_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let Some((_image, _image_width, image_height)) = Self::display_image(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        let alt_height = Self::alt_text(jvm, &this)
+            .await?
+            .map(|alt_text| Font::wrap(context.system().platform().font(), &alt_text, None).len() as i32 * Font::HEIGHT)
+            .filter(|height| *height > 0);
+        Ok(image_height.min(alt_height.unwrap_or(image_height)) + Item::appearance_inset(appearance_mode) * 2)
+    }
+
+    async fn preferred_content_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let Some((_image, image_width, _image_height)) = Self::display_image(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        Ok(image_width + Item::appearance_inset(appearance_mode) * 2)
+    }
+
+    async fn preferred_content_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
+        let Some((_image, image_width, image_height)) = Self::display_image(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        let inset = Item::appearance_inset(appearance_mode);
+        let available_width = if width < 0 { image_width } else { (width - inset * 2).max(0) };
+        if image_width <= available_width {
+            return Ok(image_height + inset * 2);
+        }
+
+        let Some(alt_text) = Self::alt_text(jvm, &this).await? else {
+            return Ok(image_height + inset * 2);
+        };
+        let wrap_width = if appearance_mode == 2 { None } else { Some(available_width.max(1)) };
+        Ok(Font::wrap(context.system().platform().font(), &alt_text, wrap_width).len() as i32 * Font::HEIGHT + inset * 2)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_content(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        _focused: bool,
+    ) -> JvmResult<()> {
+        let Some((image, image_width, image_height)) = Self::display_image(jvm, &this).await? else {
+            return Ok(());
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        Item::paint_appearance(jvm, &graphics, x, y, width, height, appearance_mode).await?;
+
+        let inset = Item::appearance_inset(appearance_mode);
+        let content_x = x + inset;
+        let content_y = y + inset;
+        let content_width = (width - inset * 2).max(0);
+        let content_height = (height - inset * 2).max(0);
+        if content_width == 0 || content_height == 0 {
+            return Ok(());
+        }
+
+        let alt_text = Self::alt_text(jvm, &this).await?;
+        if (image_width > content_width || image_height > content_height) && alt_text.is_some() {
+            let font: ClassInstanceRef<Font> = jvm
+                .invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setFont",
+                    "(Ljavax/microedition/lcdui/Font;)V",
+                    (font,),
+                )
+                .await?;
+            let color = if appearance_mode == 1 { Item::LINK_COLOR } else { Item::TEXT_COLOR };
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+                .await?;
+            let wrap_width = if appearance_mode == 2 { None } else { Some(content_width.max(1)) };
+            for (index, line) in Font::wrap(context.system().platform().font(), alt_text.as_deref().unwrap_or_default(), wrap_width)
+                .iter()
+                .enumerate()
+            {
+                let line_y = content_y + index as i32 * Font::HEIGHT;
+                if line_y >= content_y + content_height {
+                    break;
+                }
+                let line = JavaLangString::from_rust_string(jvm, line).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (line, content_x, line_y, LEFT_TOP),
+                    )
+                    .await?;
+            }
+            return Ok(());
+        }
+
+        let layout: i32 = jvm.get_field(&this, "layout", "I").await?;
+        let image_x = match layout & 0x3 {
+            2 => content_x + content_width - image_width,
+            3 => content_x + (content_width - image_width) / 2,
+            _ => content_x,
+        };
+        let image_y = match layout & 0x30 {
+            0x20 => content_y + content_height - image_height,
+            0x30 => content_y + (content_height - image_height) / 2,
+            _ => content_y,
+        };
+        jvm.invoke_virtual(
+            &graphics,
+            "javax/microedition/lcdui/Graphics",
+            "drawImage",
+            "(Ljavax/microedition/lcdui/Image;III)V",
+            (image, image_x, image_y, LEFT_TOP),
+        )
+        .await
+    }
+
+    async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ()).await
+    }
+
+    async fn handle_item_key(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>, _key: i32) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    async fn display_image(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<Option<(ClassInstanceRef<Image>, i32, i32)>> {
+        let image: ClassInstanceRef<Image> = jvm.get_field(this, "displayImage", "Ljavax/microedition/lcdui/Image;").await?;
+        if image.is_null() {
+            return Ok(None);
+        }
+
+        let width: i32 = jvm
+            .invoke_virtual(&image, "javax/microedition/lcdui/Image", "getWidth", "()I", ())
+            .await?;
+        let height: i32 = jvm
+            .invoke_virtual(&image, "javax/microedition/lcdui/Image", "getHeight", "()I", ())
+            .await?;
+        Ok(Some((image, width, height)))
+    }
+
+    async fn alt_text(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<Option<RustString>> {
+        let alt_text: ClassInstanceRef<String> = jvm.get_field(this, "altText", "Ljava/lang/String;").await?;
+        if alt_text.is_null() {
+            return Ok(None);
+        }
+
+        let alt_text = JavaLangString::to_rust_string(jvm, &alt_text).await?;
+        Ok((!alt_text.is_empty()).then_some(alt_text))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use rustjava_runtime::classes::java::lang::String;
+    use test_utils::run_jvm_test;
+    use wie_util::Result;
+
+    use crate::{
+        classes::javax::microedition::lcdui::{Graphics, Image, ImageItem},
+        get_protos,
+    };
+
+    async fn create_image_and_graphics(jvm: &Jvm, width: i32, height: i32) -> JvmResult<(ClassInstanceRef<Image>, ClassInstanceRef<Graphics>)> {
+        let image: ClassInstanceRef<Image> = jvm
+            .invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(II)Ljavax/microedition/lcdui/Image;",
+                (width, height),
+            )
+            .await?;
+        let graphics: ClassInstanceRef<Graphics> = jvm
+            .invoke_virtual(
+                &image,
+                "javax/microedition/lcdui/Image",
+                "getGraphics",
+                "()Ljavax/microedition/lcdui/Graphics;",
+                (),
+            )
+            .await?;
+        Ok((image, graphics))
+    }
+
+    async fn fill(jvm: &Jvm, graphics: &ClassInstanceRef<Graphics>, color: i32, width: i32, height: i32) -> JvmResult<()> {
+        let _: () = jvm
+            .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+            .await?;
+        jvm.invoke_virtual(
+            graphics,
+            "javax/microedition/lcdui/Graphics",
+            "fillRect",
+            "(IIII)V",
+            (0, 0, width, height),
+        )
+        .await
+    }
+
+    async fn paint_item<T>(
+        jvm: &Jvm,
+        item: &ClassInstanceRef<T>,
+        graphics: ClassInstanceRef<Graphics>,
+        bounds: (i32, i32, i32, i32),
+        focused: bool,
+    ) -> JvmResult<()> {
+        let (x, y, width, height) = bounds;
+        jvm.invoke_virtual(
+            item,
+            "javax/microedition/lcdui/Item",
+            "paintItem",
+            "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+            (graphics, x, y, width, height, focused),
+        )
+        .await
+    }
+
+    #[test]
+    fn image_item_uses_snapshots_alt_text_and_horizontal_layout() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let (source, source_graphics) = create_image_and_graphics(&jvm, 8, 4).await?;
+            fill(&jvm, &source_graphics, 0xcc1122, 8, 4).await?;
+            let alt_text = ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(&jvm, "image unavailable").await?);
+            let item: ClassInstanceRef<ImageItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/ImageItem",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
+                    (ClassInstanceRef::<String>::new(None), source.clone(), 2, alt_text.clone()),
+                )
+                .await?
+                .into();
+            let returned_source: ClassInstanceRef<Image> = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/ImageItem",
+                    "getImage",
+                    "()Ljavax/microedition/lcdui/Image;",
+                    (),
+                )
+                .await?;
+            assert_eq!(returned_source.identity(), source.identity());
+
+            fill(&jvm, &source_graphics, 0x2255dd, 8, 4).await?;
+            let (first_target, first_graphics) = create_image_and_graphics(&jvm, 30, 12).await?;
+            fill(&jvm, &first_graphics, 0xffffff, 30, 12).await?;
+            paint_item(&jvm, &item, first_graphics, (0, 0, 30, 12), false).await?;
+            let first_pixels = Image::image(&jvm, &first_target).await?;
+            let snapshot_pixel = first_pixels.get_pixel(22, 0);
+            assert_eq!((snapshot_pixel.r, snapshot_pixel.g, snapshot_pixel.b), (0xcc, 0x11, 0x22));
+            let left_pixel = first_pixels.get_pixel(0, 0);
+            assert_eq!(
+                (left_pixel.r, left_pixel.g, left_pixel.b),
+                (0xff, 0xff, 0xff),
+                "LAYOUT_RIGHT must align the image to the right"
+            );
+
+            let _: () = jvm
+                .invoke_virtual(
+                    &item,
+                    "javax/microedition/lcdui/ImageItem",
+                    "setImage",
+                    "(Ljavax/microedition/lcdui/Image;)V",
+                    (source.clone(),),
+                )
+                .await?;
+            let (second_target, second_graphics) = create_image_and_graphics(&jvm, 30, 12).await?;
+            fill(&jvm, &second_graphics, 0xffffff, 30, 12).await?;
+            paint_item(&jvm, &item, second_graphics, (0, 0, 30, 12), false).await?;
+            let second_pixels = Image::image(&jvm, &second_target).await?;
+            let refreshed_pixel = second_pixels.get_pixel(22, 0);
+            assert_eq!((refreshed_pixel.r, refreshed_pixel.g, refreshed_pixel.b), (0x22, 0x55, 0xdd));
+
+            let (oversized_source, oversized_graphics) = create_image_and_graphics(&jvm, 80, 6).await?;
+            fill(&jvm, &oversized_graphics, 0xcc1122, 80, 6).await?;
+            let oversized: ClassInstanceRef<ImageItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/ImageItem",
+                    "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;ILjava/lang/String;)V",
+                    (ClassInstanceRef::<String>::new(None), oversized_source, 1, alt_text),
+                )
+                .await?
+                .into();
+            let alt_height: i32 = jvm
+                .invoke_virtual(&oversized, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (35,))
+                .await?;
+            assert!(alt_height >= 24, "alternate text must wrap when the image cannot fit");
+            let (alt_target, alt_graphics) = create_image_and_graphics(&jvm, 35, alt_height).await?;
+            fill(&jvm, &alt_graphics, 0xffffff, 35, alt_height).await?;
+            paint_item(&jvm, &oversized, alt_graphics, (0, 0, 35, alt_height), false).await?;
+            let alt_pixels = Image::image(&jvm, &alt_target).await?;
+            let red_pixels = (0..35)
+                .flat_map(|x| (0..alt_height).map(move |y| (x, y)))
+                .filter(|&(x, y)| {
+                    let color = alt_pixels.get_pixel(x, y);
+                    color.r == 0xcc && color.g == 0x11 && color.b == 0x22
+                })
+                .count();
+            let non_white_pixels = (0..35)
+                .flat_map(|x| (0..alt_height).map(move |y| (x, y)))
+                .filter(|&(x, y)| {
+                    let color = alt_pixels.get_pixel(x, y);
+                    (color.r, color.g, color.b) != (0xff, 0xff, 0xff)
+                })
+                .count();
+            assert_eq!(red_pixels, 0, "oversized image must be replaced by alternate text");
+            assert!(non_white_pixels > 8, "alternate text must render visible glyphs");
+
+            Ok(())
+        })
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item.rs
@@ -1,31 +1,952 @@
-use alloc::vec;
+use alloc::{string::String as RustString, vec};
 
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
-use jvm_class_proto::JavaMethodProto;
-use jvm_types::{ClassAccessFlags, MethodAccessFlags};
+use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::lcdui::{Command, Displayable, Font, Graphics, ItemCommandListener};
+
+const LABEL_COLOR: i32 = 0x52606d;
+const BUTTON_BACKGROUND: i32 = 0xe7edf2;
+const BUTTON_BORDER: i32 = 0x65727d;
+const FOCUS_BORDER: i32 = 0x2f6f9f;
+const LABEL_CONTENT_GAP: i32 = 2;
+const BUTTON_INSET: i32 = 3;
+const LEFT_TOP: i32 = 4 | 16;
 
 // class javax.microedition.lcdui.Item
 pub struct Item;
 
 impl Item {
+    pub const INPUT_HANDLED: i32 = 1;
+    pub const INPUT_CHANGED: i32 = 2;
+    pub const TEXT_COLOR: i32 = 0x17212b;
+    pub const LINK_COLOR: i32 = 0x175ca8;
+
     pub fn as_proto() -> WieJavaClassProto {
         WieJavaClassProto {
             name: "javax/microedition/lcdui/Item",
             parent_class: Some("java/lang/Object"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED)],
-            fields: vec![],
+            methods: vec![
+                JavaMethodProto::new("<clinit>", "()V", Self::cl_init, MethodAccessFlags::STATIC),
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "addCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::add_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "removeCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::remove_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getLabel", "()Ljava/lang/String;", Self::get_label, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setLabel", "(Ljava/lang/String;)V", Self::set_label, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getLayout", "()I", Self::get_layout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setLayout", "(I)V", Self::set_layout, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMinimumWidth", "()I", Self::get_minimum_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getMinimumHeight", "()I", Self::get_minimum_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getPreferredWidth", "()I", Self::get_preferred_width, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getPreferredHeight", "()I", Self::get_preferred_height, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setPreferredSize", "(II)V", Self::set_preferred_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "setDefaultCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::set_default_command,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "setItemCommandListener",
+                    "(Ljavax/microedition/lcdui/ItemCommandListener;)V",
+                    Self::set_item_command_listener,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("notifyStateChanged", "()V", Self::notify_state_changed, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("measureHeight", "(I)I", Self::measure_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "paintItem",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    Self::paint_item,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "preferredContentHeight",
+                    "(I)I",
+                    Self::preferred_content_height,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "paintContent",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    Self::paint_content,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getFocusContentBounds",
+                    "(I)[I",
+                    Self::get_focus_content_bounds,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "dispatchCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    Self::dispatch_command,
+                    MethodAccessFlags::empty(),
+                ),
+            ],
+            fields: [
+                "LAYOUT_DEFAULT",
+                "LAYOUT_LEFT",
+                "LAYOUT_RIGHT",
+                "LAYOUT_CENTER",
+                "LAYOUT_TOP",
+                "LAYOUT_BOTTOM",
+                "LAYOUT_VCENTER",
+                "LAYOUT_NEWLINE_BEFORE",
+                "LAYOUT_NEWLINE_AFTER",
+                "LAYOUT_SHRINK",
+                "LAYOUT_EXPAND",
+                "LAYOUT_VSHRINK",
+                "LAYOUT_VEXPAND",
+                "LAYOUT_2",
+                "PLAIN",
+                "HYPERLINK",
+                "BUTTON",
+            ]
+            .into_iter()
+            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
+            .chain([
+                JavaFieldProto::new("owner", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("layout", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("preferredWidth", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("preferredHeight", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("commands", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("defaultCommand", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new(
+                    "itemCommandListener",
+                    "Ljavax/microedition/lcdui/ItemCommandListener;",
+                    FieldAccessFlags::PRIVATE,
+                ),
+            ])
+            .collect(),
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
 
-    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+    async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Item::<clinit>");
+
+        for (name, value) in [
+            ("LAYOUT_DEFAULT", 0),
+            ("LAYOUT_LEFT", 1),
+            ("LAYOUT_RIGHT", 2),
+            ("LAYOUT_CENTER", 3),
+            ("LAYOUT_TOP", 0x10),
+            ("LAYOUT_BOTTOM", 0x20),
+            ("LAYOUT_VCENTER", 0x30),
+            ("LAYOUT_NEWLINE_BEFORE", 0x100),
+            ("LAYOUT_NEWLINE_AFTER", 0x200),
+            ("LAYOUT_SHRINK", 0x400),
+            ("LAYOUT_EXPAND", 0x800),
+            ("LAYOUT_VSHRINK", 0x1000),
+            ("LAYOUT_VEXPAND", 0x2000),
+            ("LAYOUT_2", 0x4000),
+            ("PLAIN", 0),
+            ("HYPERLINK", 1),
+            ("BUTTON", 2),
+        ] {
+            jvm.put_static_field("javax/microedition/lcdui/Item", name, "I", value).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Item::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        let commands = jvm.new_class("java/util/Vector", "()V", ()).await?;
+        jvm.put_field(&mut this, "commands", "Ljava/util/Vector;", commands).await?;
+        jvm.put_field(&mut this, "preferredWidth", "I", -1).await?;
+        jvm.put_field(&mut this, "preferredHeight", "I", -1).await?;
 
         Ok(())
+    }
+
+    async fn check_owner_mutation(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<()> {
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(this, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        if !owner.is_null() {
+            let _: () = jvm
+                .invoke_virtual(
+                    &owner,
+                    "javax/microedition/lcdui/Displayable",
+                    "checkItemMutation",
+                    "(Ljavax/microedition/lcdui/Item;)V",
+                    (this.clone(),),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn invalidate<T: Send + Sync + 'static>(jvm: &Jvm, this: &ClassInstanceRef<T>, layout_changed: bool) -> JvmResult<()> {
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(this, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        if !owner.is_null() {
+            let _: () = jvm
+                .invoke_virtual(
+                    &owner,
+                    "javax/microedition/lcdui/Displayable",
+                    "itemInvalidated",
+                    "(Ljavax/microedition/lcdui/Item;Z)V",
+                    (this.clone(), layout_changed),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn add_command(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, command: ClassInstanceRef<Command>) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Item::addCommand({this:?}, {command:?})");
+
+        Self::check_owner_mutation(jvm, &this).await?;
+        if command.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Command is null").await);
+        }
+
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        let mut registered = false;
+        for index in 0..command_count {
+            let existing: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                .await?;
+            if existing.identity() == command.identity() {
+                registered = true;
+                break;
+            }
+        }
+        if !registered {
+            let _: () = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (command,))
+                .await?;
+            Self::invalidate(jvm, &this, false).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn remove_command(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        command: ClassInstanceRef<Command>,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Item::removeCommand({this:?}, {command:?})");
+
+        Self::check_owner_mutation(jvm, &this).await?;
+        if command.is_null() {
+            return Ok(());
+        }
+
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        for index in 0..command_count {
+            let existing: ClassInstanceRef<Command> = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                .await?;
+            if existing.identity() != command.identity() {
+                continue;
+            }
+
+            let _: () = jvm
+                .invoke_virtual(&commands, "java/util/Vector", "removeElementAt", "(I)V", (index,))
+                .await?;
+            let default_command: ClassInstanceRef<Command> = jvm.get_field(&this, "defaultCommand", "Ljavax/microedition/lcdui/Command;").await?;
+            if !default_command.is_null() && default_command.identity() == command.identity() {
+                jvm.put_field(
+                    &mut this,
+                    "defaultCommand",
+                    "Ljavax/microedition/lcdui/Command;",
+                    ClassInstanceRef::<Command>::new(None),
+                )
+                .await?;
+            }
+            Self::invalidate(jvm, &this, false).await?;
+            break;
+        }
+
+        Ok(())
+    }
+
+    async fn get_label(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "label", "Ljava/lang/String;").await
+    }
+
+    async fn set_label(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, label: ClassInstanceRef<String>) -> JvmResult<()> {
+        Self::check_owner_mutation(jvm, &this).await?;
+        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        Self::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "layout", "I").await
+    }
+
+    async fn set_layout(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, layout: i32) -> JvmResult<()> {
+        Self::check_owner_mutation(jvm, &this).await?;
+        if layout & !0x7f33 != 0 {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid Item layout").await);
+        }
+
+        jvm.put_field(&mut this, "layout", "I", layout).await?;
+        Self::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_minimum_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let content_width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "minimumContentWidth", "()I", ())
+            .await?;
+        let label = Self::label_text(jvm, &this).await?;
+        let label_width = label
+            .as_deref()
+            .map(|text| Font::minimum_width(context.system().platform().font(), text))
+            .unwrap_or(0);
+        Ok(content_width.max(label_width))
+    }
+
+    async fn get_minimum_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let content_height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "minimumContentHeight", "()I", ())
+            .await?;
+        let label = Self::label_text(jvm, &this).await?;
+        let label_height = label
+            .as_deref()
+            .map(|label| Font::wrap(context.system().platform().font(), label, None).len() as i32 * Font::HEIGHT)
+            .unwrap_or(0);
+        Ok(label_height + content_height + if label_height > 0 && content_height > 0 { LABEL_CONTENT_GAP } else { 0 })
+    }
+
+    async fn get_preferred_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let preferred_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
+        let minimum_width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumWidth", "()I", ())
+            .await?;
+        if preferred_width >= 0 {
+            return Ok(preferred_width.max(minimum_width));
+        }
+
+        let content_width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "preferredContentWidth", "()I", ())
+            .await?;
+        let label = Self::label_text(jvm, &this).await?;
+        let label_width = label
+            .as_deref()
+            .map(|text| Font::preferred_width(context.system().platform().font(), text))
+            .unwrap_or(0);
+        Ok(content_width.max(label_width).max(minimum_width))
+    }
+
+    async fn get_preferred_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let preferred_height: i32 = jvm.get_field(&this, "preferredHeight", "I").await?;
+        let minimum_height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumHeight", "()I", ())
+            .await?;
+        if preferred_height >= 0 {
+            return Ok(preferred_height.max(minimum_height));
+        }
+
+        let preferred_width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+            .await?;
+        Ok(Self::natural_height(jvm, context, &this, preferred_width).await?.max(minimum_height))
+    }
+
+    async fn set_preferred_size(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
+        Self::check_owner_mutation(jvm, &this).await?;
+        if width < -1 || height < -1 {
+            return Err(jvm
+                .exception("java/lang/IllegalArgumentException", "Preferred size is less than -1")
+                .await);
+        }
+
+        let minimum_width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumWidth", "()I", ())
+            .await?;
+        let minimum_height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumHeight", "()I", ())
+            .await?;
+        jvm.put_field(&mut this, "preferredWidth", "I", if width < 0 { -1 } else { width.max(minimum_width) })
+            .await?;
+        jvm.put_field(
+            &mut this,
+            "preferredHeight",
+            "I",
+            if height < 0 { -1 } else { height.max(minimum_height) },
+        )
+        .await?;
+        Self::invalidate(jvm, &this, true).await
+    }
+
+    async fn set_default_command(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        command: ClassInstanceRef<Command>,
+    ) -> JvmResult<()> {
+        Self::check_owner_mutation(jvm, &this).await?;
+
+        if !command.is_null() {
+            let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+            let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+            let mut registered = false;
+            for index in 0..command_count {
+                let existing: ClassInstanceRef<Command> = jvm
+                    .invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+                    .await?;
+                if existing.identity() == command.identity() {
+                    registered = true;
+                    break;
+                }
+            }
+            if !registered {
+                let _: () = jvm
+                    .invoke_virtual(&commands, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (command.clone(),))
+                    .await?;
+            }
+        }
+
+        jvm.put_field(&mut this, "defaultCommand", "Ljavax/microedition/lcdui/Command;", command)
+            .await?;
+        Self::invalidate(jvm, &this, false).await
+    }
+
+    async fn set_item_command_listener(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        listener: ClassInstanceRef<ItemCommandListener>,
+    ) -> JvmResult<()> {
+        Self::check_owner_mutation(jvm, &this).await?;
+        jvm.put_field(
+            &mut this,
+            "itemCommandListener",
+            "Ljavax/microedition/lcdui/ItemCommandListener;",
+            listener,
+        )
+        .await?;
+        Self::invalidate(jvm, &this, false).await
+    }
+
+    async fn notify_state_changed(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&this, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        if owner.is_null() {
+            return Err(jvm.exception("java/lang/IllegalStateException", "Item is not owned by a Form").await);
+        }
+
+        jvm.invoke_virtual(
+            &owner,
+            "javax/microedition/lcdui/Displayable",
+            "itemStateChanged",
+            "(Ljavax/microedition/lcdui/Item;)V",
+            (this,),
+        )
+        .await
+    }
+
+    async fn measure_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
+        let minimum_height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumHeight", "()I", ())
+            .await?;
+        let preferred_height: i32 = jvm.get_field(&this, "preferredHeight", "I").await?;
+        if preferred_height >= 0 {
+            return Ok(preferred_height.max(minimum_height));
+        }
+
+        let available_width = if width < 0 {
+            jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                .await?
+        } else {
+            width
+        };
+        let preferred_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
+        let measured_width = if preferred_width >= 0 {
+            let minimum_width: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumWidth", "()I", ())
+                .await?;
+            available_width.min(preferred_width.max(minimum_width))
+        } else {
+            available_width
+        };
+        Ok(Self::natural_height(jvm, context, &this, measured_width).await?.max(minimum_height))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_item(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        focused: bool,
+    ) -> JvmResult<()> {
+        let width = width.max(0);
+        let height = height.max(0);
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let clip_x: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipX", "()I", ())
+            .await?;
+        let clip_y: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipY", "()I", ())
+            .await?;
+        let clip_width: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipWidth", "()I", ())
+            .await?;
+        let clip_height: i32 = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "getClipHeight", "()I", ())
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "clipRect",
+                "(IIII)V",
+                (x, y, width, height),
+            )
+            .await?;
+
+        let label = Self::label_text(jvm, &this).await?;
+        let label_lines = label
+            .as_deref()
+            .map(|label| Font::wrap(context.system().platform().font(), label, Some(width)))
+            .unwrap_or_default();
+        let label_height = (label_lines.len() as i32 * Font::HEIGHT).min(height);
+        if !label_lines.is_empty() {
+            let default_font: ClassInstanceRef<Font> = jvm
+                .invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "setFont",
+                    "(Ljavax/microedition/lcdui/Font;)V",
+                    (default_font,),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (LABEL_COLOR,))
+                .await?;
+            for (index, line) in label_lines.iter().enumerate() {
+                let line_y = y + index as i32 * Font::HEIGHT;
+                if line_y >= y + label_height {
+                    break;
+                }
+                let line = JavaLangString::from_rust_string(jvm, line).await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawString",
+                        "(Ljava/lang/String;III)V",
+                        (line, x, line_y, LEFT_TOP),
+                    )
+                    .await?;
+            }
+        }
+
+        let content_preferred_height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "preferredContentHeight", "(I)I", (width,))
+            .await?;
+        let gap = if label_height > 0 && content_preferred_height > 0 {
+            LABEL_CONTENT_GAP.min((height - label_height).max(0))
+        } else {
+            0
+        };
+        let content_y = y + label_height + gap;
+        let content_height = (height - label_height - gap).max(0);
+        let paint_result: JvmResult<()> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/Item",
+                "paintContent",
+                "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                (graphics.clone(), x, content_y, width, content_height, focused),
+            )
+            .await;
+
+        if paint_result.is_ok() && focused {
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (FOCUS_BORDER,))
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawRect",
+                    "(IIII)V",
+                    (x, y, (width - 1).max(0), (height - 1).max(0)),
+                )
+                .await?;
+        }
+
+        let restore_result: JvmResult<()> = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "setClip",
+                "(IIII)V",
+                (clip_x, clip_y, clip_width, clip_height),
+            )
+            .await;
+        paint_result?;
+        restore_result
+    }
+
+    async fn minimum_content_width(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    async fn minimum_content_height(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    async fn preferred_content_width(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    async fn preferred_content_height(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>, _width: i32) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_content(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        _this: ClassInstanceRef<Self>,
+        _graphics: ClassInstanceRef<Graphics>,
+        _x: i32,
+        _y: i32,
+        _width: i32,
+        _height: i32,
+        _focused: bool,
+    ) -> JvmResult<()> {
+        Ok(())
+    }
+
+    async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        Ok(jvm.invoke_virtual::<_, i32>(&commands, "java/util/Vector", "size", "()I", ()).await? > 0)
+    }
+
+    async fn handle_item_key(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>, _key: i32) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    // Null selects the whole Item; otherwise the pair is content-local [top, bottom).
+    async fn get_focus_content_bounds(
+        _jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        _this: ClassInstanceRef<Self>,
+        _width: i32,
+    ) -> JvmResult<ClassInstanceRef<Array<i32>>> {
+        Ok(ClassInstanceRef::new(None))
+    }
+
+    pub async fn focus_bounds(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: &ClassInstanceRef<Self>,
+        width: i32,
+        height: i32,
+    ) -> JvmResult<(i32, i32)> {
+        let bounds: ClassInstanceRef<Array<i32>> = jvm
+            .invoke_virtual(this, "javax/microedition/lcdui/Item", "getFocusContentBounds", "(I)[I", (width,))
+            .await?;
+        if bounds.is_null() {
+            return Ok((0, height));
+        }
+
+        let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
+        let label = Self::label_text(jvm, this).await?;
+        let label_height = label
+            .as_deref()
+            .map(|label| Font::wrap(context.system().platform().font(), label, Some(width)).len() as i32 * Font::HEIGHT)
+            .unwrap_or(0)
+            .min(height);
+        let content_y = label_height
+            + if label_height > 0 {
+                LABEL_CONTENT_GAP.min(height - label_height)
+            } else {
+                0
+            };
+        Ok(((content_y + bounds[0]).min(height), (content_y + bounds[1]).min(height)))
+    }
+
+    async fn dispatch_command(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        command: ClassInstanceRef<Command>,
+    ) -> JvmResult<()> {
+        let listener: ClassInstanceRef<ItemCommandListener> = jvm
+            .get_field(&this, "itemCommandListener", "Ljavax/microedition/lcdui/ItemCommandListener;")
+            .await?;
+        if !listener.is_null() {
+            let _: () = jvm
+                .invoke_virtual(
+                    &listener,
+                    "javax/microedition/lcdui/ItemCommandListener",
+                    "commandAction",
+                    "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
+                    (command, this),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn label_text<T>(jvm: &Jvm, this: &ClassInstanceRef<T>) -> JvmResult<Option<RustString>> {
+        let label: ClassInstanceRef<String> = jvm.get_field(this, "label", "Ljava/lang/String;").await?;
+        if label.is_null() {
+            return Ok(None);
+        }
+
+        let label = JavaLangString::to_rust_string(jvm, &label).await?;
+        Ok((!label.is_empty()).then_some(label))
+    }
+
+    async fn natural_height(jvm: &Jvm, context: &mut WieJvmContext, this: &ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
+        let label = Self::label_text(jvm, this).await?;
+        let label_height = label
+            .as_deref()
+            .map(|label| Font::wrap(context.system().platform().font(), label, Some(width.max(1))).len() as i32 * Font::HEIGHT)
+            .unwrap_or(0);
+        let content_height: i32 = jvm
+            .invoke_virtual(this, "javax/microedition/lcdui/Item", "preferredContentHeight", "(I)I", (width,))
+            .await?;
+        Ok(label_height + content_height + if label_height > 0 && content_height > 0 { LABEL_CONTENT_GAP } else { 0 })
+    }
+
+    pub fn appearance_inset(appearance_mode: i32) -> i32 {
+        if appearance_mode == 2 { BUTTON_INSET } else { 0 }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn paint_appearance(
+        jvm: &Jvm,
+        graphics: &ClassInstanceRef<Graphics>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        appearance_mode: i32,
+    ) -> JvmResult<()> {
+        if width <= 0 || height <= 0 {
+            return Ok(());
+        }
+
+        match appearance_mode {
+            1 => {
+                let _: () = jvm
+                    .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (Self::LINK_COLOR,))
+                    .await?;
+                jvm.invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawLine",
+                    "(IIII)V",
+                    (x, y + height - 1, x + width - 1, y + height - 1),
+                )
+                .await
+            }
+            2 => {
+                let _: () = jvm
+                    .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BUTTON_BACKGROUND,))
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "fillRect",
+                        "(IIII)V",
+                        (x, y, width, height),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BUTTON_BORDER,))
+                    .await?;
+                jvm.invoke_virtual(
+                    graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawRect",
+                    "(IIII)V",
+                    (x, y, width - 1, height - 1),
+                )
+                .await
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use jvm::{ClassInstanceRef, runtime::JavaLangString};
+    use rustjava_runtime::classes::java::lang::String;
+    use test_utils::run_jvm_test;
+    use wie_util::Result;
+
+    use crate::{classes::javax::microedition::lcdui::StringItem, get_protos};
+
+    #[test]
+    fn item_sizes_include_labels_wrap_text_and_honor_dimension_locks() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let text = ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(&jvm, "alpha beta gamma delta epsilon").await?);
+            let unlabeled: ClassInstanceRef<StringItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/StringItem",
+                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                    (ClassInstanceRef::<String>::new(None), text.clone()),
+                )
+                .await?
+                .into();
+            let label = ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(&jvm, "First label line\nSecond label line").await?);
+            let labeled: ClassInstanceRef<StringItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/StringItem",
+                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                    (label, text),
+                )
+                .await?
+                .into();
+
+            let minimum_width: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "getMinimumWidth", "()I", ())
+                .await?;
+            let minimum_height: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "getMinimumHeight", "()I", ())
+                .await?;
+            let natural_width: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                .await?;
+            let natural_height: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredHeight", "()I", ())
+                .await?;
+            assert!(minimum_width > 0);
+            assert!(minimum_height > 0);
+            assert!(natural_width > minimum_width);
+            assert!(natural_height >= minimum_height);
+
+            let wide_height: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (natural_width,))
+                .await?;
+            let narrow_height: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (minimum_width + 8,))
+                .await?;
+            assert!(narrow_height > wide_height, "word and character wrapping must increase row height");
+
+            let labeled_height: i32 = jvm
+                .invoke_virtual(&labeled, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (natural_width,))
+                .await?;
+            assert!(
+                labeled_height >= wide_height + 24,
+                "two explicit label lines must contribute to row height"
+            );
+            assert!(
+                jvm.invoke_virtual::<_, i32>(&labeled, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                    .await?
+                    >= natural_width
+            );
+
+            let _: () = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/StringItem", "setPreferredSize", "(II)V", (0, 0))
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                    .await?,
+                minimum_width
+            );
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredHeight", "()I", ())
+                    .await?,
+                minimum_height
+            );
+
+            let locked_width = minimum_width + 8;
+            let _: () = jvm
+                .invoke_virtual(
+                    &unlabeled,
+                    "javax/microedition/lcdui/StringItem",
+                    "setPreferredSize",
+                    "(II)V",
+                    (locked_width, -1),
+                )
+                .await?;
+            let locked_height: i32 = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredHeight", "()I", ())
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                    .await?,
+                locked_width
+            );
+            assert!(locked_height > natural_height);
+
+            let longer_text =
+                ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(&jvm, "alpha beta gamma delta epsilon zeta eta theta iota").await?);
+            let _: () = jvm
+                .invoke_virtual(
+                    &unlabeled,
+                    "javax/microedition/lcdui/StringItem",
+                    "setText",
+                    "(Ljava/lang/String;)V",
+                    (longer_text,),
+                )
+                .await?;
+            assert_eq!(
+                jvm.invoke_virtual::<_, i32>(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                    .await?,
+                locked_width
+            );
+            assert!(
+                jvm.invoke_virtual::<_, i32>(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredHeight", "()I", ())
+                    .await?
+                    > locked_height
+            );
+
+            let _: () = jvm
+                .invoke_virtual(&unlabeled, "javax/microedition/lcdui/StringItem", "setPreferredSize", "(II)V", (-1, -1))
+                .await?;
+            assert!(
+                jvm.invoke_virtual::<_, i32>(&unlabeled, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                    .await?
+                    > locked_width
+            );
+
+            Ok(())
+        })
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item.rs
@@ -68,6 +68,7 @@ impl Item {
                     MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new("notifyStateChanged", "()V", Self::notify_state_changed, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("invalidate", "(Z)V", Self::invalidate, MethodAccessFlags::empty()),
                 JavaMethodProto::new("measureHeight", "(I)I", Self::measure_height, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "paintItem",
@@ -97,6 +98,13 @@ impl Item {
                     "(I)[I",
                     Self::get_focus_content_bounds,
                     MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("getFocusBounds", "(II)[I", Self::focus_bounds, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "paintAppearance",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIII)V",
+                    Self::paint_appearance,
+                    MethodAccessFlags::STATIC,
                 ),
                 JavaMethodProto::new(
                     "dispatchCommand",
@@ -148,27 +156,27 @@ impl Item {
     async fn cl_init(jvm: &Jvm, _context: &mut WieJvmContext) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Item::<clinit>");
 
-        for (name, value) in [
-            ("LAYOUT_DEFAULT", 0),
-            ("LAYOUT_LEFT", 1),
-            ("LAYOUT_RIGHT", 2),
-            ("LAYOUT_CENTER", 3),
-            ("LAYOUT_TOP", 0x10),
-            ("LAYOUT_BOTTOM", 0x20),
-            ("LAYOUT_VCENTER", 0x30),
-            ("LAYOUT_NEWLINE_BEFORE", 0x100),
-            ("LAYOUT_NEWLINE_AFTER", 0x200),
-            ("LAYOUT_SHRINK", 0x400),
-            ("LAYOUT_EXPAND", 0x800),
-            ("LAYOUT_VSHRINK", 0x1000),
-            ("LAYOUT_VEXPAND", 0x2000),
-            ("LAYOUT_2", 0x4000),
-            ("PLAIN", 0),
-            ("HYPERLINK", 1),
-            ("BUTTON", 2),
-        ] {
-            jvm.put_static_field("javax/microedition/lcdui/Item", name, "I", value).await?;
-        }
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_DEFAULT", "I", 0).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_LEFT", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_RIGHT", "I", 2).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_CENTER", "I", 3).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_TOP", "I", 0x10).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_BOTTOM", "I", 0x20).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_VCENTER", "I", 0x30).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_NEWLINE_BEFORE", "I", 0x100)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_NEWLINE_AFTER", "I", 0x200)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_SHRINK", "I", 0x400).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_EXPAND", "I", 0x800).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_VSHRINK", "I", 0x1000)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_VEXPAND", "I", 0x2000)
+            .await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "LAYOUT_2", "I", 0x4000).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "PLAIN", "I", 0).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "HYPERLINK", "I", 1).await?;
+        jvm.put_static_field("javax/microedition/lcdui/Item", "BUTTON", "I", 2).await?;
 
         Ok(())
     }
@@ -202,8 +210,8 @@ impl Item {
         Ok(())
     }
 
-    pub async fn invalidate<T: Send + Sync + 'static>(jvm: &Jvm, this: &ClassInstanceRef<T>, layout_changed: bool) -> JvmResult<()> {
-        let owner: ClassInstanceRef<Displayable> = jvm.get_field(this, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+    async fn invalidate(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, layout_changed: bool) -> JvmResult<()> {
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&this, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
         if !owner.is_null() {
             let _: () = jvm
                 .invoke_virtual(
@@ -243,7 +251,9 @@ impl Item {
             let _: () = jvm
                 .invoke_virtual(&commands, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (command,))
                 .await?;
-            Self::invalidate(jvm, &this, false).await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+                .await?;
         }
 
         Ok(())
@@ -277,15 +287,12 @@ impl Item {
                 .await?;
             let default_command: ClassInstanceRef<Command> = jvm.get_field(&this, "defaultCommand", "Ljavax/microedition/lcdui/Command;").await?;
             if !default_command.is_null() && default_command.identity() == command.identity() {
-                jvm.put_field(
-                    &mut this,
-                    "defaultCommand",
-                    "Ljavax/microedition/lcdui/Command;",
-                    ClassInstanceRef::<Command>::new(None),
-                )
-                .await?;
+                jvm.put_field(&mut this, "defaultCommand", "Ljavax/microedition/lcdui/Command;", None)
+                    .await?;
             }
-            Self::invalidate(jvm, &this, false).await?;
+            let _: () = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+                .await?;
             break;
         }
 
@@ -299,7 +306,8 @@ impl Item {
     async fn set_label(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, label: ClassInstanceRef<String>) -> JvmResult<()> {
         Self::check_owner_mutation(jvm, &this).await?;
         jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
-        Self::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_layout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -313,7 +321,8 @@ impl Item {
         }
 
         jvm.put_field(&mut this, "layout", "I", layout).await?;
-        Self::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_minimum_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -398,7 +407,8 @@ impl Item {
             if height < 0 { -1 } else { height.max(minimum_height) },
         )
         .await?;
-        Self::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn set_default_command(
@@ -431,7 +441,8 @@ impl Item {
 
         jvm.put_field(&mut this, "defaultCommand", "Ljavax/microedition/lcdui/Command;", command)
             .await?;
-        Self::invalidate(jvm, &this, false).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+            .await
     }
 
     async fn set_item_command_listener(
@@ -448,7 +459,8 @@ impl Item {
             listener,
         )
         .await?;
-        Self::invalidate(jvm, &this, false).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (false,))
+            .await
     }
 
     async fn notify_state_changed(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
@@ -669,37 +681,40 @@ impl Item {
         _this: ClassInstanceRef<Self>,
         _width: i32,
     ) -> JvmResult<ClassInstanceRef<Array<i32>>> {
-        Ok(ClassInstanceRef::new(None))
+        Ok(None.into())
     }
 
-    pub async fn focus_bounds(
+    async fn focus_bounds(
         jvm: &Jvm,
         context: &mut WieJvmContext,
-        this: &ClassInstanceRef<Self>,
+        this: ClassInstanceRef<Self>,
         width: i32,
         height: i32,
-    ) -> JvmResult<(i32, i32)> {
+    ) -> JvmResult<ClassInstanceRef<Array<i32>>> {
         let bounds: ClassInstanceRef<Array<i32>> = jvm
-            .invoke_virtual(this, "javax/microedition/lcdui/Item", "getFocusContentBounds", "(I)[I", (width,))
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getFocusContentBounds", "(I)[I", (width,))
             .await?;
-        if bounds.is_null() {
-            return Ok((0, height));
-        }
-
-        let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
-        let label = Self::label_text(jvm, this).await?;
-        let label_height = label
-            .as_deref()
-            .map(|label| Font::wrap(context.system().platform().font(), label, Some(width)).len() as i32 * Font::HEIGHT)
-            .unwrap_or(0)
-            .min(height);
-        let content_y = label_height
-            + if label_height > 0 {
-                LABEL_CONTENT_GAP.min(height - label_height)
-            } else {
-                0
-            };
-        Ok(((content_y + bounds[0]).min(height), (content_y + bounds[1]).min(height)))
+        let bounds = if bounds.is_null() {
+            [0, height]
+        } else {
+            let bounds = jvm.load_array::<i32>(&bounds, 0, 2).await?;
+            let label = Self::label_text(jvm, &this).await?;
+            let label_height = label
+                .as_deref()
+                .map(|label| Font::wrap(context.system().platform().font(), label, Some(width)).len() as i32 * Font::HEIGHT)
+                .unwrap_or(0)
+                .min(height);
+            let content_y = label_height
+                + if label_height > 0 {
+                    LABEL_CONTENT_GAP.min(height - label_height)
+                } else {
+                    0
+                };
+            [(content_y + bounds[0]).min(height), (content_y + bounds[1]).min(height)]
+        };
+        let mut result = jvm.instantiate_array("I", 2).await?;
+        jvm.store_array(&mut result, 0, bounds).await?;
+        Ok(result.into())
     }
 
     async fn dispatch_command(
@@ -753,9 +768,10 @@ impl Item {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn paint_appearance(
+    async fn paint_appearance(
         jvm: &Jvm,
-        graphics: &ClassInstanceRef<Graphics>,
+        _context: &mut WieJvmContext,
+        graphics: ClassInstanceRef<Graphics>,
         x: i32,
         y: i32,
         width: i32,
@@ -769,10 +785,10 @@ impl Item {
         match appearance_mode {
             1 => {
                 let _: () = jvm
-                    .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (Self::LINK_COLOR,))
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (Self::LINK_COLOR,))
                     .await?;
                 jvm.invoke_virtual(
-                    graphics,
+                    &graphics,
                     "javax/microedition/lcdui/Graphics",
                     "drawLine",
                     "(IIII)V",
@@ -782,11 +798,11 @@ impl Item {
             }
             2 => {
                 let _: () = jvm
-                    .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BUTTON_BACKGROUND,))
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BUTTON_BACKGROUND,))
                     .await?;
                 let _: () = jvm
                     .invoke_virtual(
-                        graphics,
+                        &graphics,
                         "javax/microedition/lcdui/Graphics",
                         "fillRect",
                         "(IIII)V",
@@ -794,10 +810,10 @@ impl Item {
                     )
                     .await?;
                 let _: () = jvm
-                    .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BUTTON_BORDER,))
+                    .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BUTTON_BORDER,))
                     .await?;
                 jvm.invoke_virtual(
-                    graphics,
+                    &graphics,
                     "javax/microedition/lcdui/Graphics",
                     "drawRect",
                     "(IIII)V",
@@ -829,7 +845,7 @@ mod test {
                 .new_class(
                     "javax/microedition/lcdui/StringItem",
                     "(Ljava/lang/String;Ljava/lang/String;)V",
-                    (ClassInstanceRef::<String>::new(None), text.clone()),
+                    (None, text.clone()),
                 )
                 .await?
                 .into();

--- a/wie-midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item.rs
@@ -68,6 +68,33 @@ impl Item {
                     MethodAccessFlags::PUBLIC,
                 ),
                 JavaMethodProto::new("notifyStateChanged", "()V", Self::notify_state_changed, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "getOwner",
+                    "()Ljavax/microedition/lcdui/Displayable;",
+                    Self::get_owner,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "setOwner",
+                    "(Ljavax/microedition/lcdui/Displayable;)V",
+                    Self::set_owner,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("getCommandCount", "()I", Self::get_command_count, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "getCommandAt",
+                    "(I)Ljavax/microedition/lcdui/Command;",
+                    Self::get_command_at,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "dispatchDefaultCommand",
+                    "()V",
+                    Self::dispatch_default_command,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("hasPreferredSize", "()Z", Self::has_preferred_size, MethodAccessFlags::empty()),
+                JavaMethodProto::new("canBeAlertIndicator", "()Z", Self::can_be_alert_indicator, MethodAccessFlags::empty()),
                 JavaMethodProto::new("invalidate", "(Z)V", Self::invalidate, MethodAccessFlags::empty()),
                 JavaMethodProto::new("measureWidth", "(I)I", Self::measure_width, MethodAccessFlags::empty()),
                 JavaMethodProto::new("measureHeight", "(I)I", Self::measure_height, MethodAccessFlags::empty()),
@@ -192,6 +219,72 @@ impl Item {
         jvm.put_field(&mut this, "preferredHeight", "I", -1).await?;
 
         Ok(())
+    }
+
+    async fn get_owner(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Displayable>> {
+        jvm.get_field(&this, "owner", "Ljavax/microedition/lcdui/Displayable;").await
+    }
+
+    async fn set_owner(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        owner: ClassInstanceRef<Displayable>,
+    ) -> JvmResult<()> {
+        jvm.put_field(&mut this, "owner", "Ljavax/microedition/lcdui/Displayable;", owner).await
+    }
+
+    async fn get_command_count(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await
+    }
+
+    async fn get_command_at(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        index: i32,
+    ) -> JvmResult<ClassInstanceRef<Command>> {
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&commands, "java/util/Vector", "elementAt", "(I)Ljava/lang/Object;", (index,))
+            .await
+    }
+
+    async fn dispatch_default_command(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let command: ClassInstanceRef<Command> = jvm.get_field(&this, "defaultCommand", "Ljavax/microedition/lcdui/Command;").await?;
+        if !command.is_null() {
+            let _: () = jvm
+                .invoke_virtual(
+                    &this,
+                    "javax/microedition/lcdui/Item",
+                    "dispatchCommand",
+                    "(Ljavax/microedition/lcdui/Command;)V",
+                    (command,),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn has_preferred_size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        let width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
+        let height: i32 = jvm.get_field(&this, "preferredHeight", "I").await?;
+        Ok(width != -1 || height != -1)
+    }
+
+    async fn can_be_alert_indicator(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        let owner: ClassInstanceRef<Displayable> = jvm.get_field(&this, "owner", "Ljavax/microedition/lcdui/Displayable;").await?;
+        let commands: ClassInstanceRef<Vector> = jvm.get_field(&this, "commands", "Ljava/util/Vector;").await?;
+        let command_count: i32 = jvm.invoke_virtual(&commands, "java/util/Vector", "size", "()I", ()).await?;
+        let listener: ClassInstanceRef<ItemCommandListener> = jvm
+            .get_field(&this, "itemCommandListener", "Ljavax/microedition/lcdui/ItemCommandListener;")
+            .await?;
+        let label: ClassInstanceRef<String> = jvm.get_field(&this, "label", "Ljava/lang/String;").await?;
+        let preferred: bool = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "hasPreferredSize", "()Z", ())
+            .await?;
+        let layout: i32 = jvm.get_field(&this, "layout", "I").await?;
+        Ok(owner.is_null() && command_count == 0 && listener.is_null() && label.is_null() && !preferred && layout == 0)
     }
 
     async fn check_owner_mutation(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<()> {

--- a/wie-midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item.rs
@@ -5,6 +5,7 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::{lang::String, util::Vector};
 
+use wie_backend::text_layout::{minimum_width, preferred_width, wrap};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::lcdui::{Command, Displayable, Font, Graphics, ItemCommandListener};
@@ -141,28 +142,92 @@ impl Item {
                     MethodAccessFlags::empty(),
                 ),
             ],
-            fields: [
-                "LAYOUT_DEFAULT",
-                "LAYOUT_LEFT",
-                "LAYOUT_RIGHT",
-                "LAYOUT_CENTER",
-                "LAYOUT_TOP",
-                "LAYOUT_BOTTOM",
-                "LAYOUT_VCENTER",
-                "LAYOUT_NEWLINE_BEFORE",
-                "LAYOUT_NEWLINE_AFTER",
-                "LAYOUT_SHRINK",
-                "LAYOUT_EXPAND",
-                "LAYOUT_VSHRINK",
-                "LAYOUT_VEXPAND",
-                "LAYOUT_2",
-                "PLAIN",
-                "HYPERLINK",
-                "BUTTON",
-            ]
-            .into_iter()
-            .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-            .chain([
+            fields: vec![
+                JavaFieldProto::new(
+                    "LAYOUT_DEFAULT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_LEFT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_RIGHT",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_CENTER",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_TOP",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_BOTTOM",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_VCENTER",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_NEWLINE_BEFORE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_NEWLINE_AFTER",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_SHRINK",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_EXPAND",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_VSHRINK",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_VEXPAND",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "LAYOUT_2",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "PLAIN",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "HYPERLINK",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "BUTTON",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
                 JavaFieldProto::new("owner", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("label", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("layout", "I", FieldAccessFlags::PRIVATE),
@@ -175,8 +240,7 @@ impl Item {
                     "Ljavax/microedition/lcdui/ItemCommandListener;",
                     FieldAccessFlags::PRIVATE,
                 ),
-            ])
-            .collect(),
+            ],
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
     }
@@ -426,7 +490,7 @@ impl Item {
         let label = Self::label_text(jvm, &this).await?;
         let label_width = label
             .as_deref()
-            .map(|text| Font::minimum_width(context.system().platform().font(), text))
+            .map(|text| minimum_width(context.system().platform().font(), text, 10.0))
             .unwrap_or(0);
         Ok(content_width.max(label_width))
     }
@@ -438,18 +502,18 @@ impl Item {
         let label = Self::label_text(jvm, &this).await?;
         let label_height = label
             .as_deref()
-            .map(|label| Font::wrap(context.system().platform().font(), label, None).len() as i32 * Font::HEIGHT)
+            .map(|label| wrap(context.system().platform().font(), label, 10.0, None).len() as i32 * Font::HEIGHT)
             .unwrap_or(0);
         Ok(label_height + content_height + if label_height > 0 && content_height > 0 { LABEL_CONTENT_GAP } else { 0 })
     }
 
     async fn get_preferred_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
-        let preferred_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
+        let locked_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
         let minimum_width: i32 = jvm
             .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumWidth", "()I", ())
             .await?;
-        if preferred_width >= 0 {
-            return Ok(preferred_width.max(minimum_width));
+        if locked_width >= 0 {
+            return Ok(locked_width.max(minimum_width));
         }
 
         let content_width: i32 = jvm
@@ -458,7 +522,7 @@ impl Item {
         let label = Self::label_text(jvm, &this).await?;
         let label_width = label
             .as_deref()
-            .map(|text| Font::preferred_width(context.system().platform().font(), text))
+            .map(|text| preferred_width(context.system().platform().font(), text, 10.0))
             .unwrap_or(0);
         Ok(content_width.max(label_width).max(minimum_width))
     }
@@ -645,7 +709,7 @@ impl Item {
         let label = Self::label_text(jvm, &this).await?;
         let label_lines = label
             .as_deref()
-            .map(|label| Font::wrap(context.system().platform().font(), label, Some(width)))
+            .map(|label| wrap(context.system().platform().font(), label, 10.0, Some(width)))
             .unwrap_or_default();
         let label_height = (label_lines.len() as i32 * Font::HEIGHT).min(height);
         if !label_lines.is_empty() {
@@ -797,7 +861,7 @@ impl Item {
             let label = Self::label_text(jvm, &this).await?;
             let label_height = label
                 .as_deref()
-                .map(|label| Font::wrap(context.system().platform().font(), label, Some(width)).len() as i32 * Font::HEIGHT)
+                .map(|label| wrap(context.system().platform().font(), label, 10.0, Some(width)).len() as i32 * Font::HEIGHT)
                 .unwrap_or(0)
                 .min(height);
             let content_y = label_height
@@ -851,7 +915,7 @@ impl Item {
         let label = Self::label_text(jvm, this).await?;
         let label_height = label
             .as_deref()
-            .map(|label| Font::wrap(context.system().platform().font(), label, Some(width.max(1))).len() as i32 * Font::HEIGHT)
+            .map(|label| wrap(context.system().platform().font(), label, 10.0, Some(width.max(1))).len() as i32 * Font::HEIGHT)
             .unwrap_or(0);
         let content_height: i32 = jvm
             .invoke_virtual(this, "javax/microedition/lcdui/Item", "preferredContentHeight", "(I)I", (width,))

--- a/wie-midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item.rs
@@ -69,6 +69,7 @@ impl Item {
                 ),
                 JavaMethodProto::new("notifyStateChanged", "()V", Self::notify_state_changed, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("invalidate", "(Z)V", Self::invalidate, MethodAccessFlags::empty()),
+                JavaMethodProto::new("measureWidth", "(I)I", Self::measure_width, MethodAccessFlags::empty()),
                 JavaMethodProto::new("measureHeight", "(I)I", Self::measure_height, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "paintItem",
@@ -479,6 +480,17 @@ impl Item {
         .await
     }
 
+    async fn measure_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, available_width: i32) -> JvmResult<i32> {
+        let layout: i32 = jvm.get_field(&this, "layout", "I").await?;
+        if layout & 0x800 != 0 {
+            return Ok(available_width.max(0));
+        }
+        let preferred_width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+            .await?;
+        Ok(preferred_width.min(available_width.max(0)))
+    }
+
     async fn measure_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
         let minimum_height: i32 = jvm
             .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumHeight", "()I", ())
@@ -494,16 +506,7 @@ impl Item {
         } else {
             width
         };
-        let preferred_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
-        let measured_width = if preferred_width >= 0 {
-            let minimum_width: i32 = jvm
-                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getMinimumWidth", "()I", ())
-                .await?;
-            available_width.min(preferred_width.max(minimum_width))
-        } else {
-            available_width
-        };
-        Ok(Self::natural_height(jvm, context, &this, measured_width).await?.max(minimum_height))
+        Ok(Self::natural_height(jvm, context, &this, available_width).await?.max(minimum_height))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/wie-midp/src/classes/javax/microedition/lcdui/item_command_listener.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item_command_listener.rs
@@ -1,0 +1,26 @@
+use alloc::vec;
+
+use jvm_class_proto::JavaMethodProto;
+use jvm_types::{ClassAccessFlags, MethodAccessFlags};
+
+use wie_jvm_support::WieJavaClassProto;
+
+// interface javax.microedition.lcdui.ItemCommandListener
+pub struct ItemCommandListener;
+
+impl ItemCommandListener {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/ItemCommandListener",
+            parent_class: None,
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new_abstract(
+                "commandAction",
+                "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+            )],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
+        }
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/item_state_listener.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item_state_listener.rs
@@ -1,0 +1,26 @@
+use alloc::vec;
+
+use jvm_class_proto::JavaMethodProto;
+use jvm_types::{ClassAccessFlags, MethodAccessFlags};
+
+use wie_jvm_support::WieJavaClassProto;
+
+// interface javax.microedition.lcdui.ItemStateListener
+pub struct ItemStateListener;
+
+impl ItemStateListener {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/ItemStateListener",
+            parent_class: None,
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new_abstract(
+                "itemStateChanged",
+                "(Ljavax/microedition/lcdui/Item;)V",
+                MethodAccessFlags::PUBLIC | MethodAccessFlags::ABSTRACT,
+            )],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::INTERFACE | ClassAccessFlags::ABSTRACT,
+        }
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/screen.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/screen.rs
@@ -6,6 +6,8 @@ use jvm_types::{ClassAccessFlags, MethodAccessFlags};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
+use crate::classes::javax::microedition::lcdui::Graphics;
+
 // class javax.microedition.lcdui.Screen
 pub struct Screen;
 
@@ -15,7 +17,15 @@ impl Screen {
             name: "javax/microedition/lcdui/Screen",
             parent_class: Some("javax/microedition/lcdui/Displayable"),
             interfaces: vec![],
-            methods: vec![JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PROTECTED)],
+            methods: vec![
+                JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "handlePaintEvent",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    Self::handle_paint_event,
+                    MethodAccessFlags::empty(),
+                ),
+            ],
             fields: vec![],
             access_flags: ClassAccessFlags::PUBLIC | ClassAccessFlags::ABSTRACT,
         }
@@ -29,5 +39,33 @@ impl Screen {
             .await?;
 
         Ok(())
+    }
+
+    async fn handle_paint_event(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+    ) -> JvmResult<()> {
+        let width: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "getWidth", "()I", ())
+            .await?;
+        let height: i32 = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Displayable", "getHeight", "()I", ())
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0xffffff,))
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "fillRect",
+                "(IIII)V",
+                (0, 0, width, height),
+            )
+            .await?;
+        jvm.invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0,))
+            .await
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
@@ -94,7 +94,9 @@ impl StringItem {
         }
 
         let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
-        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        let _: () = jvm
+            .invoke_special(&this, "javax/microedition/lcdui/Item", "setLabel", "(Ljava/lang/String;)V", (label,))
+            .await?;
         jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
         jvm.put_field(&mut this, "appearanceMode", "I", appearance_mode).await?;
         jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", None).await?;
@@ -138,10 +140,11 @@ impl StringItem {
     }
 
     async fn measure_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, available_width: i32) -> JvmResult<i32> {
-        let preferred_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
-        let preferred_height: i32 = jvm.get_field(&this, "preferredHeight", "I").await?;
+        let preferred: bool = jvm
+            .invoke_virtual(&this, "javax/microedition/lcdui/Item", "hasPreferredSize", "()Z", ())
+            .await?;
         // MIDP ignores shrink/expand directives on a StringItem with either dimension locked.
-        if preferred_width >= 0 || preferred_height >= 0 {
+        if preferred {
             let width: i32 = jvm
                 .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
                 .await?;

--- a/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
@@ -34,6 +34,7 @@ impl StringItem {
                 JavaMethodProto::new("setFont", "(Ljavax/microedition/lcdui/Font;)V", Self::set_font, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("getFont", "()Ljavax/microedition/lcdui/Font;", Self::get_font, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("setPreferredSize", "(II)V", Self::set_preferred_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("measureWidth", "(I)I", Self::measure_width, MethodAccessFlags::empty()),
                 JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
                 JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
                 JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
@@ -133,6 +134,20 @@ impl StringItem {
 
     async fn set_preferred_size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
         jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "setPreferredSize", "(II)V", (width, height))
+            .await
+    }
+
+    async fn measure_width(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, available_width: i32) -> JvmResult<i32> {
+        let preferred_width: i32 = jvm.get_field(&this, "preferredWidth", "I").await?;
+        let preferred_height: i32 = jvm.get_field(&this, "preferredHeight", "I").await?;
+        // MIDP ignores shrink/expand directives on a StringItem with either dimension locked.
+        if preferred_width >= 0 || preferred_height >= 0 {
+            let width: i32 = jvm
+                .invoke_virtual(&this, "javax/microedition/lcdui/Item", "getPreferredWidth", "()I", ())
+                .await?;
+            return Ok(width.min(available_width.max(0)));
+        }
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "measureWidth", "(I)I", (available_width,))
             .await
     }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
@@ -1,0 +1,445 @@
+use alloc::{string::String as RustString, vec};
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::lang::String;
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::lcdui::{Font, Graphics, Item};
+
+const LEFT_TOP: i32 = 4 | 16;
+
+// class javax.microedition.lcdui.StringItem
+pub struct StringItem;
+
+impl StringItem {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/StringItem",
+            parent_class: Some("javax/microedition/lcdui/Item"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljava/lang/String;Ljava/lang/String;I)V",
+                    Self::init_with_appearance,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("getText", "()Ljava/lang/String;", Self::get_text, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setText", "(Ljava/lang/String;)V", Self::set_text, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getAppearanceMode", "()I", Self::get_appearance_mode, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setFont", "(Ljavax/microedition/lcdui/Font;)V", Self::set_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getFont", "()Ljavax/microedition/lcdui/Font;", Self::get_font, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setPreferredSize", "(II)V", Self::set_preferred_size, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("minimumContentWidth", "()I", Self::minimum_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new("minimumContentHeight", "()I", Self::minimum_content_height, MethodAccessFlags::empty()),
+                JavaMethodProto::new("preferredContentWidth", "()I", Self::preferred_content_width, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "preferredContentHeight",
+                    "(I)I",
+                    Self::preferred_content_height,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new(
+                    "paintContent",
+                    "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+                    Self::paint_content,
+                    MethodAccessFlags::empty(),
+                ),
+                JavaMethodProto::new("isFocusable", "()Z", Self::is_focusable, MethodAccessFlags::empty()),
+                JavaMethodProto::new("handleItemKey", "(I)I", Self::handle_item_key, MethodAccessFlags::empty()),
+            ],
+            fields: vec![
+                JavaFieldProto::new("text", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("appearanceMode", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("font", "Ljavax/microedition/lcdui/Font;", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        label: ClassInstanceRef<String>,
+        text: ClassInstanceRef<String>,
+    ) -> JvmResult<()> {
+        jvm.invoke_special(
+            &this,
+            "javax/microedition/lcdui/StringItem",
+            "<init>",
+            "(Ljava/lang/String;Ljava/lang/String;I)V",
+            (label, text, 0),
+        )
+        .await
+    }
+
+    async fn init_with_appearance(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        label: ClassInstanceRef<String>,
+        text: ClassInstanceRef<String>,
+        appearance_mode: i32,
+    ) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.StringItem::<init>({this:?}, {label:?}, {text:?}, {appearance_mode})");
+
+        if !(0..=2).contains(&appearance_mode) {
+            return Err(jvm.exception("java/lang/IllegalArgumentException", "Invalid appearance mode").await);
+        }
+
+        let _: () = jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "appearanceMode", "I", appearance_mode).await?;
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", ClassInstanceRef::<Font>::new(None))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn get_text(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        jvm.get_field(&this, "text", "Ljava/lang/String;").await
+    }
+
+    async fn set_text(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_appearance_mode(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        jvm.get_field(&this, "appearanceMode", "I").await
+    }
+
+    async fn set_font(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, font: ClassInstanceRef<Font>) -> JvmResult<()> {
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", font).await?;
+        Item::invalidate(jvm, &this, true).await
+    }
+
+    async fn get_font(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Font>> {
+        let font: ClassInstanceRef<Font> = jvm.get_field(&this, "font", "Ljavax/microedition/lcdui/Font;").await?;
+        if font.is_null() {
+            jvm.invoke_static("javax/microedition/lcdui/Font", "getDefaultFont", "()Ljavax/microedition/lcdui/Font;", ())
+                .await
+        } else {
+            Ok(font)
+        }
+    }
+
+    async fn set_preferred_size(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32, height: i32) -> JvmResult<()> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "setPreferredSize", "(II)V", (width, height))
+            .await
+    }
+
+    async fn minimum_content_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let Some(text) = Self::text(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        let text_width = if appearance_mode == 2 {
+            Font::preferred_width(context.system().platform().font(), &text)
+        } else {
+            Font::minimum_width(context.system().platform().font(), &text)
+        };
+        Ok(text_width + Item::appearance_inset(appearance_mode) * 2)
+    }
+
+    async fn minimum_content_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let Some(text) = Self::text(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        Ok(Font::wrap(context.system().platform().font(), &text, None).len() as i32 * Font::HEIGHT + Item::appearance_inset(appearance_mode) * 2)
+    }
+
+    async fn preferred_content_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
+        let Some(text) = Self::text(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        Ok(Font::preferred_width(context.system().platform().font(), &text) + Item::appearance_inset(appearance_mode) * 2)
+    }
+
+    async fn preferred_content_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
+        let Some(text) = Self::text(jvm, &this).await? else {
+            return Ok(0);
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        let inset = Item::appearance_inset(appearance_mode);
+        let wrap_width = if appearance_mode == 2 || width < 0 {
+            None
+        } else {
+            Some((width - inset * 2).max(1))
+        };
+        Ok(Font::wrap(context.system().platform().font(), &text, wrap_width).len() as i32 * Font::HEIGHT + inset * 2)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn paint_content(
+        jvm: &Jvm,
+        context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        _focused: bool,
+    ) -> JvmResult<()> {
+        let Some(text) = Self::text(jvm, &this).await? else {
+            return Ok(());
+        };
+        let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
+        Item::paint_appearance(jvm, &graphics, x, y, width, height, appearance_mode).await?;
+
+        let inset = Item::appearance_inset(appearance_mode);
+        let content_x = x + inset;
+        let content_y = y + inset;
+        let content_width = (width - inset * 2).max(0);
+        let content_height = (height - inset * 2).max(0);
+        if content_width == 0 || content_height == 0 {
+            return Ok(());
+        }
+
+        let font: ClassInstanceRef<Font> = jvm
+            .invoke_virtual(
+                &this,
+                "javax/microedition/lcdui/StringItem",
+                "getFont",
+                "()Ljavax/microedition/lcdui/Font;",
+                (),
+            )
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "setFont",
+                "(Ljavax/microedition/lcdui/Font;)V",
+                (font,),
+            )
+            .await?;
+        let color = if appearance_mode == 1 { Item::LINK_COLOR } else { Item::TEXT_COLOR };
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+            .await?;
+        let wrap_width = if appearance_mode == 2 { None } else { Some(content_width.max(1)) };
+        for (index, line) in Font::wrap(context.system().platform().font(), &text, wrap_width).iter().enumerate() {
+            let line_y = content_y + index as i32 * Font::HEIGHT;
+            if line_y >= content_y + content_height {
+                break;
+            }
+            let java_line = JavaLangString::from_rust_string(jvm, line).await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "drawString",
+                    "(Ljava/lang/String;III)V",
+                    (java_line, content_x, line_y, LEFT_TOP),
+                )
+                .await?;
+            if appearance_mode == 1 && !line.is_empty() {
+                let line_width = Font::text_width(context.system().platform().font(), line).min(content_width);
+                let underline_y = (line_y + Font::HEIGHT - 1).min(content_y + content_height - 1);
+                let _: () = jvm
+                    .invoke_virtual(
+                        &graphics,
+                        "javax/microedition/lcdui/Graphics",
+                        "drawLine",
+                        "(IIII)V",
+                        (content_x, underline_y, content_x + line_width.saturating_sub(1), underline_y),
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn is_focusable(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        jvm.invoke_special(&this, "javax/microedition/lcdui/Item", "isFocusable", "()Z", ()).await
+    }
+
+    async fn handle_item_key(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>, _key: i32) -> JvmResult<i32> {
+        Ok(0)
+    }
+
+    async fn text(jvm: &Jvm, this: &ClassInstanceRef<Self>) -> JvmResult<Option<RustString>> {
+        let text: ClassInstanceRef<String> = jvm.get_field(this, "text", "Ljava/lang/String;").await?;
+        if text.is_null() {
+            return Ok(None);
+        }
+
+        let text = JavaLangString::to_rust_string(jvm, &text).await?;
+        Ok((!text.is_empty()).then_some(text))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::boxed::Box;
+
+    use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use rustjava_runtime::classes::java::lang::String;
+    use test_utils::run_jvm_test;
+    use wie_util::Result;
+
+    use crate::{
+        classes::javax::microedition::lcdui::{Font, Graphics, Image, StringItem},
+        get_protos,
+    };
+
+    async fn create_image_and_graphics(jvm: &Jvm, width: i32, height: i32) -> JvmResult<(ClassInstanceRef<Image>, ClassInstanceRef<Graphics>)> {
+        let image: ClassInstanceRef<Image> = jvm
+            .invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(II)Ljavax/microedition/lcdui/Image;",
+                (width, height),
+            )
+            .await?;
+        let graphics: ClassInstanceRef<Graphics> = jvm
+            .invoke_virtual(
+                &image,
+                "javax/microedition/lcdui/Image",
+                "getGraphics",
+                "()Ljavax/microedition/lcdui/Graphics;",
+                (),
+            )
+            .await?;
+        Ok((image, graphics))
+    }
+
+    async fn fill(jvm: &Jvm, graphics: &ClassInstanceRef<Graphics>, color: i32, width: i32, height: i32) -> JvmResult<()> {
+        let _: () = jvm
+            .invoke_virtual(graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
+            .await?;
+        jvm.invoke_virtual(
+            graphics,
+            "javax/microedition/lcdui/Graphics",
+            "fillRect",
+            "(IIII)V",
+            (0, 0, width, height),
+        )
+        .await
+    }
+
+    async fn paint_item<T>(
+        jvm: &Jvm,
+        item: &ClassInstanceRef<T>,
+        graphics: ClassInstanceRef<Graphics>,
+        bounds: (i32, i32, i32, i32),
+        focused: bool,
+    ) -> JvmResult<()> {
+        let (x, y, width, height) = bounds;
+        jvm.invoke_virtual(
+            item,
+            "javax/microedition/lcdui/Item",
+            "paintItem",
+            "(Ljavax/microedition/lcdui/Graphics;IIIIZ)V",
+            (graphics, x, y, width, height, focused),
+        )
+        .await
+    }
+
+    #[test]
+    fn string_item_renders_newlines_wrapping_appearance_focus_and_requested_font() -> Result<()> {
+        run_jvm_test(Box::new([get_protos().into()]), |jvm| async move {
+            let text = ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(&jvm, "first line\nsecond line wraps here").await?);
+            let hyperlink: ClassInstanceRef<StringItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/StringItem",
+                    "(Ljava/lang/String;Ljava/lang/String;I)V",
+                    (ClassInstanceRef::<String>::new(None), text, 1),
+                )
+                .await?
+                .into();
+            let custom_font: ClassInstanceRef<Font> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Font",
+                    "getFont",
+                    "(III)Ljavax/microedition/lcdui/Font;",
+                    (0, 1, 8),
+                )
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(
+                    &hyperlink,
+                    "javax/microedition/lcdui/StringItem",
+                    "setFont",
+                    "(Ljavax/microedition/lcdui/Font;)V",
+                    (custom_font.clone(),),
+                )
+                .await?;
+            let wrapped_height: i32 = jvm
+                .invoke_virtual(&hyperlink, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (54,))
+                .await?;
+            assert!(wrapped_height >= 36, "explicit newline and width wrapping must both be preserved");
+
+            let (hyperlink_image, hyperlink_graphics) = create_image_and_graphics(&jvm, 80, 70).await?;
+            fill(&jvm, &hyperlink_graphics, 0xffffff, 80, 70).await?;
+            paint_item(&jvm, &hyperlink, hyperlink_graphics.clone(), (4, 4, 54, wrapped_height), true).await?;
+            let active_font: ClassInstanceRef<Font> = jvm
+                .invoke_virtual(
+                    &hyperlink_graphics,
+                    "javax/microedition/lcdui/Graphics",
+                    "getFont",
+                    "()Ljavax/microedition/lcdui/Font;",
+                    (),
+                )
+                .await?;
+            assert_eq!(
+                active_font.identity(),
+                custom_font.identity(),
+                "StringItem paint must select its requested font"
+            );
+
+            let hyperlink_pixels = Image::image(&jvm, &hyperlink_image).await?;
+            let blue_pixels = (4..58)
+                .flat_map(|x| (4..(4 + wrapped_height).min(70)).map(move |y| (x, y)))
+                .filter(|&(x, y)| {
+                    let color = hyperlink_pixels.get_pixel(x, y);
+                    color.b > color.r && color.b > color.g
+                })
+                .count();
+            assert!(blue_pixels > 8, "hyperlink text and underline must be visibly styled");
+            let focus_corner = hyperlink_pixels.get_pixel(4, 4);
+            assert_eq!((focus_corner.r, focus_corner.g, focus_corner.b), (0x2f, 0x6f, 0x9f));
+
+            let button_text = ClassInstanceRef::<String>::from(JavaLangString::from_rust_string(&jvm, "button text that does not wrap").await?);
+            let button: ClassInstanceRef<StringItem> = jvm
+                .new_class(
+                    "javax/microedition/lcdui/StringItem",
+                    "(Ljava/lang/String;Ljava/lang/String;I)V",
+                    (ClassInstanceRef::<String>::new(None), button_text, 2),
+                )
+                .await?
+                .into();
+            let button_narrow_height: i32 = jvm
+                .invoke_virtual(&button, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (35,))
+                .await?;
+            let button_wide_height: i32 = jvm
+                .invoke_virtual(&button, "javax/microedition/lcdui/Item", "measureHeight", "(I)I", (180,))
+                .await?;
+            assert_eq!(button_narrow_height, button_wide_height, "button appearance must not width-wrap text");
+
+            let (button_image, button_graphics) = create_image_and_graphics(&jvm, 90, 30).await?;
+            fill(&jvm, &button_graphics, 0xffffff, 90, 30).await?;
+            paint_item(&jvm, &button, button_graphics, (5, 5, 70, button_narrow_height), false).await?;
+            let button_pixels = Image::image(&jvm, &button_image).await?;
+            let border = button_pixels.get_pixel(5, 5);
+            assert_ne!(
+                (border.r, border.g, border.b),
+                (0xff, 0xff, 0xff),
+                "button appearance must render a border"
+            );
+
+            Ok(())
+        })
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
@@ -5,6 +5,10 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
+use wie_backend::{
+    canvas::string_width,
+    text_layout::{minimum_width, preferred_width, wrap},
+};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::lcdui::{Font, Graphics, Item};
@@ -160,9 +164,9 @@ impl StringItem {
         };
         let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
         let text_width = if appearance_mode == 2 {
-            Font::preferred_width(context.system().platform().font(), &text)
+            preferred_width(context.system().platform().font(), &text, 10.0)
         } else {
-            Font::minimum_width(context.system().platform().font(), &text)
+            minimum_width(context.system().platform().font(), &text, 10.0)
         };
         Ok(text_width + Item::appearance_inset(appearance_mode) * 2)
     }
@@ -172,7 +176,7 @@ impl StringItem {
             return Ok(0);
         };
         let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
-        Ok(Font::wrap(context.system().platform().font(), &text, None).len() as i32 * Font::HEIGHT + Item::appearance_inset(appearance_mode) * 2)
+        Ok(wrap(context.system().platform().font(), &text, 10.0, None).len() as i32 * Font::HEIGHT + Item::appearance_inset(appearance_mode) * 2)
     }
 
     async fn preferred_content_width(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -180,7 +184,7 @@ impl StringItem {
             return Ok(0);
         };
         let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
-        Ok(Font::preferred_width(context.system().platform().font(), &text) + Item::appearance_inset(appearance_mode) * 2)
+        Ok(preferred_width(context.system().platform().font(), &text, 10.0) + Item::appearance_inset(appearance_mode) * 2)
     }
 
     async fn preferred_content_height(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, width: i32) -> JvmResult<i32> {
@@ -194,7 +198,7 @@ impl StringItem {
         } else {
             Some((width - inset * 2).max(1))
         };
-        Ok(Font::wrap(context.system().platform().font(), &text, wrap_width).len() as i32 * Font::HEIGHT + inset * 2)
+        Ok(wrap(context.system().platform().font(), &text, 10.0, wrap_width).len() as i32 * Font::HEIGHT + inset * 2)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -254,7 +258,7 @@ impl StringItem {
             .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (color,))
             .await?;
         let wrap_width = if appearance_mode == 2 { None } else { Some(content_width.max(1)) };
-        for (index, line) in Font::wrap(context.system().platform().font(), &text, wrap_width).iter().enumerate() {
+        for (index, line) in wrap(context.system().platform().font(), &text, 10.0, wrap_width).iter().enumerate() {
             let line_y = content_y + index as i32 * Font::HEIGHT;
             if line_y >= content_y + content_height {
                 break;
@@ -270,7 +274,7 @@ impl StringItem {
                 )
                 .await?;
             if appearance_mode == 1 && !line.is_empty() {
-                let line_width = Font::text_width(context.system().platform().font(), line).min(content_width);
+                let line_width = (string_width(context.system().platform().font(), line, 10.0).ceil() as i32).min(content_width);
                 let underline_y = (line_y + Font::HEIGHT - 1).min(content_y + content_height - 1);
                 let _: () = jvm
                     .invoke_virtual(

--- a/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/string_item.rs
@@ -96,8 +96,7 @@ impl StringItem {
         jvm.put_field(&mut this, "label", "Ljava/lang/String;", label).await?;
         jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
         jvm.put_field(&mut this, "appearanceMode", "I", appearance_mode).await?;
-        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", ClassInstanceRef::<Font>::new(None))
-            .await?;
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", None).await?;
 
         Ok(())
     }
@@ -108,7 +107,8 @@ impl StringItem {
 
     async fn set_text(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
         jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_appearance_mode(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<i32> {
@@ -117,7 +117,8 @@ impl StringItem {
 
     async fn set_font(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, font: ClassInstanceRef<Font>) -> JvmResult<()> {
         jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", font).await?;
-        Item::invalidate(jvm, &this, true).await
+        jvm.invoke_virtual(&this, "javax/microedition/lcdui/Item", "invalidate", "(Z)V", (true,))
+            .await
     }
 
     async fn get_font(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<Font>> {
@@ -194,7 +195,14 @@ impl StringItem {
             return Ok(());
         };
         let appearance_mode: i32 = jvm.get_field(&this, "appearanceMode", "I").await?;
-        Item::paint_appearance(jvm, &graphics, x, y, width, height, appearance_mode).await?;
+        let _: () = jvm
+            .invoke_static(
+                "javax/microedition/lcdui/Item",
+                "paintAppearance",
+                "(Ljavax/microedition/lcdui/Graphics;IIIII)V",
+                (graphics.clone(), x, y, width, height, appearance_mode),
+            )
+            .await?;
 
         let inset = Item::appearance_inset(appearance_mode);
         let content_x = x + inset;
@@ -355,7 +363,7 @@ mod test {
                 .new_class(
                     "javax/microedition/lcdui/StringItem",
                     "(Ljava/lang/String;Ljava/lang/String;I)V",
-                    (ClassInstanceRef::<String>::new(None), text, 1),
+                    (None, text, 1),
                 )
                 .await?
                 .into();
@@ -416,7 +424,7 @@ mod test {
                 .new_class(
                     "javax/microedition/lcdui/StringItem",
                     "(Ljava/lang/String;Ljava/lang/String;I)V",
-                    (ClassInstanceRef::<String>::new(None), button_text, 2),
+                    (None, button_text, 2),
                 )
                 .await?
                 .into();

--- a/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
@@ -51,7 +51,7 @@ impl Ticker {
         jvm.get_field(&this, "text", "Ljava/lang/String;").await
     }
 
-    async fn set_string(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
+    async fn set_string(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
         tracing::debug!("javax.microedition.lcdui.Ticker::setString({this:?}, {text:?})");
 
         if text.is_null() {
@@ -73,9 +73,19 @@ impl Ticker {
                     (midlet,),
                 )
                 .await?;
-            let ticker = Display::visible_ticker(jvm, context, &display).await?;
+            let ticker: ClassInstanceRef<Ticker> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getVisibleTicker",
+                    "()Ljavax/microedition/lcdui/Ticker;",
+                    (),
+                )
+                .await?;
             if !ticker.is_null() && ticker.identity() == this.identity() {
-                Display::ticker_changed(jvm, context, display.clone()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "tickerChanged", "()V", ())
+                    .await?;
                 let _: () = jvm
                     .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
                     .await?;

--- a/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
@@ -1,0 +1,305 @@
+use alloc::vec;
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::lang::String;
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::{lcdui::Display, midlet::MIDlet};
+
+// class javax.microedition.lcdui.Ticker
+pub struct Ticker;
+
+impl Ticker {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "javax/microedition/lcdui/Ticker",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![
+                JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("getString", "()Ljava/lang/String;", Self::get_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, MethodAccessFlags::PUBLIC),
+            ],
+            fields: vec![
+                JavaFieldProto::new("text", "Ljava/lang/String;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("scrollOffset", "I", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Ticker::<init>({this:?}, {text:?})");
+
+        if text.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Ticker text is null").await);
+        }
+
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "scrollOffset", "I", 0).await?;
+
+        Ok(())
+    }
+
+    async fn get_string(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<ClassInstanceRef<String>> {
+        tracing::debug!("javax.microedition.lcdui.Ticker::getString({this:?})");
+
+        jvm.get_field(&this, "text", "Ljava/lang/String;").await
+    }
+
+    async fn set_string(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, text: ClassInstanceRef<String>) -> JvmResult<()> {
+        tracing::debug!("javax.microedition.lcdui.Ticker::setString({this:?}, {text:?})");
+
+        if text.is_null() {
+            return Err(jvm.exception("java/lang/NullPointerException", "Ticker text is null").await);
+        }
+
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "scrollOffset", "I", 0).await?;
+
+        let midlet: ClassInstanceRef<MIDlet> = jvm
+            .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+            .await?;
+        if !midlet.is_null() {
+            let display: ClassInstanceRef<Display> = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Display",
+                    "getDisplay",
+                    "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
+                    (midlet,),
+                )
+                .await?;
+            let ticker = Display::visible_ticker(jvm, context, &display).await?;
+            if !ticker.is_null() && ticker.identity() == this.identity() {
+                Display::ticker_changed(jvm, context, display.clone()).await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "repaint", "(IIII)V", (0, 0, -1, -1))
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec, vec::Vec};
+
+    use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+    use jvm_class_proto::JavaMethodProto;
+    use jvm_types::{ClassAccessFlags, MethodAccessFlags};
+    use test_utils::{TestClock, TestPlatform, run_jvm_test_with_system};
+
+    use wie_backend::{Event, System};
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_util::Result;
+
+    use crate::{
+        classes::javax::microedition::{
+            lcdui::{Display, Displayable, Image, Ticker},
+            midlet::MIDlet,
+        },
+        get_protos,
+    };
+
+    const DISPLAY: &str = "javax/microedition/lcdui/Display";
+    const DISPLAYABLE: &str = "javax/microedition/lcdui/Displayable";
+    const TICKER: &str = "javax/microedition/lcdui/Ticker";
+    const FORM: &str = "javax/microedition/lcdui/Form";
+
+    struct TickerMidlet;
+
+    impl TickerMidlet {
+        fn as_proto() -> WieJavaClassProto {
+            WieJavaClassProto {
+                name: "test/TickerMidlet",
+                parent_class: Some("javax/microedition/midlet/MIDlet"),
+                interfaces: vec![],
+                methods: vec![
+                    JavaMethodProto::new("<init>", "()V", Self::init, MethodAccessFlags::PUBLIC),
+                    JavaMethodProto::new("startApp", "()V", Self::start_app, MethodAccessFlags::PROTECTED),
+                ],
+                fields: vec![],
+                access_flags: ClassAccessFlags::PUBLIC,
+            }
+        }
+
+        async fn init(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            jvm.invoke_special(&this, "javax/microedition/midlet/MIDlet", "<init>", "()V", ()).await
+        }
+
+        async fn start_app(_jvm: &Jvm, _context: &mut WieJvmContext, _this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            Ok(())
+        }
+    }
+
+    async fn pump(jvm: &Jvm, system: &System, clock: &TestClock, millis: u64) -> JvmResult<()> {
+        clock.advance(millis);
+        system.event_queue().push(Event::Redraw);
+        let queue = jvm
+            .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+            .await?;
+        let event: ClassInstanceRef<Array<i32>> = jvm.instantiate_array("I", 4).await?.into();
+        jvm.invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event,)).await
+    }
+
+    async fn pixels(jvm: &Jvm, display: &ClassInstanceRef<Display>) -> JvmResult<Vec<u8>> {
+        let _: () = jvm.invoke_virtual(display, DISPLAY, "handlePaintEvent", "()V", ()).await?;
+        let image: ClassInstanceRef<Image> = jvm.get_field(display, "screenImage", "Ljavax/microedition/lcdui/Image;").await?;
+        Ok(Image::image(jvm, &image).await?.raw().into_owned())
+    }
+
+    #[test]
+    fn ticker_scrolls_on_the_current_screen_without_retaining_previous_screens() -> Result<()> {
+        let clock = TestClock::new();
+        run_jvm_test_with_system(
+            Box::new([get_protos().into(), [TickerMidlet::as_proto()].into()]),
+            Box::new(TestPlatform::with_clock(clock.clone())),
+            move |jvm, system| async move {
+                jvm.push_native_frame();
+                let midlet: ClassInstanceRef<MIDlet> = jvm.new_class("test/TickerMidlet", "()V", ()).await?.into();
+                let display = MIDlet::display(&jvm, &midlet).await?;
+                let text = JavaLangString::from_rust_string(&jvm, "News\r\nNext\nEnd\r!").await?;
+                let ticker: ClassInstanceRef<Ticker> = jvm.new_class(TICKER, "(Ljava/lang/String;)V", (text,)).await?.into();
+                let ticker_root = jvm.new_global_ref(&ticker).unwrap();
+                let first: ClassInstanceRef<Displayable> = jvm.new_class(FORM, "(Ljava/lang/String;)V", (None,)).await?.into();
+                let first_root = jvm.new_global_ref(&first).unwrap();
+                let second: ClassInstanceRef<Displayable> = jvm.new_class(FORM, "(Ljava/lang/String;)V", (None,)).await?.into();
+                let second_root = jvm.new_global_ref(&second).unwrap();
+                for screen in [&first, &second] {
+                    let _: () = jvm
+                        .invoke_virtual(
+                            screen,
+                            DISPLAYABLE,
+                            "setTicker",
+                            "(Ljavax/microedition/lcdui/Ticker;)V",
+                            (ticker.clone(),),
+                        )
+                        .await?;
+                }
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        DISPLAY,
+                        "setCurrent",
+                        "(Ljavax/microedition/lcdui/Displayable;)V",
+                        (first.clone(),),
+                    )
+                    .await?;
+                let initial = pixels(&jvm, &display).await?;
+                pump(&jvm, &system, &clock, 101).await?;
+                let step: i32 = jvm.get_field(&ticker, "scrollOffset", "I").await?;
+                assert!(step > 0, "a due event must move the ticker");
+                assert_ne!(initial, pixels(&jvm, &display).await?);
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        DISPLAY,
+                        "setCurrent",
+                        "(Ljavax/microedition/lcdui/Displayable;)V",
+                        (second.clone(),),
+                    )
+                    .await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, step);
+                pump(&jvm, &system, &clock, 101).await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, step * 2);
+                jvm.pop_frame();
+                jvm.collect_garbage()?;
+                drop(first_root);
+                assert!(
+                    jvm.collect_garbage()? > 0,
+                    "the shared ticker and pending timers must release the old Form"
+                );
+
+                jvm.push_native_frame();
+                let original = jvm.invoke_virtual(&ticker, TICKER, "getString", "()Ljava/lang/String;", ()).await?;
+                assert_eq!(JavaLangString::to_rust_string(&jvm, &original).await?, "News\r\nNext\nEnd\r!");
+                let normalized = JavaLangString::from_rust_string(&jvm, "News Next End !").await?;
+                let _: () = jvm
+                    .invoke_virtual(&ticker, TICKER, "setString", "(Ljava/lang/String;)V", (normalized,))
+                    .await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, 0);
+                assert_eq!(initial, pixels(&jvm, &display).await?, "line endings must render as separators");
+                pump(&jvm, &system, &clock, 101).await?;
+                let replacement = JavaLangString::from_rust_string(&jvm, "Fresh").await?;
+                let _: () = jvm
+                    .invoke_virtual(&ticker, TICKER, "setString", "(Ljava/lang/String;)V", (replacement,))
+                    .await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, 0);
+                assert_ne!(initial, pixels(&jvm, &display).await?);
+                pump(&jvm, &system, &clock, 101).await?;
+                assert_eq!(
+                    jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?,
+                    step,
+                    "old text timers must be stale"
+                );
+
+                let mut wrapped = false;
+                let mut offset = step;
+                for _ in 0..200 {
+                    pump(&jvm, &system, &clock, 101).await?;
+                    let next: i32 = jvm.get_field(&ticker, "scrollOffset", "I").await?;
+                    wrapped |= next < offset;
+                    offset = next;
+                    if wrapped && offset >= 0 {
+                        break;
+                    }
+                }
+                assert!(wrapped && offset >= 0, "text must reenter from the right and keep scrolling");
+                let _: () = jvm
+                    .invoke_virtual(&second, DISPLAYABLE, "setTicker", "(Ljavax/microedition/lcdui/Ticker;)V", (None,))
+                    .await?;
+                pump(&jvm, &system, &clock, 101).await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, offset);
+                assert!(system.event_queue().pop().is_none(), "detaching must stop recurring ticks");
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &second,
+                        DISPLAYABLE,
+                        "setTicker",
+                        "(Ljavax/microedition/lcdui/Ticker;)V",
+                        (ticker.clone(),),
+                    )
+                    .await?;
+                let hidden = jvm.new_class(FORM, "(Ljava/lang/String;)V", (None,)).await?;
+                let _: () = jvm
+                    .invoke_virtual(&display, DISPLAY, "setCurrent", "(Ljavax/microedition/lcdui/Displayable;)V", (hidden,))
+                    .await?;
+                pump(&jvm, &system, &clock, 101).await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, offset);
+                let hidden_text = JavaLangString::from_rust_string(&jvm, "Hidden").await?;
+                let _: () = jvm
+                    .invoke_virtual(&ticker, TICKER, "setString", "(Ljava/lang/String;)V", (hidden_text,))
+                    .await?;
+                assert!(system.event_queue().pop().is_none(), "changing a hidden ticker must not schedule work");
+
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        DISPLAY,
+                        "setCurrent",
+                        "(Ljavax/microedition/lcdui/Displayable;)V",
+                        (second.clone(),),
+                    )
+                    .await?;
+                let empty = JavaLangString::from_rust_string(&jvm, "").await?;
+                let _: () = jvm
+                    .invoke_virtual(&ticker, TICKER, "setString", "(Ljava/lang/String;)V", (empty,))
+                    .await?;
+                pump(&jvm, &system, &clock, 101).await?;
+                assert_eq!(jvm.get_field::<i32>(&ticker, "scrollOffset", "I").await?, 0);
+                assert!(system.event_queue().pop().is_none(), "empty text must not keep a timer alive");
+                jvm.pop_frame();
+                drop((ticker_root, second_root));
+                Ok(())
+            },
+        )
+    }
+}

--- a/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
@@ -1,13 +1,22 @@
 use alloc::vec;
 
-use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
 use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::{lcdui::Display, midlet::MIDlet};
+use crate::classes::javax::microedition::{
+    lcdui::{Display, Font, Graphics},
+    midlet::MIDlet,
+};
+
+const TITLE_HORIZONTAL_PADDING: i32 = 4;
+const TICKER_SCROLL_STEP: i32 = 2;
+const TICKER_BACKGROUND: i32 = 0xdde5ec;
+const BLACK: i32 = 0;
+const LEFT_TOP: i32 = 4 | 16;
 
 // class javax.microedition.lcdui.Ticker
 pub struct Ticker;
@@ -21,6 +30,13 @@ impl Ticker {
             methods: vec![
                 JavaMethodProto::new("<init>", "(Ljava/lang/String;)V", Self::init, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("getString", "()Ljava/lang/String;", Self::get_string, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("advance", "(I)Z", Self::advance, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "paint",
+                    "(Ljavax/microedition/lcdui/Graphics;III)V",
+                    Self::paint,
+                    MethodAccessFlags::empty(),
+                ),
                 JavaMethodProto::new("setString", "(Ljava/lang/String;)V", Self::set_string, MethodAccessFlags::PUBLIC),
             ],
             fields: vec![
@@ -42,6 +58,79 @@ impl Ticker {
         jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
         jvm.put_field(&mut this, "scrollOffset", "I", 0).await?;
 
+        Ok(())
+    }
+
+    async fn advance(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>, width: i32) -> JvmResult<bool> {
+        let text: ClassInstanceRef<String> = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
+        let text = JavaLangString::to_rust_string(jvm, &text)
+            .await?
+            .replace("\r\n", " ")
+            .replace(['\r', '\n'], " ");
+        if text.is_empty() {
+            return Ok(false);
+        }
+        let offset: i32 = jvm.get_field(&this, "scrollOffset", "I").await?;
+        let offset = offset + TICKER_SCROLL_STEP;
+        let offset = if offset >= Font::text_width(context.system().platform().font(), &text) + TITLE_HORIZONTAL_PADDING {
+            TITLE_HORIZONTAL_PADDING - width
+        } else {
+            offset
+        };
+        jvm.put_field(&mut this, "scrollOffset", "I", offset).await?;
+        Ok(true)
+    }
+
+    async fn paint(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        this: ClassInstanceRef<Self>,
+        graphics: ClassInstanceRef<Graphics>,
+        width: i32,
+        y: i32,
+        height: i32,
+    ) -> JvmResult<()> {
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "setClip",
+                "(IIII)V",
+                (0, y, width, height),
+            )
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (TICKER_BACKGROUND,))
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "fillRect",
+                "(IIII)V",
+                (0, y, width, height),
+            )
+            .await?;
+
+        let text: ClassInstanceRef<String> = jvm.get_field(&this, "text", "Ljava/lang/String;").await?;
+        let text = JavaLangString::to_rust_string(jvm, &text)
+            .await?
+            .replace("\r\n", " ")
+            .replace(['\r', '\n'], " ");
+        let text = JavaLangString::from_rust_string(jvm, &text).await?;
+        let scroll_offset: i32 = jvm.get_field(&this, "scrollOffset", "I").await?;
+        let _: () = jvm
+            .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (BLACK,))
+            .await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &graphics,
+                "javax/microedition/lcdui/Graphics",
+                "drawString",
+                "(Ljava/lang/String;III)V",
+                (text, TITLE_HORIZONTAL_PADDING - scroll_offset, y + 2, LEFT_TOP),
+            )
+            .await?;
         Ok(())
     }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/ticker.rs
@@ -5,10 +5,11 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::String;
 
+use wie_backend::canvas::string_width;
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::{
-    lcdui::{Display, Font, Graphics},
+    lcdui::{Display, Graphics},
     midlet::MIDlet,
 };
 
@@ -72,7 +73,7 @@ impl Ticker {
         }
         let offset: i32 = jvm.get_field(&this, "scrollOffset", "I").await?;
         let offset = offset + TICKER_SCROLL_STEP;
-        let offset = if offset >= Font::text_width(context.system().platform().font(), &text) + TITLE_HORIZONTAL_PADDING {
+        let offset = if offset >= string_width(context.system().platform().font(), &text, 10.0).ceil() as i32 + TITLE_HORIZONTAL_PADDING {
             TITLE_HORIZONTAL_PADDING - width
         } else {
             offset

--- a/wie-midp/src/classes/net/wie.rs
+++ b/wie-midp/src/classes/net/wie.rs
@@ -1,10 +1,14 @@
+mod choice_element;
 mod event_queue;
+mod item_state_event;
 mod launcher;
 mod smaf_player;
 mod wie_error;
 
 pub use self::{
+    choice_element::ChoiceElement,
     event_queue::{EventQueue, KeyboardEventType, MIDPKeyCode},
+    item_state_event::ItemStateEvent,
     launcher::Launcher,
     smaf_player::SmafPlayer,
     wie_error::WieError,

--- a/wie-midp/src/classes/net/wie/choice_element.rs
+++ b/wie-midp/src/classes/net/wie/choice_element.rs
@@ -1,0 +1,70 @@
+use alloc::vec;
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+use rustjava_runtime::classes::java::lang::String;
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::lcdui::{Font, Image};
+
+// WIE guest record for one Choice element.
+pub struct ChoiceElement;
+
+impl ChoiceElement {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "net/wie/ChoiceElement",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec![],
+            methods: vec![JavaMethodProto::new(
+                "<init>",
+                "(Ljava/lang/String;Ljavax/microedition/lcdui/Image;Z)V",
+                Self::init,
+                MethodAccessFlags::empty(),
+            )],
+            fields: vec![
+                JavaFieldProto::new("text", "Ljava/lang/String;", FieldAccessFlags::empty()),
+                JavaFieldProto::new("image", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::empty()),
+                JavaFieldProto::new("displayImage", "Ljavax/microedition/lcdui/Image;", FieldAccessFlags::empty()),
+                JavaFieldProto::new("font", "Ljavax/microedition/lcdui/Font;", FieldAccessFlags::empty()),
+                JavaFieldProto::new("selected", "Z", FieldAccessFlags::empty()),
+            ],
+            access_flags: ClassAccessFlags::empty(),
+        }
+    }
+
+    async fn init(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        text: ClassInstanceRef<String>,
+        image: ClassInstanceRef<Image>,
+        selected: bool,
+    ) -> JvmResult<()> {
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+
+        let display_image: ClassInstanceRef<Image> = if image.is_null() {
+            ClassInstanceRef::new(None)
+        } else {
+            jvm.invoke_static(
+                "javax/microedition/lcdui/Image",
+                "createImage",
+                "(Ljavax/microedition/lcdui/Image;)Ljavax/microedition/lcdui/Image;",
+                (image.clone(),),
+            )
+            .await?
+        };
+
+        jvm.put_field(&mut this, "text", "Ljava/lang/String;", text).await?;
+        jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
+        jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
+            .await?;
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", ClassInstanceRef::<Font>::new(None))
+            .await?;
+        jvm.put_field(&mut this, "selected", "Z", selected).await?;
+
+        Ok(())
+    }
+}

--- a/wie-midp/src/classes/net/wie/choice_element.rs
+++ b/wie-midp/src/classes/net/wie/choice_element.rs
@@ -7,7 +7,7 @@ use rustjava_runtime::classes::java::lang::String;
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::{Font, Image};
+use crate::classes::javax::microedition::lcdui::Image;
 
 // WIE guest record for one Choice element.
 pub struct ChoiceElement;
@@ -46,7 +46,7 @@ impl ChoiceElement {
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
         let display_image: ClassInstanceRef<Image> = if image.is_null() {
-            ClassInstanceRef::new(None)
+            None.into()
         } else {
             jvm.invoke_static(
                 "javax/microedition/lcdui/Image",
@@ -61,8 +61,7 @@ impl ChoiceElement {
         jvm.put_field(&mut this, "image", "Ljavax/microedition/lcdui/Image;", image).await?;
         jvm.put_field(&mut this, "displayImage", "Ljavax/microedition/lcdui/Image;", display_image)
             .await?;
-        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", ClassInstanceRef::<Font>::new(None))
-            .await?;
+        jvm.put_field(&mut this, "font", "Ljavax/microedition/lcdui/Font;", None).await?;
         jvm.put_field(&mut this, "selected", "Z", selected).await?;
 
         Ok(())

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -198,6 +198,30 @@ impl EventQueue {
 
         let mut pending_timer_events = Vec::new();
         loop {
+            let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
+            let callback_count: i32 = jvm.invoke_virtual(&call_serially_events, "java/util/Vector", "size", "()I", ()).await?;
+            if callback_count > 0 {
+                let midlet: ClassInstanceRef<MIDlet> = jvm
+                    .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                    .await?;
+                if !midlet.is_null() {
+                    let display = MIDlet::display(jvm, &midlet).await?;
+                    // A frontend Redraw may not have reached the backend queue yet.
+                    if jvm.get_field::<bool>(&display, "repaintPending", "Z").await? {
+                        let _: () = jvm
+                            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
+                            .await?;
+                    }
+                }
+            }
+            // Callbacks queued during delivery wait until the next event-loop iteration.
+            for _ in 0..callback_count {
+                let event: ClassInstanceRef<Runnable> = jvm
+                    .invoke_virtual(&call_serially_events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
+                    .await?;
+                let _: () = jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await?;
+            }
+
             let now = context.system().platform().now();
             let maybe_event = context.system().event_queue().pop();
 
@@ -224,7 +248,7 @@ impl EventQueue {
                     ],
                     Event::Timer { due, callback } => {
                         // TODO we should wait for timer more efficiently
-                        if due < now {
+                        if due <= now {
                             callback()
                                 .or_else(async |x| Err(jvm.exception("net/wie/WieError", &x.to_string()).await))
                                 .await?
@@ -243,17 +267,6 @@ impl EventQueue {
 
                 break;
             } else {
-                let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-                if !jvm
-                    .invoke_virtual(&call_serially_events, "java/util/Vector", "isEmpty", "()Z", ())
-                    .await?
-                {
-                    let event: ClassInstanceRef<Runnable> = jvm
-                        .invoke_virtual(&call_serially_events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
-                        .await?;
-                    let _: () = jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await?;
-                }
-
                 context.system().sleep(16).await; // TODO we need to wait for events
 
                 for event in pending_timer_events.drain(..) {
@@ -377,5 +390,142 @@ impl EventQueue {
             [event.into()],
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloc::{boxed::Box, vec};
+
+    use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
+    use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+    use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+
+    use test_utils::{TestPlatform, run_jvm_test_with_system};
+    use wie_backend::{Event, KeyCode};
+    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use wie_util::Result;
+
+    use crate::{
+        classes::javax::microedition::{
+            lcdui::{Display, Graphics, Image},
+            midlet::MIDlet,
+        },
+        get_protos,
+    };
+
+    use super::{EventQueue, EventQueueEvent};
+
+    struct RecurringCallback;
+
+    impl RecurringCallback {
+        async fn paint(
+            jvm: &Jvm,
+            _context: &mut WieJvmContext,
+            _this: ClassInstanceRef<Self>,
+            graphics: ClassInstanceRef<Graphics>,
+        ) -> JvmResult<()> {
+            let _: () = jvm
+                .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x22aa44,))
+                .await?;
+            jvm.invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
+                .await
+        }
+
+        async fn run(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            assert_eq!(count, 0, "requeued callback ran before the pending backend event");
+            let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
+            let mut graphics = Display::screen_graphics(jvm, &display).await?;
+            let image = Graphics::image(jvm, &mut graphics).await?;
+            let pixel = Image::image(jvm, &image).await?.get_pixel(0, 0);
+            assert_eq!(
+                (pixel.r, pixel.g, pixel.b),
+                (0x22, 0xaa, 0x44),
+                "pending Canvas paint must finish before run"
+            );
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            let queue: ClassInstanceRef<EventQueue> = jvm
+                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                .await?;
+            jvm.invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (this,))
+                .await
+        }
+    }
+
+    #[test]
+    fn pending_canvas_paints_before_recurring_callback_and_backend_input() -> Result<()> {
+        let callback_proto = WieJavaClassProto {
+            name: "net/wie/RecurringCallback",
+            parent_class: Some("javax/microedition/lcdui/Canvas"),
+            interfaces: vec!["java/lang/Runnable"],
+            methods: vec![
+                JavaMethodProto::new("run", "()V", RecurringCallback::run, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new(
+                    "paint",
+                    "(Ljavax/microedition/lcdui/Graphics;)V",
+                    RecurringCallback::paint,
+                    MethodAccessFlags::PROTECTED,
+                ),
+            ],
+            fields: vec![JavaFieldProto::new("count", "I", FieldAccessFlags::PRIVATE)],
+            access_flags: ClassAccessFlags::PUBLIC,
+        };
+        let midlet_proto = WieJavaClassProto {
+            name: "net/wie/QueueTestMidlet",
+            parent_class: Some("javax/microedition/midlet/MIDlet"),
+            interfaces: vec![],
+            methods: vec![],
+            fields: vec![],
+            access_flags: ClassAccessFlags::PUBLIC,
+        };
+        run_jvm_test_with_system(
+            Box::new([get_protos().into(), Box::new([callback_proto, midlet_proto])]),
+            Box::new(TestPlatform::new()),
+            |jvm, system| async move {
+                let queue: ClassInstanceRef<EventQueue> = jvm
+                    .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                    .await?;
+                let midlet: ClassInstanceRef<MIDlet> = jvm.instantiate_class("net/wie/QueueTestMidlet").await?.into();
+                let _: () = jvm
+                    .invoke_special(&midlet, "javax/microedition/midlet/MIDlet", "<init>", "()V", ())
+                    .await?;
+                let display = MIDlet::display(&jvm, &midlet).await?;
+                let callback: ClassInstanceRef<RecurringCallback> = jvm.instantiate_class("net/wie/RecurringCallback").await?.into();
+                let _: () = jvm
+                    .invoke_special(&callback, "javax/microedition/lcdui/Canvas", "<init>", "()V", ())
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "setCurrent",
+                        "(Ljavax/microedition/lcdui/Displayable;)V",
+                        (callback.clone(),),
+                    )
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&callback, "javax/microedition/lcdui/Canvas", "repaint", "()V", ())
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "callSerially",
+                        "(Ljava/lang/Runnable;)V",
+                        (callback.clone(),),
+                    )
+                    .await?;
+                // The frontend has not delivered its Redraw yet.
+                system.event_queue().push(Event::Keydown(KeyCode::NUM1));
+                let event: ClassInstanceRef<Array<i32>> = jvm.instantiate_array("I", 4).await?.into();
+                let _: () = jvm
+                    .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                    .await?;
+                assert_eq!(jvm.load_array::<i32>(&event, 0, 1).await?, [EventQueueEvent::KeyEvent as i32]);
+                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 1);
+                Ok(())
+            },
+        )
     }
 }

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -207,11 +207,9 @@ impl EventQueue {
                 if !midlet.is_null() {
                     let display = MIDlet::display(jvm, &midlet).await?;
                     // A frontend Redraw may not have reached the backend queue yet.
-                    if jvm.get_field::<bool>(&display, "repaintPending", "Z").await? {
-                        let _: () = jvm
-                            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
-                            .await?;
-                    }
+                    let _: () = jvm
+                        .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
+                        .await?;
                 }
             }
             // Callbacks queued during delivery wait until the next event-loop iteration.

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -436,7 +436,15 @@ mod test {
             let count: i32 = jvm.get_field(&this, "count", "I").await?;
             assert_eq!(count, 0, "requeued callback ran before the pending backend event");
             let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
-            let mut graphics = Display::screen_graphics(jvm, &display).await?;
+            let mut graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
             let image = Graphics::image(jvm, &mut graphics).await?;
             let pixel = Image::image(jvm, &image).await?.get_pixel(0, 0);
             assert_eq!(

--- a/wie-midp/src/classes/net/wie/item_state_event.rs
+++ b/wie-midp/src/classes/net/wie/item_state_event.rs
@@ -6,7 +6,7 @@ use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::{Form, Item, ItemStateListener};
+use crate::classes::javax::microedition::lcdui::{Form, Item};
 
 // class net.wie.ItemStateEvent
 pub struct ItemStateEvent;
@@ -48,18 +48,11 @@ impl ItemStateEvent {
 
     async fn run(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let form: ClassInstanceRef<Form> = jvm.get_field(&this, "form", "Ljavax/microedition/lcdui/Form;").await?;
-        let listener: ClassInstanceRef<ItemStateListener> = jvm
-            .get_field(&form, "itemStateListener", "Ljavax/microedition/lcdui/ItemStateListener;")
-            .await?;
-        if listener.is_null() {
-            return Ok(());
-        }
-
         let item: ClassInstanceRef<Item> = jvm.get_field(&this, "item", "Ljavax/microedition/lcdui/Item;").await?;
         jvm.invoke_virtual(
-            &listener,
-            "javax/microedition/lcdui/ItemStateListener",
-            "itemStateChanged",
+            &form,
+            "javax/microedition/lcdui/Form",
+            "dispatchItemStateChanged",
             "(Ljavax/microedition/lcdui/Item;)V",
             (item,),
         )

--- a/wie-midp/src/classes/net/wie/item_state_event.rs
+++ b/wie-midp/src/classes/net/wie/item_state_event.rs
@@ -1,0 +1,68 @@
+use alloc::vec;
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::lcdui::{Form, Item, ItemStateListener};
+
+// class net.wie.ItemStateEvent
+pub struct ItemStateEvent;
+
+impl ItemStateEvent {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "net/wie/ItemStateEvent",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec!["java/lang/Runnable"],
+            methods: vec![
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljavax/microedition/lcdui/Form;Ljavax/microedition/lcdui/Item;)V",
+                    Self::init,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("run", "()V", Self::run, MethodAccessFlags::PUBLIC),
+            ],
+            fields: vec![
+                JavaFieldProto::new("form", "Ljavax/microedition/lcdui/Form;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("item", "Ljavax/microedition/lcdui/Item;", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        form: ClassInstanceRef<Form>,
+        item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "form", "Ljavax/microedition/lcdui/Form;", form).await?;
+        jvm.put_field(&mut this, "item", "Ljavax/microedition/lcdui/Item;", item).await
+    }
+
+    async fn run(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let form: ClassInstanceRef<Form> = jvm.get_field(&this, "form", "Ljavax/microedition/lcdui/Form;").await?;
+        let listener: ClassInstanceRef<ItemStateListener> = jvm
+            .get_field(&form, "itemStateListener", "Ljavax/microedition/lcdui/ItemStateListener;")
+            .await?;
+        if listener.is_null() {
+            return Ok(());
+        }
+
+        let item: ClassInstanceRef<Item> = jvm.get_field(&this, "item", "Ljavax/microedition/lcdui/Item;").await?;
+        jvm.invoke_virtual(
+            &listener,
+            "javax/microedition/lcdui/ItemStateListener",
+            "itemStateChanged",
+            "(Ljavax/microedition/lcdui/Item;)V",
+            (item,),
+        )
+        .await
+    }
+}

--- a/wie-midp/src/lib.rs
+++ b/wie-midp/src/lib.rs
@@ -5,22 +5,30 @@ pub mod classes;
 
 use wie_jvm_support::WieJavaClassProto;
 
-pub fn get_protos() -> [WieJavaClassProto; 26] {
+pub fn get_protos() -> [WieJavaClassProto; 36] {
     [
         classes::javax::microedition::lcdui::Alert::as_proto(),
         classes::javax::microedition::lcdui::AlertType::as_proto(),
         classes::javax::microedition::lcdui::Canvas::as_proto(),
+        classes::javax::microedition::lcdui::Choice::as_proto(),
         classes::javax::microedition::lcdui::ChoiceGroup::as_proto(),
         classes::javax::microedition::lcdui::Command::as_proto(),
+        classes::javax::microedition::lcdui::CommandListener::as_proto(),
         classes::javax::microedition::lcdui::Display::as_proto(),
         classes::javax::microedition::lcdui::Displayable::as_proto(),
         classes::javax::microedition::lcdui::Font::as_proto(),
         classes::javax::microedition::lcdui::Form::as_proto(),
+        classes::javax::microedition::lcdui::Gauge::as_proto(),
         classes::javax::microedition::lcdui::Graphics::as_proto(),
         classes::javax::microedition::lcdui::Image::as_proto(),
+        classes::javax::microedition::lcdui::ImageItem::as_proto(),
         classes::javax::microedition::lcdui::Item::as_proto(),
+        classes::javax::microedition::lcdui::ItemCommandListener::as_proto(),
+        classes::javax::microedition::lcdui::ItemStateListener::as_proto(),
         classes::javax::microedition::lcdui::Screen::as_proto(),
+        classes::javax::microedition::lcdui::StringItem::as_proto(),
         classes::javax::microedition::lcdui::TextBox::as_proto(),
+        classes::javax::microedition::lcdui::Ticker::as_proto(),
         classes::javax::microedition::lcdui::game::GameCanvas::as_proto(),
         classes::javax::microedition::media::Manager::as_proto(),
         classes::javax::microedition::media::MediaException::as_proto(),
@@ -29,7 +37,9 @@ pub fn get_protos() -> [WieJavaClassProto; 26] {
         classes::javax::microedition::rms::InvalidRecordIDException::as_proto(),
         classes::javax::microedition::rms::RecordStore::as_proto(),
         classes::javax::microedition::rms::RecordStoreException::as_proto(),
+        classes::net::wie::ChoiceElement::as_proto(),
         classes::net::wie::EventQueue::as_proto(),
+        classes::net::wie::ItemStateEvent::as_proto(),
         classes::net::wie::Launcher::as_proto(),
         classes::net::wie::SmafPlayer::as_proto(),
         classes::net::wie::WieError::as_proto(),

--- a/wie-skvm/src/classes/com/skt/m/phone_book.rs
+++ b/wie-skvm/src/classes/com/skt/m/phone_book.rs
@@ -61,10 +61,32 @@ impl PhoneBook {
                 JavaMethodProto::new("isUsed", "(I)Z", Self::is_used, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
                 JavaMethodProto::new("next", "()I", Self::next, MethodAccessFlags::PUBLIC | MethodAccessFlags::STATIC),
             ],
-            fields: ["ALL", "NAME", "GROUP", "HANDPHONE", "HOME", "OFFICE", "EMAIL", "MEMO"]
-                .into_iter()
-                .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-                .collect(),
+            fields: vec![
+                JavaFieldProto::new("ALL", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new("NAME", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new(
+                    "GROUP",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "HANDPHONE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new("HOME", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+                JavaFieldProto::new(
+                    "OFFICE",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "EMAIL",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new("MEMO", "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }

--- a/wie-skvm/src/classes/com/skt/m/sis_image.rs
+++ b/wie-skvm/src/classes/com/skt/m/sis_image.rs
@@ -82,10 +82,23 @@ impl SISImage {
                     MethodAccessFlags::PUBLIC,
                 ),
             ],
-            fields: ["IMG_LEVEL_BW", "IMG_LEVEL_4G", "IMG_LEVEL_256C"]
-                .into_iter()
-                .map(|name| JavaFieldProto::new(name, "I", FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL))
-                .collect(),
+            fields: vec![
+                JavaFieldProto::new(
+                    "IMG_LEVEL_BW",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "IMG_LEVEL_4G",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+                JavaFieldProto::new(
+                    "IMG_LEVEL_256C",
+                    "I",
+                    FieldAccessFlags::PUBLIC | FieldAccessFlags::STATIC | FieldAccessFlags::FINAL,
+                ),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
     }

--- a/wie-skvm/src/classes/com/xce/lcdui/toolkit.rs
+++ b/wie-skvm/src/classes/com/xce/lcdui/toolkit.rs
@@ -273,7 +273,15 @@ impl Toolkit {
                     (current_midlet,),
                 )
                 .await?;
-            let graphics: ClassInstanceRef<Graphics> = Display::screen_graphics(jvm, &display).await?;
+            let graphics: ClassInstanceRef<Graphics> = jvm
+                .invoke_virtual(
+                    &display,
+                    "javax/microedition/lcdui/Display",
+                    "getScreenGraphics",
+                    "()Ljavax/microedition/lcdui/Graphics;",
+                    (),
+                )
+                .await?;
 
             jvm.put_static_field("com/xce/lcdui/Toolkit", "graphics", "Ljavax/microedition/lcdui/Graphics;", graphics)
                 .await?;


### PR DESCRIPTION
## Summary
- Implement MIDP Form, Screen, and Alert rendering and lifecycle through the existing Display/Graphics path.
- Add Item layout, ownership, focus, scrolling, ChoiceGroup interaction, StringItem, ImageItem, Gauge, and listener dispatch.
- Implement title, ticker, softkey/menu commands, live viewport updates, and serialized Alert/Ticker timers with guest-backed state.
- Preserve Canvas/GameCanvas behavior and paint-before-callback ordering; use injected platform fonts for measurement and wrapping.
- Add focused inline regression tests and a controllable test clock; document the public-specification/reference-implementation boundary in AGENTS.md.

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy --target wasm32-unknown-unknown --workspace --exclude wie-app -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Validation uses JVM unit tests and backing-image checks. Frontend visual smoke testing was not performed.
