### PR TITLE
Preserve ARM instruction budget across SVC calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,9 +6844,9 @@ dependencies = [
 
 [[package]]
 name = "wipi-types"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae8e36c0e344c9687be257c923352fe2de3d160b828f2e622d404d155bc8de0"
+checksum = "a8d38954b4adea75c59c5bcffb6e70ad7d88a229e087afaf6d46dd87dd88f6cd"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "^1", default-features = false, features = ["derive", "alloc
 spin = { version = "^0.12", features = ["spin_mutex", "rwlock"], default-features = false }
 toml = { version = "^1", default-features = false, features = ["parse", "serde"] }
 tracing = { version = "^0.1", default-features = false, features = ["attributes"] }
-wipi-types = { version = "^0.0.1" }
+wipi-types = { version = "^0.0.2" }
 
 wie-backend = { version = "0.1.0", path = "wie-backend" }
 wie-j2me = { version = "0.1.0", path = "wie-j2me" }

--- a/wie-core-arm/src/binary_patches/hook.rs
+++ b/wie-core-arm/src/binary_patches/hook.rs
@@ -617,10 +617,10 @@ mod tests {
 
         let result = {
             let mut inner = core.inner.lock();
-            inner.engine.run(0, &mut 10)?
+            inner.engine.run(0, 10)?
         };
-        let category = match result {
-            crate::engine::EngineRunResult::Svc { category, lr, spsr } => {
+        let category = match result.stop_reason {
+            crate::engine::EngineStopReason::Svc { category, lr, spsr } => {
                 let mut inner = core.inner.lock();
                 inner.engine.reg_write(ArmRegister::Cpsr, spsr);
                 inner.engine.reg_write(ArmRegister::PC, lr);

--- a/wie-core-arm/src/binary_patches/hook.rs
+++ b/wie-core-arm/src/binary_patches/hook.rs
@@ -617,7 +617,7 @@ mod tests {
 
         let result = {
             let mut inner = core.inner.lock();
-            inner.engine.run(0, 10)?
+            inner.engine.run(0, &mut 10)?
         };
         let category = match result {
             crate::engine::EngineRunResult::Svc { category, lr, spsr } => {

--- a/wie-core-arm/src/core.rs
+++ b/wie-core-arm/src/core.rs
@@ -24,6 +24,7 @@ const GLOBAL_DATA_BASE: u32 = 0x7fff0000;
 const FUNCTIONS_BASE: u32 = 0x71000000;
 const FUNCTIONS_SIZE: usize = 0x10000;
 const SVC_STUB_SIZE: u32 = 16;
+const INSTRUCTIONS_PER_YIELD: u32 = 10_000;
 pub const RUN_FUNCTION_LR: u32 = 0x7f000000;
 pub const HEAP_BASE: u32 = 0x40000000;
 pub const HEAP_SIZE: u32 = 0x10000000;
@@ -42,6 +43,7 @@ struct ProfileState {
 
 pub(crate) struct ArmCoreInner {
     pub(crate) engine: Box<dyn ArmEngine>,
+    instructions_remaining: u32,
     last_thread_id: ThreadId,
     threads: BTreeMap<ThreadId, ThreadState>,
     svc_handlers: BTreeMap<u32, Arc<Box<dyn RegisteredFunction>>>,
@@ -96,6 +98,7 @@ impl ArmCore {
 
         let inner = ArmCoreInner {
             engine,
+            instructions_remaining: INSTRUCTIONS_PER_YIELD,
             last_thread_id: 0,
             threads: BTreeMap::new(),
             svc_handlers: BTreeMap::new(),
@@ -284,24 +287,38 @@ impl ArmCore {
         }
 
         loop {
-            let result = {
+            let (result, should_yield) = {
                 let mut inner = self.inner.lock();
-                inner.engine.run(RUN_FUNCTION_LR, 10_000)?
+                let ArmCoreInner {
+                    engine,
+                    instructions_remaining,
+                    ..
+                } = &mut *inner;
+                let result = engine.run(RUN_FUNCTION_LR, instructions_remaining)?;
+                let should_yield = *instructions_remaining == 0;
+                if should_yield {
+                    *instructions_remaining = INSTRUCTIONS_PER_YIELD;
+                }
+                (result, should_yield)
             };
 
             self.sample_profile();
 
+            if let EngineRunResult::Svc { lr, spsr, .. } = result {
+                // Leave exception mode before yielding: thread contexts do not save banked SVC registers.
+                let mut inner = self.inner.lock();
+                inner.engine.reg_write(ArmRegister::Cpsr, spsr);
+                inner.engine.reg_write(ArmRegister::PC, lr);
+            }
+
+            if should_yield {
+                YieldFuture::new().await;
+            }
+
             match result {
                 EngineRunResult::End => break,
-                EngineRunResult::CountExhausted => YieldFuture::new().await, // yield to allow other tasks to run
-                EngineRunResult::Svc { category, lr, spsr } => {
-                    {
-                        let mut inner = self.inner.lock();
-                        // Restore the pre-exception execution state before running the Rust SVC handler.
-                        inner.engine.reg_write(ArmRegister::Cpsr, spsr);
-                        inner.engine.reg_write(ArmRegister::PC, lr);
-                    }
-
+                EngineRunResult::CountExhausted => continue,
+                EngineRunResult::Svc { category, .. } => {
                     let function = {
                         let inner = self.inner.lock();
                         inner
@@ -683,12 +700,95 @@ impl Drop for ThreadContextGuard {
 
 #[cfg(test)]
 mod tests {
+    use core::{
+        pin::pin,
+        sync::atomic::{AtomicU32, Ordering},
+        task::{Context, Poll, Waker},
+    };
+
+    use crate::function::JumpTo;
+
     use super::*;
 
     async fn test_svc_handler(_core: &mut ArmCore, seen_id: &mut Option<u32>, id: crate::SvcId) -> Result<()> {
         *seen_id = Some(id.0);
 
         Ok(())
+    }
+
+    async fn count_inline_svc(core: &mut ArmCore, calls: &mut Arc<AtomicU32>) -> Result<JumpTo> {
+        calls.fetch_add(1, Ordering::Relaxed);
+        Ok(JumpTo(core.read_pc_lr()?.0 | 1))
+    }
+
+    async fn call_nested_arm(core: &mut ArmCore, result: &mut Arc<AtomicU32>) -> Result<JumpTo> {
+        let pc = core.read_pc_lr()?.0;
+        let value = core.run_function(0x10001, &[0]).await?;
+        result.store(value, Ordering::Relaxed);
+        Ok(JumpTo(pc | 1))
+    }
+
+    #[test]
+    fn yields_every_ten_thousand_instructions_across_svc() {
+        let mut core = ArmCore::new(false, None).unwrap();
+        let calls = Arc::new(AtomicU32::new(0));
+        core.register_svc_handler(1, count_inline_svc, &calls).unwrap();
+        let mut code = [0x01, 0x30, 0x01, 0xdf].repeat(10_000); // add r0, #1; svc #1
+        code.extend_from_slice(&[0x70, 0x47]); // bx lr
+        core.load(&code, 0x1000, code.len()).unwrap();
+
+        let observer = core.clone();
+        let mut run = pin!(core.run_function::<u32>(0x1001, &[0]));
+        let mut cx = Context::from_waker(Waker::noop());
+        for completed in [5_000, 10_000] {
+            assert!(run.as_mut().poll(&mut cx).is_pending());
+            assert_eq!(observer.read_param(0).unwrap(), completed);
+            assert_eq!(calls.load(Ordering::Relaxed), completed - 1);
+            assert_eq!(observer.save_context().cpsr & 0x3f, 0x3f);
+        }
+        assert!(matches!(run.as_mut().poll(&mut cx), Poll::Ready(Ok(10_000))));
+        assert_eq!(calls.load(Ordering::Relaxed), 10_000);
+    }
+
+    #[test]
+    fn nested_arm_calls_share_the_instruction_budget() {
+        let mut core = ArmCore::new(false, None).unwrap();
+        let result = Arc::new(AtomicU32::new(0));
+        core.register_svc_handler(1, call_nested_arm, &result).unwrap();
+        let mut outer = [0xc0, 0x46].repeat(5_000); // nop
+        outer.extend_from_slice(&[0x01, 0xdf, 0x70, 0x47]); // svc #1; bx lr
+        core.load(&outer, 0x1000, outer.len()).unwrap();
+        let mut nested = [0x01, 0x30].repeat(5_000); // add r0, #1
+        nested.extend_from_slice(&[0x70, 0x47]); // bx lr
+        core.load(&nested, 0x10000, nested.len()).unwrap();
+
+        let observer = core.clone();
+        let mut run = pin!(core.run_function::<u32>(0x1001, &[17]));
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(run.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(observer.read_param(0).unwrap(), 4_999);
+        assert_eq!(result.load(Ordering::Relaxed), 0);
+        assert!(matches!(run.as_mut().poll(&mut cx), Poll::Ready(Ok(17))));
+        assert_eq!(result.load(Ordering::Relaxed), 5_000);
+    }
+
+    #[test]
+    fn returning_arm_calls_do_not_reset_the_instruction_budget() {
+        let mut core = ArmCore::new(false, None).unwrap();
+        core.load(&[0x70, 0x47], 0x1000, 2).unwrap(); // bx lr
+        let completed = Arc::new(AtomicU32::new(0));
+        let observed = completed.clone();
+        let mut run = pin!(async move {
+            for _ in 0..10_001 {
+                core.run_function::<()>(0x1001, &[]).await.unwrap();
+                completed.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(run.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(observed.load(Ordering::Relaxed), 9_999);
+        assert!(run.as_mut().poll(&mut cx).is_ready());
+        assert_eq!(observed.load(Ordering::Relaxed), 10_001);
     }
 
     #[test]
@@ -711,7 +811,7 @@ mod tests {
             inner.engine.reg_write(ArmRegister::Cpsr, 0x3f);
             inner.engine.reg_write(ArmRegister::PC, second);
             inner.engine.reg_write(ArmRegister::LR, RUN_FUNCTION_LR);
-            inner.engine.run(RUN_FUNCTION_LR, 10).unwrap()
+            inner.engine.run(RUN_FUNCTION_LR, &mut 10).unwrap()
         };
 
         match result {

--- a/wie-core-arm/src/core.rs
+++ b/wie-core-arm/src/core.rs
@@ -9,7 +9,7 @@ use wie_util::{ByteRead, ByteWrite, Result, WieError, read_generic};
 use crate::{
     EmulatedFunction, ResultWriter, ThreadId,
     context::ArmCoreContext,
-    engine::{Arm32CpuEngine, ArmEngine, ArmRegister, EngineRunResult, MemoryPermission},
+    engine::{Arm32CpuEngine, ArmEngine, ArmRegister, EngineStopReason, MemoryPermission},
     function::{RegisteredFunction, RegisteredFunctionHolder},
     thread::ThreadState,
     thread_wrapper::ArmCoreThreadWrapper,
@@ -289,22 +289,19 @@ impl ArmCore {
         loop {
             let (result, should_yield) = {
                 let mut inner = self.inner.lock();
-                let ArmCoreInner {
-                    engine,
-                    instructions_remaining,
-                    ..
-                } = &mut *inner;
-                let result = engine.run(RUN_FUNCTION_LR, instructions_remaining)?;
-                let should_yield = *instructions_remaining == 0;
+                let budget = inner.instructions_remaining;
+                let result = inner.engine.run(RUN_FUNCTION_LR, budget)?;
+                inner.instructions_remaining -= result.instructions_executed;
+                let should_yield = inner.instructions_remaining == 0;
                 if should_yield {
-                    *instructions_remaining = INSTRUCTIONS_PER_YIELD;
+                    inner.instructions_remaining = INSTRUCTIONS_PER_YIELD;
                 }
-                (result, should_yield)
+                (result.stop_reason, should_yield)
             };
 
             self.sample_profile();
 
-            if let EngineRunResult::Svc { lr, spsr, .. } = result {
+            if let EngineStopReason::Svc { lr, spsr, .. } = result {
                 // Leave exception mode before yielding: thread contexts do not save banked SVC registers.
                 let mut inner = self.inner.lock();
                 inner.engine.reg_write(ArmRegister::Cpsr, spsr);
@@ -316,9 +313,9 @@ impl ArmCore {
             }
 
             match result {
-                EngineRunResult::End => break,
-                EngineRunResult::CountExhausted => continue,
-                EngineRunResult::Svc { category, .. } => {
+                EngineStopReason::End => break,
+                EngineStopReason::CountExhausted => continue,
+                EngineStopReason::Svc { category, .. } => {
                     let function = {
                         let inner = self.inner.lock();
                         inner
@@ -811,17 +808,18 @@ mod tests {
             inner.engine.reg_write(ArmRegister::Cpsr, 0x3f);
             inner.engine.reg_write(ArmRegister::PC, second);
             inner.engine.reg_write(ArmRegister::LR, RUN_FUNCTION_LR);
-            inner.engine.run(RUN_FUNCTION_LR, &mut 10).unwrap()
+            inner.engine.run(RUN_FUNCTION_LR, 10).unwrap()
         };
 
-        match result {
-            EngineRunResult::Svc { category, lr, spsr } => {
+        assert_eq!(result.instructions_executed, 5);
+        match result.stop_reason {
+            EngineStopReason::Svc { category, lr, spsr } => {
                 assert_eq!(category, 1);
                 assert_eq!(lr, FUNCTIONS_BASE + SVC_STUB_SIZE + 10);
                 assert_ne!(spsr & 0x20, 0);
             }
-            EngineRunResult::End => panic!("expected SVC, got end"),
-            EngineRunResult::CountExhausted => panic!("expected SVC, got count exhausted"),
+            EngineStopReason::End => panic!("expected SVC, got end"),
+            EngineStopReason::CountExhausted => panic!("expected SVC, got count exhausted"),
         }
     }
 }

--- a/wie-core-arm/src/engine.rs
+++ b/wie-core-arm/src/engine.rs
@@ -17,7 +17,8 @@ pub enum EngineRunResult {
 }
 
 pub trait ArmEngine: Send + AsAny {
-    fn run(&mut self, end: u32, count: u32) -> Result<EngineRunResult>;
+    /// Decrements the remaining instruction budget, including when execution stops at an SVC.
+    fn run(&mut self, end: u32, count: &mut u32) -> Result<EngineRunResult>;
     fn reg_write(&mut self, reg: ArmRegister, value: u32);
     fn reg_read(&self, reg: ArmRegister) -> u32;
     fn mem_map(&mut self, address: u32, size: usize, permission: MemoryPermission);

--- a/wie-core-arm/src/engine.rs
+++ b/wie-core-arm/src/engine.rs
@@ -10,15 +10,19 @@ pub use debugged_arm32_cpu::DebuggedArm32CpuEngine;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use debugged_arm32_cpu::{DebugBreakpointKind, DebugInner, DebugSignal, DebugStopReason};
 
-pub enum EngineRunResult {
+pub enum EngineStopReason {
     End,
     CountExhausted,
     Svc { category: u32, lr: u32, spsr: u32 },
 }
 
+pub struct EngineRunResult {
+    pub stop_reason: EngineStopReason,
+    pub instructions_executed: u32,
+}
+
 pub trait ArmEngine: Send + AsAny {
-    /// Decrements the remaining instruction budget, including when execution stops at an SVC.
-    fn run(&mut self, end: u32, count: &mut u32) -> Result<EngineRunResult>;
+    fn run(&mut self, end: u32, count: u32) -> Result<EngineRunResult>;
     fn reg_write(&mut self, reg: ArmRegister, value: u32);
     fn reg_read(&self, reg: ArmRegister) -> u32;
     fn mem_map(&mut self, address: u32, size: usize, permission: MemoryPermission);

--- a/wie-core-arm/src/engine/arm32_cpu.rs
+++ b/wie-core-arm/src/engine/arm32_cpu.rs
@@ -5,7 +5,7 @@ use arm32_cpu::{Cpu, Memory, Mode, reg};
 
 use wie_util::{Result, WieError};
 
-use crate::engine::{ArmEngine, ArmRegister, EngineRunResult, MemoryPermission};
+use crate::engine::{ArmEngine, ArmRegister, EngineRunResult, EngineStopReason, MemoryPermission};
 
 pub struct Arm32CpuEngine {
     cpu: Cpu,
@@ -24,7 +24,7 @@ impl Arm32CpuEngine {
         self.cpu.reg_get(Mode::User, reg::PC) == 0x08 && (self.cpu.reg_get(Mode::User, reg::CPSR) & 0x1f) == 0x13
     }
 
-    fn read_svc_result(&mut self) -> Result<EngineRunResult> {
+    fn read_svc_result(&mut self) -> Result<EngineStopReason> {
         let lr = self.cpu.reg_get(Mode::Supervisor, reg::LR);
         let spsr = self.cpu.reg_get(Mode::Supervisor, reg::SPSR);
 
@@ -40,17 +40,18 @@ impl Arm32CpuEngine {
 
         let category = instruction as u32 & 0xff;
 
-        Ok(EngineRunResult::Svc { category, lr, spsr })
+        Ok(EngineStopReason::Svc { category, lr, spsr })
     }
 }
 
 impl ArmEngine for Arm32CpuEngine {
-    fn run(&mut self, end: u32, count: &mut u32) -> Result<EngineRunResult> {
-        loop {
+    fn run(&mut self, end: u32, count: u32) -> Result<EngineRunResult> {
+        let mut instructions_executed = 0;
+        let stop_reason = loop {
             let pc = self.cpu.reg_get(Mode::User, reg::PC);
 
             if self.is_svc_exception() {
-                return self.read_svc_result();
+                break self.read_svc_result()?;
             }
 
             if pc < 0x1000 {
@@ -58,11 +59,11 @@ impl ArmEngine for Arm32CpuEngine {
             }
 
             if pc == end {
-                return Ok(EngineRunResult::End);
+                break EngineStopReason::End;
             }
 
-            if *count == 0 {
-                return Ok(EngineRunResult::CountExhausted);
+            if instructions_executed == count {
+                break EngineStopReason::CountExhausted;
             }
 
             let mut arm32cpu_memory = self.mem.as_arm32cpu_memory();
@@ -70,12 +71,17 @@ impl ArmEngine for Arm32CpuEngine {
             if !(self.cpu.step(&mut arm32cpu_memory)) {
                 return Err(WieError::FatalError("Undefined instruction".into()));
             }
-            *count -= 1;
+            instructions_executed += 1;
 
             if let Some(x) = arm32cpu_memory.memory_error() {
                 return Err(WieError::InvalidMemoryAccess(x));
             }
-        }
+        };
+
+        Ok(EngineRunResult {
+            stop_reason,
+            instructions_executed,
+        })
     }
 
     fn reg_write(&mut self, reg: ArmRegister, value: u32) {
@@ -347,7 +353,28 @@ mod tests {
 
     use arm32_cpu::Memory;
 
-    use super::EmulatedMemory;
+    use crate::engine::{ArmEngine, ArmRegister, EngineStopReason, MemoryPermission};
+
+    use super::{Arm32CpuEngine, EmulatedMemory};
+
+    #[test]
+    fn run_reports_executed_instructions_at_budget_and_return_boundaries() {
+        let mut engine = Arm32CpuEngine::new();
+        engine.mem_map(0x1000, 0x1000, MemoryPermission::ReadWriteExecute);
+        engine.mem_write(0x1000, &[0xc0, 0x46, 0xc0, 0x46, 0x70, 0x47]).unwrap(); // nop; nop; bx lr
+        engine.reg_write(ArmRegister::Cpsr, 0x3f);
+        engine.reg_write(ArmRegister::PC, 0x1001);
+        engine.reg_write(ArmRegister::LR, 0x2000);
+
+        for (budget, expected_count, at_end) in [(0, 0, false), (2, 2, false), (10, 1, true), (10, 0, true)] {
+            let result = engine.run(0x2000, budget).unwrap();
+            assert_eq!(result.instructions_executed, expected_count);
+            assert!(matches!(
+                (result.stop_reason, at_end),
+                (EngineStopReason::End, true) | (EngineStopReason::CountExhausted, false)
+            ));
+        }
+    }
 
     #[test]
     fn page_table_is_heap_allocated() {

--- a/wie-core-arm/src/engine/arm32_cpu.rs
+++ b/wie-core-arm/src/engine/arm32_cpu.rs
@@ -45,7 +45,7 @@ impl Arm32CpuEngine {
 }
 
 impl ArmEngine for Arm32CpuEngine {
-    fn run(&mut self, end: u32, mut count: u32) -> Result<EngineRunResult> {
+    fn run(&mut self, end: u32, count: &mut u32) -> Result<EngineRunResult> {
         loop {
             let pc = self.cpu.reg_get(Mode::User, reg::PC);
 
@@ -61,7 +61,7 @@ impl ArmEngine for Arm32CpuEngine {
                 return Ok(EngineRunResult::End);
             }
 
-            if count == 0 {
+            if *count == 0 {
                 return Ok(EngineRunResult::CountExhausted);
             }
 
@@ -70,7 +70,7 @@ impl ArmEngine for Arm32CpuEngine {
             if !(self.cpu.step(&mut arm32cpu_memory)) {
                 return Err(WieError::FatalError("Undefined instruction".into()));
             }
-            count -= 1;
+            *count -= 1;
 
             if let Some(x) = arm32cpu_memory.memory_error() {
                 return Err(WieError::InvalidMemoryAccess(x));

--- a/wie-core-arm/src/engine/debugged_arm32_cpu.rs
+++ b/wie-core-arm/src/engine/debugged_arm32_cpu.rs
@@ -7,7 +7,7 @@ use wie_util::WieError;
 
 use crate::{ThreadId, context::ArmCoreContext};
 
-use super::{Arm32CpuEngine, ArmEngine, ArmRegister, EngineRunResult, MemoryPermission};
+use super::{Arm32CpuEngine, ArmEngine, ArmRegister, EngineRunResult, EngineStopReason, MemoryPermission};
 
 #[derive(Copy, Clone)]
 enum ResumeMode {
@@ -420,32 +420,16 @@ impl DebuggedArm32CpuEngine {
     fn stop_thread_id(&self) -> ThreadId {
         self.debug.current_thread().unwrap_or(1)
     }
-
-    fn handle_breakpoint_reinsert(&mut self, addr: u32, end: u32, resume_mode: ResumeMode, count: &mut u32) -> wie_util::Result<()> {
-        let mut remaining = 1;
-        let result = self.debug.cpu.lock().run(end, &mut remaining);
-        *count -= 1 - remaining;
-        if let Err(error) = self.debug.reinsert_breakpoint(addr) {
-            self.stop(DebugStopReason::Signal(DebugSignal::Abrt));
-            return Err(error);
-        }
-
-        match result {
-            Ok(EngineRunResult::Svc { .. }) => {}
-            Ok(_) if matches!(resume_mode, ResumeMode::Continue) => {}
-            Ok(_) => self.stop(DebugStopReason::SwBreak(self.stop_thread_id())),
-            Err(error) => self.stop(DebugInner::map_stop_reason(error)),
-        }
-
-        Ok(())
-    }
 }
 
 impl ArmEngine for DebuggedArm32CpuEngine {
-    fn run(&mut self, end: u32, count: &mut u32) -> wie_util::Result<EngineRunResult> {
+    fn run(&mut self, end: u32, count: u32) -> wie_util::Result<EngineRunResult> {
+        let mut instructions_executed = 0;
         loop {
-            if *count == 0 {
-                return self.debug.cpu.lock().run(end, count);
+            if instructions_executed == count {
+                let mut result = self.debug.cpu.lock().run(end, 0)?;
+                result.instructions_executed += instructions_executed;
+                return Ok(result);
             }
 
             if self.debug.take_interrupt() {
@@ -455,48 +439,49 @@ impl ArmEngine for DebuggedArm32CpuEngine {
 
             let resume_mode = self.wait_for_resume_mode();
 
-            if let Some(addr) = self.pending_breakpoint_reinsert.take() {
-                self.handle_breakpoint_reinsert(addr, end, resume_mode, count)?;
-                continue;
-            }
-
-            let current_pc = DebugInner::normalize_addr(self.debug.cpu.lock().reg_read(ArmRegister::PC));
-
-            match self.debug.try_restore_breakpoint(current_pc) {
-                Ok(true) => {
-                    self.pending_breakpoint_reinsert = Some(current_pc);
-                    self.stop(DebugStopReason::SwBreak(self.stop_thread_id()));
-                    continue;
-                }
-                Ok(false) => {}
-                Err(error) => {
+            let result = if let Some(addr) = self.pending_breakpoint_reinsert.take() {
+                let result = self.debug.cpu.lock().run(end, 1);
+                if let Err(error) = self.debug.reinsert_breakpoint(addr) {
                     self.stop(DebugStopReason::Signal(DebugSignal::Abrt));
                     return Err(error);
                 }
-            }
+                result
+            } else {
+                let current_pc = DebugInner::normalize_addr(self.debug.cpu.lock().reg_read(ArmRegister::PC));
 
-            let run_count = match resume_mode {
-                ResumeMode::Continue => {
-                    if self.debug.has_breakpoints() {
-                        1
-                    } else {
-                        *count
+                match self.debug.try_restore_breakpoint(current_pc) {
+                    Ok(true) => {
+                        self.pending_breakpoint_reinsert = Some(current_pc);
+                        self.stop(DebugStopReason::SwBreak(self.stop_thread_id()));
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        self.stop(DebugStopReason::Signal(DebugSignal::Abrt));
+                        return Err(error);
                     }
                 }
-                ResumeMode::Step => 1,
+
+                let run_count = match resume_mode {
+                    ResumeMode::Continue if !self.debug.has_breakpoints() => count - instructions_executed,
+                    _ => 1,
+                };
+                self.debug.cpu.lock().run(end, run_count)
             };
 
-            let mut remaining = run_count;
-            let result = self.debug.cpu.lock().run(end, &mut remaining);
-            *count -= run_count - remaining;
-
             match result {
-                Ok(result @ EngineRunResult::Svc { .. }) => return Ok(result),
-                Ok(EngineRunResult::CountExhausted) if *count > 0 && matches!(resume_mode, ResumeMode::Continue) => continue,
-                Ok(result) => match resume_mode {
-                    ResumeMode::Continue => return Ok(result),
-                    ResumeMode::Step => self.stop(DebugStopReason::SwBreak(self.stop_thread_id())),
-                },
+                Ok(mut result) => {
+                    instructions_executed += result.instructions_executed;
+                    result.instructions_executed = instructions_executed;
+                    match result.stop_reason {
+                        EngineStopReason::Svc { .. } => return Ok(result),
+                        EngineStopReason::CountExhausted if instructions_executed < count && matches!(resume_mode, ResumeMode::Continue) => continue,
+                        _ => match resume_mode {
+                            ResumeMode::Continue => return Ok(result),
+                            ResumeMode::Step => self.stop(DebugStopReason::SwBreak(self.stop_thread_id())),
+                        },
+                    }
+                }
                 Err(error) => self.stop(DebugInner::map_stop_reason(error)),
             }
         }
@@ -542,12 +527,9 @@ mod tests {
         engine.debug.resume_continue();
         engine.debug.resume_continue();
 
-        let mut remaining = 3;
-        assert!(matches!(
-            engine.run(0, &mut remaining).unwrap(),
-            EngineRunResult::Svc { category: 1, lr: 0x1006, .. }
-        ));
-        assert_eq!(remaining, 0);
+        let result = engine.run(0, 3).unwrap();
+        assert!(matches!(result.stop_reason, EngineStopReason::Svc { category: 1, lr: 0x1006, .. }));
+        assert_eq!(result.instructions_executed, 3);
         assert_eq!(engine.reg_read(ArmRegister::R0), 2);
     }
 

--- a/wie-core-arm/src/engine/debugged_arm32_cpu.rs
+++ b/wie-core-arm/src/engine/debugged_arm32_cpu.rs
@@ -421,8 +421,10 @@ impl DebuggedArm32CpuEngine {
         self.debug.current_thread().unwrap_or(1)
     }
 
-    fn handle_breakpoint_reinsert(&mut self, addr: u32, end: u32, resume_mode: ResumeMode) -> wie_util::Result<()> {
-        let result = self.debug.cpu.lock().run(end, 1);
+    fn handle_breakpoint_reinsert(&mut self, addr: u32, end: u32, resume_mode: ResumeMode, count: &mut u32) -> wie_util::Result<()> {
+        let mut remaining = 1;
+        let result = self.debug.cpu.lock().run(end, &mut remaining);
+        *count -= 1 - remaining;
         if let Err(error) = self.debug.reinsert_breakpoint(addr) {
             self.stop(DebugStopReason::Signal(DebugSignal::Abrt));
             return Err(error);
@@ -440,8 +442,12 @@ impl DebuggedArm32CpuEngine {
 }
 
 impl ArmEngine for DebuggedArm32CpuEngine {
-    fn run(&mut self, end: u32, count: u32) -> wie_util::Result<EngineRunResult> {
+    fn run(&mut self, end: u32, count: &mut u32) -> wie_util::Result<EngineRunResult> {
         loop {
+            if *count == 0 {
+                return self.debug.cpu.lock().run(end, count);
+            }
+
             if self.debug.take_interrupt() {
                 self.stop(DebugStopReason::Signal(DebugSignal::Trap));
                 continue;
@@ -450,7 +456,7 @@ impl ArmEngine for DebuggedArm32CpuEngine {
             let resume_mode = self.wait_for_resume_mode();
 
             if let Some(addr) = self.pending_breakpoint_reinsert.take() {
-                self.handle_breakpoint_reinsert(addr, end, resume_mode)?;
+                self.handle_breakpoint_reinsert(addr, end, resume_mode, count)?;
                 continue;
             }
 
@@ -474,16 +480,19 @@ impl ArmEngine for DebuggedArm32CpuEngine {
                     if self.debug.has_breakpoints() {
                         1
                     } else {
-                        count
+                        *count
                     }
                 }
                 ResumeMode::Step => 1,
             };
 
-            let result = self.debug.cpu.lock().run(end, run_count);
+            let mut remaining = run_count;
+            let result = self.debug.cpu.lock().run(end, &mut remaining);
+            *count -= run_count - remaining;
 
             match result {
                 Ok(result @ EngineRunResult::Svc { .. }) => return Ok(result),
+                Ok(EngineRunResult::CountExhausted) if *count > 0 && matches!(resume_mode, ResumeMode::Continue) => continue,
                 Ok(result) => match resume_mode {
                     ResumeMode::Continue => return Ok(result),
                     ResumeMode::Step => self.stop(DebugStopReason::SwBreak(self.stop_thread_id())),
@@ -521,6 +530,26 @@ impl ArmEngine for DebuggedArm32CpuEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn breakpoint_steps_count_toward_the_svc_instruction_budget() {
+        let mut engine = DebuggedArm32CpuEngine::new();
+        engine.mem_map(0x1000, 0x1000, MemoryPermission::ReadWriteExecute);
+        engine.mem_write(0x1000, &[0x01, 0x30, 0x01, 0x30, 0x01, 0xdf]).unwrap(); // add r0, #1; add r0, #1; svc #1
+        engine.reg_write(ArmRegister::Cpsr, 0x3f);
+        engine.reg_write(ArmRegister::PC, 0x1001);
+        engine.debug.add_breakpoint(0x1002, DebugBreakpointKind::Thumb16).unwrap();
+        engine.debug.resume_continue();
+        engine.debug.resume_continue();
+
+        let mut remaining = 3;
+        assert!(matches!(
+            engine.run(0, &mut remaining).unwrap(),
+            EngineRunResult::Svc { category: 1, lr: 0x1006, .. }
+        ));
+        assert_eq!(remaining, 0);
+        assert_eq!(engine.reg_read(ArmRegister::R0), 2);
+    }
 
     #[test]
     fn test_thumb_breakpoint_patch_and_restore() {

--- a/wie-ktf/src/emulator.rs
+++ b/wie-ktf/src/emulator.rs
@@ -166,6 +166,8 @@ impl KtfEmulator {
             .await
             .unwrap();
 
+        KtfJvmSupport::register_static_classes(core, &jvm, class_loader, &main_class_name).await?;
+
         let mut args_array = jvm.instantiate_array("Ljava/lang/String;", 1).await.unwrap();
         jvm.store_array(&mut args_array, 0, vec![main_class_name_java]).await.unwrap();
         let result: JvmResult<()> = jvm

--- a/wie-ktf/src/runtime/init.rs
+++ b/wie-ktf/src/runtime/init.rs
@@ -45,7 +45,7 @@ pub async fn load_native(
     data: &[u8],
     ptr_jvm_context: u32,
     ptr_current_jvm_thread_context: u32,
-) -> Result<ExeInterfaceFunctions> {
+) -> Result<u32> {
     let bss_size = parse_bss_size(filename)?;
 
     core.load(data, IMAGE_BASE, data.len() + bss_size as usize)?;
@@ -100,7 +100,7 @@ pub async fn load_native(
         fn_java_check_type: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::JavaCheckType)?,
         fn_java_new: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::JavaNew)?,
         fn_java_array_new: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::JavaArrayNew)?,
-        unk6: 0,
+        fn_visit_gc_root: 0,
         fn_java_class_load: core.make_svc_stub(SVC_CATEGORY_INIT, InitSvcId::JavaClassLoad)?,
         unk7: 0,
         unk8: 0,
@@ -132,7 +132,7 @@ pub async fn load_native(
         return Err(WieError::FatalError(format!("wipi init failed with code {result:#x}")));
     }
 
-    Ok(exe_interface_functions)
+    Ok(exe_interface.ptr_functions)
 }
 
 async fn get_interface(core: &mut ArmCore, ptr_name: u32) -> Result<u32> {

--- a/wie-ktf/src/runtime/java/jvm_support.rs
+++ b/wie-ktf/src/runtime/java/jvm_support.rs
@@ -15,8 +15,10 @@ use core::mem::{offset_of, size_of};
 use jvm_implementation::KtfJvmImplementation;
 
 use bytemuck::{Pod, Zeroable};
+use futures::TryFutureExt;
 
-use jvm::{ClassDefinition, ClassInstance, ClassInstanceRef, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm::{ClassDefinition, ClassInstance, ClassInstanceRef, Field, Jvm, Result as JvmResult, runtime::JavaLangString};
+use jvm_types::FieldAccessFlags;
 use rustjava_runtime::classes::java::util::{Enumeration, jar::JarEntry};
 
 use wie_backend::System;
@@ -25,7 +27,7 @@ use wie_jvm_support::JvmSupport;
 use wie_midp::classes::javax::microedition::midlet::MIDlet;
 use wie_util::{Result, WieError, read_generic, read_null_terminated_table, write_generic};
 
-use wipi_types::ktf::InitParam2;
+use wipi_types::ktf::{ExeInterfaceFunctions, InitParam2, java::JavaClass as RawJavaClass};
 
 use self::{
     array_class_instance::JavaArrayClassInstance,
@@ -160,6 +162,55 @@ impl KtfJvmSupport {
         Ok((jvm, class_loader))
     }
 
+    // Native initialization must have linked the class catalog before registration.
+    pub(crate) async fn register_static_classes(
+        core: &mut ArmCore,
+        jvm: &Jvm,
+        class_loader: Box<dyn ClassInstance>,
+        main_class_name: &str,
+    ) -> Result<()> {
+        let ptr_functions: i32 = jvm
+            .get_field(&class_loader, "nativeFunctions", "I")
+            .or_else(async |error| Err(JvmSupport::to_wie_err(jvm, error).await))
+            .await?;
+        let functions: ExeInterfaceFunctions = read_generic(core, ptr_functions as u32)?;
+        let predicate = functions.fn_is_native_class_address;
+        if predicate == 0 {
+            return Ok(());
+        }
+
+        let main_class = jvm
+            .resolve_class(main_class_name)
+            .or_else(async |error| Err(JvmSupport::to_wie_err(jvm, error).await))
+            .await?;
+        let mut ptr_class = Self::class_definition_raw(&*main_class.definition)?;
+        if core.run_function::<u32>(predicate, &[ptr_class]).await? == 0 {
+            return Ok(());
+        }
+
+        let class_size = size_of::<RawJavaClass>() as u32;
+        while core.run_function::<u32>(predicate, &[ptr_class - class_size]).await? != 0 {
+            ptr_class -= class_size;
+        }
+        while core.run_function::<u32>(predicate, &[ptr_class]).await? != 0 {
+            let class = JavaClassDefinition::from_raw(ptr_class, core);
+            let name = class.name()?;
+            if !jvm.has_class(&name)
+                && class
+                    .fields()?
+                    .iter()
+                    .any(|field| field.access_flags().contains(FieldAccessFlags::STATIC))
+            {
+                jvm.register_class(Box::new(class), Some(class_loader.clone()))
+                    .or_else(async |error| Err(JvmSupport::to_wie_err(jvm, error).await))
+                    .await?;
+            }
+            ptr_class += class_size;
+        }
+
+        Ok(())
+    }
+
     pub(crate) async fn disable_midp_paint(jvm: &Jvm) -> JvmResult<()> {
         let midlet: ClassInstanceRef<MIDlet> = jvm
             .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
@@ -245,13 +296,24 @@ mod test {
     use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
     use core::{
         mem::size_of,
-        sync::atomic::{AtomicBool, Ordering},
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     };
 
     use bytemuck::Zeroable;
-    use jvm::{ClassInstanceRef, JavaValue, Jvm, runtime::JavaLangString};
-    use jvm_types::{ClassAccessFlags, MethodAccessFlags};
-    use wipi_types::ktf::java::JavaMethodDefinition as RawJavaMethod;
+    use jvm::{
+        ClassInstanceRef, JavaValue, Jvm,
+        runtime::{JavaLangClass, JavaLangString},
+    };
+    use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
+    use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+    use rustjava_runtime::classes::java::lang::Class;
+    use wipi_types::ktf::{
+        ExeInterfaceFunctions,
+        java::{
+            JavaClass as RawJavaClass, JavaClassInstance as RawJavaClassInstance, JavaFieldDefinition as RawJavaField,
+            JavaMethodDefinition as RawJavaMethod,
+        },
+    };
 
     use wie_backend::{DefaultTaskRunner, System};
     use wie_core_arm::{Allocator, ArmCore};
@@ -259,7 +321,12 @@ mod test {
     use wie_midp::classes::javax::microedition::{lcdui::Display as MidpDisplay, midlet::MIDlet};
     use wie_util::{Result, WieError, read_generic, write_generic};
 
-    use super::{JavaArrayClassInstance, JavaClassDefinition, JavaMethod, KtfJvmSupport, KtfJvmThreadContext, value::JavaValueCodec};
+    use crate::runtime::java::{JavaSvcFunctions, handle_java_svc};
+
+    use super::{
+        ClassLoaderContext, JavaArrayClassInstance, JavaClassDefinition, JavaMethod, KtfClassLoader, KtfJvmSupport, KtfJvmThreadContext,
+        value::JavaValueCodec,
+    };
 
     use test_utils::{TestClock, TestPlatform};
 
@@ -279,6 +346,204 @@ mod test {
         let (jvm, _) = KtfJvmSupport::init(&mut core, system, None).await?;
 
         Ok((jvm, core))
+    }
+
+    #[test]
+    fn test_register_static_classes_keeps_live_guest_roots_without_initializing() -> Result<()> {
+        async fn is_native_class(_core: &mut ArmCore, range: &mut core::ops::Range<u32>, address: u32) -> Result<u32> {
+            Ok(u32::from(range.contains(&address)))
+        }
+
+        async fn count_initialization(_jvm: &Jvm, count: &mut Arc<AtomicUsize>) -> jvm::Result<()> {
+            count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        let mut system = System::new(Box::new(TestPlatform::new()), "", "", DefaultTaskRunner);
+        let done = Arc::new(AtomicBool::new(false));
+        let done_clone = done.clone();
+        let mut system_clone = system.clone();
+        system.spawn(async move || {
+            let (jvm, mut core) = init_jvm(&mut system_clone).await?;
+            let java_functions = JavaSvcFunctions::default();
+            core.register_svc_handler(5, handle_java_svc, &java_functions)?;
+            let loader_class = JavaClassDefinition::new(
+                &mut core.clone(),
+                &jvm,
+                KtfClassLoader::as_proto(),
+                Box::new(ClassLoaderContext {
+                    core: core.clone(),
+                    system: system_clone.clone(),
+                }),
+                java_functions.clone(),
+            )
+            .await?;
+            for method in loader_class.methods()? {
+                let mut raw: RawJavaMethod = read_generic(&core, method.ptr_raw)?;
+                raw.fn_body = core.make_svc_stub(5, method.ptr_raw)?;
+                write_generic(&mut core, method.ptr_raw, raw)?;
+            }
+            jvm.register_class(Box::new(loader_class), None).await.unwrap();
+            let mut loader = jvm.instantiate_class("net/wie/KtfClassLoader").await.unwrap();
+            let ptr_functions = Allocator::alloc(&mut core, size_of::<ExeInterfaceFunctions>() as u32)?;
+            let mut functions = ExeInterfaceFunctions::zeroed();
+            write_generic(&mut core, ptr_functions, functions)?;
+            jvm.put_field(&mut loader, "nativeFunctions", "I", ptr_functions as i32).await.unwrap();
+
+            let missing_name = JavaLangString::from_rust_string(&jvm, "test/Missing").await.unwrap();
+            let missing: ClassInstanceRef<Class> = jvm
+                .invoke_virtual(
+                    &loader,
+                    "net/wie/KtfClassLoader",
+                    "findClass",
+                    "(Ljava/lang/String;)Ljava/lang/Class;",
+                    (missing_name,),
+                )
+                .await
+                .unwrap();
+            assert!(missing.is_null());
+
+            let class_size = size_of::<RawJavaClass>() as u32;
+            let begin = Allocator::alloc(&mut core, class_size * 4)?;
+            let end = begin + class_size * 4;
+            core.register_svc_handler(6, is_native_class, &(begin..end))?;
+            let predicate = core.make_svc_stub(6, 0u32)?;
+            let initialization_count = Arc::new(AtomicUsize::new(0));
+            let mut classes = Vec::new();
+            for (index, name) in ["test/Before", "test/Unused", "test/Main", "test/After"].into_iter().enumerate() {
+                let class = JavaClassDefinition::new(
+                    &mut core,
+                    &jvm,
+                    JavaClassProto {
+                        name,
+                        parent_class: Some("java/lang/Object"),
+                        interfaces: vec![],
+                        methods: if index == 0 {
+                            vec![JavaMethodProto::new("<clinit>", "()V", count_initialization, MethodAccessFlags::STATIC)]
+                        } else {
+                            vec![]
+                        },
+                        fields: vec![JavaFieldProto::new(
+                            "root",
+                            "Ljava/lang/Object;",
+                            if index == 1 {
+                                FieldAccessFlags::PUBLIC
+                            } else {
+                                FieldAccessFlags::STATIC
+                            },
+                        )],
+                        access_flags: ClassAccessFlags::PUBLIC,
+                    },
+                    Box::new(initialization_count.clone()),
+                    java_functions.clone(),
+                )
+                .await?;
+
+                // Relocate only the class headers into the native ABI's contiguous table.
+                let ptr_class = begin + index as u32 * class_size;
+                let mut raw: RawJavaClass = read_generic(&core, class.ptr_raw)?;
+                raw.ptr_next = ptr_class + 4;
+                write_generic(&mut core, ptr_class, raw)?;
+                for field in class.fields()? {
+                    let mut raw: RawJavaField = read_generic(&core, field.ptr_raw)?;
+                    raw.ptr_class = ptr_class;
+                    write_generic(&mut core, field.ptr_raw, raw)?;
+                }
+                for method in class.methods()? {
+                    let mut raw: RawJavaMethod = read_generic(&core, method.ptr_raw)?;
+                    raw.ptr_class = ptr_class;
+                    raw.fn_body = core.make_svc_stub(5, method.ptr_raw)?;
+                    write_generic(&mut core, method.ptr_raw, raw)?;
+                }
+                classes.push(JavaClassDefinition::from_raw(ptr_class, &core));
+            }
+            let seed = jvm
+                .register_class(Box::new(classes[2].clone()), Some(loader.clone()))
+                .await
+                .unwrap()
+                .unwrap();
+            let seed_identity = seed.identity();
+
+            KtfJvmSupport::register_static_classes(&mut core, &jvm, loader.clone(), "test/Main").await?;
+            assert!(!jvm.has_class("test/Before"));
+            assert!(!jvm.has_class("test/After"));
+            functions.fn_is_native_class_address = predicate;
+            write_generic(&mut core, ptr_functions, functions)?;
+            KtfJvmSupport::register_static_classes(&mut core, &jvm, loader.clone(), "java/lang/Object").await?;
+            assert!(!jvm.has_class("test/Before"));
+            assert!(!jvm.has_class("test/After"));
+
+            let mut identities = Vec::new();
+            for pass in 0..2 {
+                KtfJvmSupport::register_static_classes(&mut core, &jvm, loader.clone(), "test/Main").await?;
+                assert!(!jvm.has_class("test/Unused"));
+                for (index, name) in ["test/Before", "test/Main", "test/After"].into_iter().enumerate() {
+                    assert!(jvm.has_class(name));
+                    let class = jvm.resolve_class(name).await.unwrap().java_class();
+                    let registered_loader = JavaLangClass::class_loader(&jvm, &class).await.unwrap().unwrap();
+                    assert_eq!(registered_loader.identity(), loader.identity());
+                    if pass == 0 {
+                        identities.push(class.identity());
+                    } else {
+                        assert_eq!(class.identity(), identities[index]);
+                    }
+                }
+                assert_eq!(identities[1], seed_identity);
+                assert_eq!(initialization_count.load(Ordering::Relaxed), 0);
+            }
+            for class in &classes {
+                let raw: RawJavaClass = read_generic(&core, class.ptr_raw)?;
+                assert_eq!(raw.unk_flag, 8);
+            }
+
+            let before_root = classes[0].field("root", "Ljava/lang/Object;", true)?.unwrap();
+            let after_root = classes[3].field("root", "Ljava/lang/Object;", true)?.unwrap();
+            jvm.pop_frame();
+            jvm.collect_garbage().unwrap();
+            jvm.push_native_frame();
+            let mut objects = Vec::new();
+            for _ in 0..3 {
+                let object = jvm.new_class("java/lang/Object", "()V", ()).await.unwrap();
+                objects.push(KtfJvmSupport::class_instance_raw(&object));
+            }
+            classes[0].write_static_field(&before_root, objects[0])?;
+            classes[3].write_static_field(&after_root, objects[1])?;
+            jvm.pop_frame();
+            jvm.collect_garbage().unwrap();
+            let instance_size = size_of::<RawJavaClassInstance>() as u32;
+            assert!(Allocator::is_allocated(&core, objects[0], instance_size)?);
+            assert!(Allocator::is_allocated(&core, objects[1], instance_size)?);
+            assert!(!Allocator::is_allocated(&core, objects[2], instance_size)?);
+
+            jvm.push_native_frame();
+            let replacement = jvm.new_class("java/lang/Object", "()V", ()).await.unwrap();
+            let replacement = KtfJvmSupport::class_instance_raw(&replacement);
+            classes[0].write_static_field(&before_root, replacement)?;
+            jvm.pop_frame();
+            jvm.collect_garbage().unwrap();
+            assert!(!Allocator::is_allocated(&core, objects[0], instance_size)?);
+            assert!(Allocator::is_allocated(&core, objects[1], instance_size)?);
+            assert!(Allocator::is_allocated(&core, replacement, instance_size)?);
+
+            classes[0].write_static_field(&before_root, 0)?;
+            classes[3].write_static_field(&after_root, 0)?;
+            jvm.collect_garbage().unwrap();
+            assert!(!Allocator::is_allocated(&core, objects[1], instance_size)?);
+            assert!(!Allocator::is_allocated(&core, replacement, instance_size)?);
+            assert_eq!(initialization_count.load(Ordering::Relaxed), 0);
+            jvm.push_native_frame();
+            jvm.ensure_initialized(&jvm.resolve_class("test/Before").await.unwrap()).await.unwrap();
+            assert_eq!(initialization_count.load(Ordering::Relaxed), 1);
+            jvm.pop_frame();
+
+            done_clone.store(true, Ordering::Relaxed);
+            Ok(())
+        });
+
+        while !done.load(Ordering::Relaxed) {
+            system.tick()?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/wie-ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/classes/net/wie/ktf_class_loader.rs
@@ -8,10 +8,11 @@ use jvm::{
 use jvm_class_proto::{JavaClassProto, JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::{Class, ClassLoader, String};
+use wipi_types::ktf::ExeInterfaceFunctions;
 
 use wie_backend::System;
 use wie_core_arm::{Allocator, ArmCore};
-use wie_util::write_null_terminated_string_bytes;
+use wie_util::{read_generic, write_null_terminated_string_bytes};
 
 use crate::runtime::{init::load_native, java::jvm_support::class_definition::JavaClassDefinition};
 
@@ -47,7 +48,7 @@ impl KtfClassLoader {
                 ),
             ],
             fields: vec![
-                JavaFieldProto::new("fnGetClass", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("nativeFunctions", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("nativeStrings", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new(
                     "instance",
@@ -107,7 +108,7 @@ impl KtfClassLoader {
         .await
         .unwrap();
 
-        jvm.put_field(&mut this, "fnGetClass", "I", native_functions.fn_get_class as i32).await?;
+        jvm.put_field(&mut this, "nativeFunctions", "I", native_functions as i32).await?;
 
         Ok(())
     }
@@ -120,9 +121,13 @@ impl KtfClassLoader {
     ) -> JvmResult<ClassInstanceRef<Class>> {
         tracing::debug!("net.wie.KtfClassLoader::findClass({this:?}, {name:?})");
 
-        let fn_get_class: i32 = jvm.get_field(&this, "fnGetClass", "I").await?;
+        let ptr_native_functions: i32 = jvm.get_field(&this, "nativeFunctions", "I").await?;
 
-        if fn_get_class == 0 {
+        if ptr_native_functions == 0 {
+            return Ok(None.into());
+        }
+        let native_functions: ExeInterfaceFunctions = read_generic(&context.core, ptr_native_functions as u32).unwrap();
+        if native_functions.fn_get_class == 0 {
             return Ok(None.into());
         }
 
@@ -133,7 +138,7 @@ impl KtfClassLoader {
         let ptr_name = Allocator::alloc(&mut context.core, ptr_name_size).unwrap();
         write_null_terminated_string_bytes(&mut context.core, ptr_name, name.as_bytes()).unwrap();
 
-        let ptr_raw = context.core.run_function(fn_get_class as _, &[ptr_name]).await.unwrap();
+        let ptr_raw = context.core.run_function(native_functions.fn_get_class, &[ptr_name]).await.unwrap();
         Allocator::free(&mut context.core, ptr_name, ptr_name_size).unwrap();
 
         if ptr_raw != 0 {


### PR DESCRIPTION
## Summary

Stacked on #1397 (`fix/ktf-static-class-registration`, baseline `47abdce8`). This PR contains only the ARM instruction-budget fix.

- `run(end, count)` takes its instruction budget by value and returns an `EngineRunResult` containing `stop_reason` and `instructions_executed`. `ArmCore` subtracts that execution count from its shared 10,000-instruction budget across SVC dispatch, nested ARM calls, and completed function calls.
- Yield when the budget reaches zero, even if the last instruction was an SVC or a return. Restore the pre-SVC register state before yielding, since thread contexts do not save banked exception registers.
- Account for instructions executed by GDB single-stepping and breakpoint reinsertion using the same budget.

## Verification

- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test --workspace`: 317 tests passed, including 74 tests in `wie-core-arm`.
- Five new regressions cover SVC-heavy execution, nested calls, short returning calls, GDB breakpoint accounting, and the reported execution count at budget/return boundaries (including zero instructions).
- `npm run build:dev`

The SVC-heavy regression failed before the fix: one poll completed the whole 20,001-instruction program without yielding. After the fix it yields at instruction 10,000 and 20,000, then completes on the third poll. The checks also cover an SVC exactly at the budget boundary and restoration out of exception mode.

## Firefox Benchmark

Local comparison using the same KTF game archive and input sequence for both builds. These are indicative development-build measurements, not production performance guarantees or hardware-isolated measurements.

The measured commits are `47abdce8` (before) and `84c4dd7c` (after the yield fix). These timings predate the follow-up change from a mutable budget parameter to an explicit execution count in the run result.

- Linux x86_64, AMD Ryzen 9 3900X; Playwright Firefox 155.0, headless, 1280x900 viewport.
- Both builds use `npm run build:dev` / `wasm-pack --dev` (unoptimized WASM), served locally from separate immutable build directories.
- Three fresh browser contexts per build. Launch the game, press Space after 15 seconds, again 6 seconds later and again 3 seconds later, then wait another 35 seconds. Each recording spans approximately 59 seconds.
- Measure each `requestAnimationFrame` callback with `performance.now()` around the existing callback, which calls `WieWeb.update()`. No runtime features or logging are disabled. This measures main-thread callback duration, not rendered FPS or emulated instruction throughput.
- All six runs completed without page errors or error dialogs. Before/after screenshots show the same in-game room.
- Input archive SHA-256: `ead25bc6ffa7777862328ba6fa057911645d69ad47c2e8d922a1d545a1728d2d`.

Median of the three per-run measurements:

| Metric | Before | After |
| --- | ---: | ---: |
| P50 callback duration | 10 ms | 10 ms |
| P95 callback duration | 111 ms | 96 ms |
| P99 callback duration | 365 ms | 118 ms |
| Maximum callback duration | 1,669 ms | 517 ms |
| Callbacks exceeding 50 ms | 29.35% | 14.44% |
| Recorded callbacks | 1,341 | 2,097 |

P99 decreased by approximately 68%, and the median maximum callback duration decreased by approximately 69%.

Raw per-run results:

| Build / run | Callbacks | P50 (ms) | P95 (ms) | P99 (ms) | Max (ms) | Over 50 ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Before 1 | 1,341 | 10 | 111 | 365 | 1,669 | 394 |
| Before 2 | 1,333 | 10 | 112 | 374 | 2,180 | 385 |
| Before 3 | 1,356 | 10 | 110 | 336 | 1,640 | 398 |
| After 1 | 2,098 | 10 | 96 | 118 | 517 | 303 |
| After 2 | 2,058 | 10 | 101 | 119 | 508 | 305 |
| After 3 | 2,097 | 10 | 96 | 115 | 563 | 300 |

This bounds ARM instructions between cooperative yields, not wall-clock execution time. Synchronous host-side work can still exceed the executor's 8 ms budget; the remaining 508-563 ms maximum callbacks require separate profiling. This PR does not claim to fix the separately reported Firefox reload hang.
