### PR TITLE
Fix input backlog from recurring display callbacks

### DIFF
--- a/wie-backend/src/system/event_queue.rs
+++ b/wie-backend/src/system/event_queue.rs
@@ -103,8 +103,9 @@ impl EventQueue {
         self.events.push_back(event);
     }
 
-    pub fn pop(&mut self) -> Option<Event> {
-        self.events.pop_front()
+    /// Returns the oldest event and the number of events left in the queue.
+    pub fn pop(&mut self) -> Option<(Event, usize)> {
+        self.events.pop_front().map(|event| (event, self.events.len()))
     }
 }
 
@@ -123,13 +124,13 @@ mod tests {
         }
         queue.push(Event::Keyup(KeyCode::DOWN));
 
-        assert!(matches!(queue.pop(), Some(Event::Keydown(KeyCode::DOWN))));
-        assert!(matches!(queue.pop(), Some(Event::Redraw)));
+        assert!(matches!(queue.pop(), Some((Event::Keydown(KeyCode::DOWN), 3))));
+        assert!(matches!(queue.pop(), Some((Event::Redraw, 2))));
         // A repaint requested while painting still needs another delivery.
         queue.push(Event::Redraw);
-        assert!(matches!(queue.pop(), Some(Event::Keyrepeat(KeyCode::DOWN))));
-        assert!(matches!(queue.pop(), Some(Event::Keyup(KeyCode::DOWN))));
-        assert!(matches!(queue.pop(), Some(Event::Redraw)));
+        assert!(matches!(queue.pop(), Some((Event::Keyrepeat(KeyCode::DOWN), 2))));
+        assert!(matches!(queue.pop(), Some((Event::Keyup(KeyCode::DOWN), 1))));
+        assert!(matches!(queue.pop(), Some((Event::Redraw, 0))));
         assert!(queue.pop().is_none());
     }
 }

--- a/wie-backend/src/system/event_queue.rs
+++ b/wie-backend/src/system/event_queue.rs
@@ -88,33 +88,40 @@ impl Event {
 
 #[derive(Default)]
 pub struct EventQueue {
+    input_events: VecDeque<Event>,
     events: VecDeque<Event>,
 }
 
 impl EventQueue {
     pub fn new() -> Self {
-        Self { events: VecDeque::new() }
+        Self::default()
     }
 
     pub fn push(&mut self, event: Event) {
+        if matches!(event, Event::Keydown(_) | Event::Keyup(_) | Event::Keyrepeat(_)) {
+            self.input_events.push_back(event);
+            return;
+        }
         if matches!(event, Event::Redraw) && self.events.iter().any(|event| matches!(event, Event::Redraw)) {
             return;
         }
         self.events.push_back(event);
     }
 
-    /// Returns the oldest event and the number of events left in the queue.
-    pub fn pop(&mut self) -> Option<(Event, usize)> {
-        self.events.pop_front().map(|event| (event, self.events.len()))
+    /// Keyboard input takes priority; events at the same priority remain FIFO.
+    pub fn pop(&mut self) -> Option<Event> {
+        self.input_events.pop_front().or_else(|| self.events.pop_front())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::Instant;
+
     use super::{Event, EventQueue, KeyCode};
 
     #[test]
-    fn coalesces_pending_redraws_without_reordering_input() {
+    fn prioritizes_input_and_coalesces_pending_redraws() {
         let mut queue = EventQueue::new();
         queue.push(Event::Keydown(KeyCode::DOWN));
         queue.push(Event::Redraw);
@@ -124,13 +131,38 @@ mod tests {
         }
         queue.push(Event::Keyup(KeyCode::DOWN));
 
-        assert!(matches!(queue.pop(), Some((Event::Keydown(KeyCode::DOWN), 3))));
-        assert!(matches!(queue.pop(), Some((Event::Redraw, 2))));
+        assert!(matches!(queue.pop(), Some(Event::Keydown(KeyCode::DOWN))));
+        assert!(matches!(queue.pop(), Some(Event::Keyrepeat(KeyCode::DOWN))));
+        assert!(matches!(queue.pop(), Some(Event::Keyup(KeyCode::DOWN))));
+        assert!(matches!(queue.pop(), Some(Event::Redraw)));
         // A repaint requested while painting still needs another delivery.
         queue.push(Event::Redraw);
-        assert!(matches!(queue.pop(), Some((Event::Keyrepeat(KeyCode::DOWN), 2))));
-        assert!(matches!(queue.pop(), Some((Event::Keyup(KeyCode::DOWN), 1))));
-        assert!(matches!(queue.pop(), Some((Event::Redraw, 0))));
+        assert!(matches!(queue.pop(), Some(Event::Redraw)));
+        assert!(queue.pop().is_none());
+    }
+
+    #[test]
+    fn new_input_precedes_timers_and_notifications_without_reordering_them() {
+        let mut queue = EventQueue::new();
+        queue.push(Event::timer(Instant::from_epoch_millis(10), || async { Ok(()) }));
+        queue.push(Event::Notify {
+            r#type: 1,
+            param1: 2,
+            param2: 3,
+        });
+        queue.push(Event::Keydown(KeyCode::OK));
+        assert!(matches!(queue.pop(), Some(Event::Keydown(KeyCode::OK))));
+        queue.push(Event::Keyup(KeyCode::OK));
+        assert!(matches!(queue.pop(), Some(Event::Keyup(KeyCode::OK))));
+        assert!(matches!(queue.pop(), Some(Event::Timer { due, .. }) if due.raw() == 10));
+        assert!(matches!(
+            queue.pop(),
+            Some(Event::Notify {
+                r#type: 1,
+                param1: 2,
+                param2: 3
+            })
+        ));
         assert!(queue.pop().is_none());
     }
 }

--- a/wie-backend/src/system/event_queue.rs
+++ b/wie-backend/src/system/event_queue.rs
@@ -97,10 +97,39 @@ impl EventQueue {
     }
 
     pub fn push(&mut self, event: Event) {
+        if matches!(event, Event::Redraw) && self.events.iter().any(|event| matches!(event, Event::Redraw)) {
+            return;
+        }
         self.events.push_back(event);
     }
 
     pub fn pop(&mut self) -> Option<Event> {
         self.events.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Event, EventQueue, KeyCode};
+
+    #[test]
+    fn coalesces_pending_redraws_without_reordering_input() {
+        let mut queue = EventQueue::new();
+        queue.push(Event::Keydown(KeyCode::DOWN));
+        queue.push(Event::Redraw);
+        queue.push(Event::Keyrepeat(KeyCode::DOWN));
+        for _ in 0..100 {
+            queue.push(Event::Redraw);
+        }
+        queue.push(Event::Keyup(KeyCode::DOWN));
+
+        assert!(matches!(queue.pop(), Some(Event::Keydown(KeyCode::DOWN))));
+        assert!(matches!(queue.pop(), Some(Event::Redraw)));
+        // A repaint requested while painting still needs another delivery.
+        queue.push(Event::Redraw);
+        assert!(matches!(queue.pop(), Some(Event::Keyrepeat(KeyCode::DOWN))));
+        assert!(matches!(queue.pop(), Some(Event::Keyup(KeyCode::DOWN))));
+        assert!(matches!(queue.pop(), Some(Event::Redraw)));
+        assert!(queue.pop().is_none());
     }
 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -1010,6 +1010,7 @@ mod test {
             .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
             .await?;
         assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [1000, 731, 19, 23]);
+        let _: bool = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ()).await?;
         Ok(())
     }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -1010,7 +1010,7 @@ mod test {
             .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
             .await?;
         assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [1000, 731, 19, 23]);
-        let _: bool = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ()).await?;
+        let _: () = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()V", ()).await?;
         Ok(())
     }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -1445,12 +1445,23 @@ mod test {
                 panic!("CommandEvent swallowed the listener exception");
             };
             assert!(jvm.is_instance(&*exception, "java/lang/RuntimeException"));
+            let queue = jvm
+                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (event,))
+                .await?;
+            let result: JvmResult<()> = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()V", ()).await;
+            let Err(JavaError::JavaException(exception)) = result else {
+                panic!("EventQueue swallowed the callback exception");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/RuntimeException"));
             Ok(())
         })
     }
 
     #[test]
-    fn sole_application_command_fires_once_at_the_exact_deadline_despite_listener_exception() -> Result<()> {
+    fn sole_application_command_fires_once_and_propagates_its_listener_exception() -> Result<()> {
         let clock = TestClock::new();
         run_jvm_test_with_system(
             test_protos(),
@@ -1491,9 +1502,17 @@ mod test {
                         (alert.clone(), previous.clone()),
                     )
                     .await?;
-                for (now, count) in [(49, 0), (50, 1), (50, 1), (1000, 1)] {
+                for (now, count, failed) in [(49, 0, false), (50, 1, true), (50, 1, false), (1000, 1, false)] {
                     clock.set(now);
-                    pump_backend_queue(&jvm, &system).await?;
+                    let result = pump_backend_queue(&jvm, &system).await;
+                    if failed {
+                        let Err(JavaError::JavaException(exception)) = result else {
+                            panic!("Alert command listener exception was not propagated");
+                        };
+                        assert!(jvm.is_instance(&*exception, "java/lang/RuntimeException"));
+                    } else {
+                        result?;
+                    }
                     assert_eq!(jvm.get_field::<i32>(&listener, "count", "I").await?, count);
                     assert_eq!(current(&jvm, &display).await?.identity(), alert.identity());
                 }

--- a/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/alert.rs
@@ -1428,6 +1428,28 @@ mod test {
     }
 
     #[test]
+    fn command_event_propagates_listener_exception() -> Result<()> {
+        run_jvm_test(test_protos(), |jvm| async move {
+            let listener = jvm.new_class("javax/microedition/lcdui/TestAlertCommandListener", "()V", ()).await?;
+            let command = new_command(&jvm, "Continue").await?;
+            let alert = new_alert(&jvm, "custom").await?;
+            let event = jvm
+                .new_class(
+                    "net/wie/CommandEvent",
+                    "(Ljavax/microedition/lcdui/CommandListener;Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                    (listener, command, alert),
+                )
+                .await?;
+            let result: JvmResult<()> = jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await;
+            let Err(JavaError::JavaException(exception)) = result else {
+                panic!("CommandEvent swallowed the listener exception");
+            };
+            assert!(jvm.is_instance(&*exception, "java/lang/RuntimeException"));
+            Ok(())
+        })
+    }
+
+    #[test]
     fn sole_application_command_fires_once_at_the_exact_deadline_despite_listener_exception() -> Result<()> {
         let clock = TestClock::new();
         run_jvm_test_with_system(

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -107,12 +107,6 @@ impl Display {
                 JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
-                JavaMethodProto::new(
-                    "handleCallbackEvent",
-                    "(Ljava/lang/Runnable;)V",
-                    Self::handle_callback_event,
-                    MethodAccessFlags::STATIC,
-                ),
                 JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleAlertTimeout", "(I)V", Self::handle_alert_timeout, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleTickerTick", "(I)V", Self::handle_ticker_tick, MethodAccessFlags::empty()),
@@ -745,14 +739,6 @@ impl Display {
             }
         }
 
-        Ok(())
-    }
-
-    async fn handle_callback_event(jvm: &Jvm, _context: &mut WieJvmContext, callback: ClassInstanceRef<Runnable>) -> JvmResult<()> {
-        let result: JvmResult<()> = jvm.invoke_virtual(&callback, "java/lang/Runnable", "run", "()V", ()).await;
-        if let Err(error) = result {
-            Self::handle_exception(jvm, error).await?;
-        }
         Ok(())
     }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -107,6 +107,12 @@ impl Display {
                 JavaMethodProto::new("serviceRepaints", "()V", Self::service_repaints, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handlePaintEvent", "()V", Self::handle_paint_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleKeyEvent", "(II)V", Self::handle_key_event, MethodAccessFlags::empty()),
+                JavaMethodProto::new(
+                    "handleCallbackEvent",
+                    "(Ljava/lang/Runnable;)V",
+                    Self::handle_callback_event,
+                    MethodAccessFlags::STATIC,
+                ),
                 JavaMethodProto::new("handleNotifyEvent", "(III)V", Self::handle_notify_event, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleAlertTimeout", "(I)V", Self::handle_alert_timeout, MethodAccessFlags::empty()),
                 JavaMethodProto::new("handleTickerTick", "(I)V", Self::handle_ticker_tick, MethodAccessFlags::empty()),
@@ -742,6 +748,24 @@ impl Display {
         Ok(())
     }
 
+    async fn handle_callback_event(jvm: &Jvm, _context: &mut WieJvmContext, callback: ClassInstanceRef<Runnable>) -> JvmResult<()> {
+        let midlet: ClassInstanceRef<MIDlet> = jvm
+            .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+            .await?;
+        if !midlet.is_null() {
+            let display = MIDlet::display(jvm, &midlet).await?;
+            // A frontend Redraw may not have reached the backend queue yet.
+            let _: () = jvm
+                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
+                .await?;
+        }
+        let result: JvmResult<()> = jvm.invoke_virtual(&callback, "java/lang/Runnable", "run", "()V", ()).await;
+        if let Err(error) = result {
+            Self::handle_exception(jvm, error).await?;
+        }
+        Ok(())
+    }
+
     async fn handle_alert_timeout(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>, generation: i32) -> JvmResult<()> {
         let current_generation: i32 = jvm.get_field(&this, "alertGeneration", "I").await?;
         if current_generation != generation {
@@ -1021,7 +1045,7 @@ impl Display {
         jvm.get_field(&this, "screenGraphics", "Ljavax/microedition/lcdui/Graphics;").await
     }
 
-    pub(crate) async fn handle_exception(jvm: &Jvm, err: JavaError) -> JvmResult<()> {
+    async fn handle_exception(jvm: &Jvm, err: JavaError) -> JvmResult<()> {
         let JavaError::JavaException(x) = err;
 
         if jvm.is_instance(&*x, "java/lang/Error") {

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -1021,7 +1021,7 @@ impl Display {
         jvm.get_field(&this, "screenGraphics", "Ljavax/microedition/lcdui/Graphics;").await
     }
 
-    async fn handle_exception(jvm: &Jvm, err: JavaError) -> JvmResult<()> {
+    pub(crate) async fn handle_exception(jvm: &Jvm, err: JavaError) -> JvmResult<()> {
         let JavaError::JavaException(x) = err;
 
         if jvm.is_instance(&*x, "java/lang/Error") {
@@ -1348,14 +1348,20 @@ mod test {
     }
 
     async fn send_key(jvm: &Jvm, display: &ClassInstanceRef<Display>, event_type: KeyboardEventType, key: MIDPKeyCode) -> JvmResult<()> {
-        jvm.invoke_virtual(
-            display,
-            "javax/microedition/lcdui/Display",
-            "handleKeyEvent",
-            "(II)V",
-            (event_type as i32, key as i32),
-        )
-        .await
+        let _: () = jvm
+            .invoke_virtual(
+                display,
+                "javax/microedition/lcdui/Display",
+                "handleKeyEvent",
+                "(II)V",
+                (event_type as i32, key as i32),
+            )
+            .await?;
+        let queue = jvm
+            .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+            .await?;
+        let _: bool = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ()).await?;
+        Ok(())
     }
 
     #[test]

--- a/wie-midp/src/classes/javax/microedition/lcdui/display.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/display.rs
@@ -749,16 +749,6 @@ impl Display {
     }
 
     async fn handle_callback_event(jvm: &Jvm, _context: &mut WieJvmContext, callback: ClassInstanceRef<Runnable>) -> JvmResult<()> {
-        let midlet: ClassInstanceRef<MIDlet> = jvm
-            .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
-            .await?;
-        if !midlet.is_null() {
-            let display = MIDlet::display(jvm, &midlet).await?;
-            // A frontend Redraw may not have reached the backend queue yet.
-            let _: () = jvm
-                .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
-                .await?;
-        }
         let result: JvmResult<()> = jvm.invoke_virtual(&callback, "java/lang/Runnable", "run", "()V", ()).await;
         if let Err(error) = result {
             Self::handle_exception(jvm, error).await?;
@@ -1384,7 +1374,7 @@ mod test {
         let queue = jvm
             .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
             .await?;
-        let _: bool = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ()).await?;
+        let _: () = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()V", ()).await?;
         Ok(())
     }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/displayable.rs
@@ -9,7 +9,7 @@ use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Font, Graphics, Item, Ticker};
 
-use crate::classes::net::wie::{KeyboardEventType, MIDPKeyCode};
+use crate::classes::net::wie::{CommandEvent, EventQueue, KeyboardEventType, MIDPKeyCode};
 
 const COMMAND_BACK: i32 = 2;
 const COMMAND_CANCEL: i32 = 3;
@@ -427,14 +427,19 @@ impl Displayable {
             .get_field(&this, "commandListener", "Ljavax/microedition/lcdui/CommandListener;")
             .await?;
         if !listener.is_null() {
-            let _: () = jvm
-                .invoke_virtual(
-                    &listener,
-                    "javax/microedition/lcdui/CommandListener",
-                    "commandAction",
-                    "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
-                    (command, this),
+            let event: ClassInstanceRef<CommandEvent> = jvm
+                .new_class(
+                    "net/wie/CommandEvent",
+                    "(Ljavax/microedition/lcdui/CommandListener;Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                    (listener.clone(), command, this),
                 )
+                .await?
+                .into();
+            let queue: ClassInstanceRef<EventQueue> = jvm
+                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (event,))
                 .await?;
         }
 

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -738,7 +738,7 @@ impl Form {
         let queue: ClassInstanceRef<EventQueue> = jvm
             .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
             .await?;
-        jvm.invoke_virtual(&queue, "net/wie/EventQueue", "postCallback", "(Ljava/lang/Runnable;)V", (event,))
+        jvm.invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (event,))
             .await
     }
 
@@ -1233,6 +1233,7 @@ mod test {
                     JavaFieldProto::new("count", "I", FieldAccessFlags::PUBLIC),
                     JavaFieldProto::new("lastCommand", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PUBLIC),
                     JavaFieldProto::new("lastDisplayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PUBLIC),
+                    JavaFieldProto::new("stateCountAtCommand", "I", FieldAccessFlags::PUBLIC),
                 ],
                 access_flags: ClassAccessFlags::PUBLIC,
             }
@@ -1249,6 +1250,13 @@ mod test {
             command: ClassInstanceRef<Command>,
             displayable: ClassInstanceRef<Displayable>,
         ) -> JvmResult<()> {
+            let state_listener: ClassInstanceRef<ItemStateListener> = jvm
+                .get_field(&displayable, "itemStateListener", "Ljavax/microedition/lcdui/ItemStateListener;")
+                .await?;
+            if !state_listener.is_null() {
+                let state_count: i32 = jvm.get_field(&state_listener, "count", "I").await?;
+                jvm.put_field(&mut this, "stateCountAtCommand", "I", state_count).await?;
+            }
             let count: i32 = jvm.get_field(&this, "count", "I").await?;
             jvm.put_field(&mut this, "count", "I", count + 1).await?;
             jvm.put_field(&mut this, "lastCommand", "Ljavax/microedition/lcdui/Command;", command)
@@ -1376,14 +1384,20 @@ mod test {
     }
 
     async fn send_key(jvm: &Jvm, display: &ClassInstanceRef<Display>, event_type: KeyboardEventType, key: MIDPKeyCode) -> JvmResult<()> {
-        jvm.invoke_virtual(
-            display,
-            "javax/microedition/lcdui/Display",
-            "handleKeyEvent",
-            "(II)V",
-            (event_type as i32, key as i32),
-        )
-        .await
+        let _: () = jvm
+            .invoke_virtual(
+                display,
+                "javax/microedition/lcdui/Display",
+                "handleKeyEvent",
+                "(II)V",
+                (event_type as i32, key as i32),
+            )
+            .await?;
+        let queue = jvm
+            .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+            .await?;
+        let _: bool = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ()).await?;
+        Ok(())
     }
 
     #[test]
@@ -2010,7 +2024,7 @@ mod test {
     }
 
     #[test]
-    fn serial_item_callbacks_run_before_the_next_backend_input_and_command() -> Result<()> {
+    fn item_changes_and_commands_share_the_serial_callback_queue() -> Result<()> {
         run_jvm_test(test_protos(), |jvm| async move {
             let midlet: ClassInstanceRef<RecordingFormMidlet> =
                 jvm.new_class("javax/microedition/lcdui/TestRecordingFormMidlet", "()V", ()).await?.into();
@@ -2083,33 +2097,26 @@ mod test {
                 .invoke_static("javax/microedition/lcdui/TestBackendEventInjector", "enqueueOrderingInputs", "()V", ())
                 .await?;
 
-            for (key, delivered_count) in [
-                (MIDPKeyCode::LEFT, 0),
-                (MIDPKeyCode::RIGHT, 0),
-                (MIDPKeyCode::RIGHT, 1),
-                (MIDPKeyCode::DOWN, 1),
-                (MIDPKeyCode::RIGHT, 1),
-                (MIDPKeyCode::LEFT_SOFT_KEY, 2),
+            for key in [
+                MIDPKeyCode::LEFT,
+                MIDPKeyCode::RIGHT,
+                MIDPKeyCode::RIGHT,
+                MIDPKeyCode::DOWN,
+                MIDPKeyCode::RIGHT,
+                MIDPKeyCode::LEFT_SOFT_KEY,
             ] {
                 let _: () = jvm
                     .invoke_virtual(&event_queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
                     .await?;
                 assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?[2], key as i32);
-                assert_eq!(jvm.get_field::<i32>(&state_listener, "count", "I").await?, delivered_count);
+                assert_eq!(jvm.get_field::<i32>(&state_listener, "count", "I").await?, 0);
                 assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 0);
-                if delivered_count > 0 {
-                    let delivered: ClassInstanceRef<Item> = jvm.get_field(&state_listener, "lastItem", "Ljavax/microedition/lcdui/Item;").await?;
-                    assert_eq!(
-                        delivered.identity(),
-                        if delivered_count == 1 { first.identity() } else { second.identity() }
-                    );
-                }
                 let _: () = jvm
                     .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event.clone(),))
                     .await?;
                 assert_eq!(
                     jvm.get_field::<i32>(&state_listener, "count", "I").await?,
-                    delivered_count,
+                    0,
                     "ItemStateListener must not run inside the input handler"
                 );
             }
@@ -2119,8 +2126,15 @@ mod test {
             let _: () = jvm
                 .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event,))
                 .await?;
+            assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 0);
+            let _: bool = jvm
+                .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ())
+                .await?;
             assert_eq!(jvm.get_field::<i32>(&state_listener, "count", "I").await?, 2);
             assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 1);
+            assert_eq!(jvm.get_field::<i32>(&command_listener, "stateCountAtCommand", "I").await?, 2);
+            let delivered: ClassInstanceRef<Item> = jvm.get_field(&state_listener, "lastItem", "Ljavax/microedition/lcdui/Item;").await?;
+            assert_eq!(delivered.identity(), second.identity());
             Ok(())
         })
     }

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -8,11 +8,8 @@ use rustjava_runtime::classes::java::{lang::String, util::Vector};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::{
-    javax::microedition::{
-        lcdui::{Command, Display, Displayable, Graphics, Image, ImageItem, Item, ItemStateListener, StringItem},
-        midlet::MIDlet,
-    },
-    net::wie::{ItemStateEvent, KeyboardEventType, MIDPKeyCode},
+    javax::microedition::lcdui::{Command, Displayable, Graphics, Image, ImageItem, Item, ItemStateListener, StringItem},
+    net::wie::{EventQueue, ItemStateEvent, KeyboardEventType, MIDPKeyCode},
 };
 
 struct ItemRect {
@@ -730,29 +727,6 @@ impl Form {
         this: ClassInstanceRef<Self>,
         item: ClassInstanceRef<Item>,
     ) -> JvmResult<()> {
-        let mut display: ClassInstanceRef<Display> = jvm
-            .invoke_virtual(
-                &this,
-                "javax/microedition/lcdui/Displayable",
-                "getDisplay",
-                "()Ljavax/microedition/lcdui/Display;",
-                (),
-            )
-            .await?;
-        if display.is_null() {
-            let midlet: ClassInstanceRef<MIDlet> = jvm
-                .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
-                .await?;
-            display = jvm
-                .invoke_static(
-                    "javax/microedition/lcdui/Display",
-                    "getDisplay",
-                    "(Ljavax/microedition/midlet/MIDlet;)Ljavax/microedition/lcdui/Display;",
-                    (midlet,),
-                )
-                .await?;
-        }
-
         let event: ClassInstanceRef<ItemStateEvent> = jvm
             .new_class(
                 "net/wie/ItemStateEvent",
@@ -761,14 +735,11 @@ impl Form {
             )
             .await?
             .into();
-        jvm.invoke_virtual(
-            &display,
-            "javax/microedition/lcdui/Display",
-            "callSerially",
-            "(Ljava/lang/Runnable;)V",
-            (event,),
-        )
-        .await
+        let queue: ClassInstanceRef<EventQueue> = jvm
+            .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+            .await?;
+        jvm.invoke_virtual(&queue, "net/wie/EventQueue", "postCallback", "(Ljava/lang/Runnable;)V", (event,))
+            .await
     }
 
     async fn dispatch_item_state_changed(

--- a/wie-midp/src/classes/javax/microedition/lcdui/form.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/form.rs
@@ -1396,7 +1396,7 @@ mod test {
         let queue = jvm
             .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
             .await?;
-        let _: bool = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ()).await?;
+        let _: () = jvm.invoke_virtual(&queue, "net/wie/EventQueue", "dispatchCallbacks", "()V", ()).await?;
         Ok(())
     }
 
@@ -2125,10 +2125,6 @@ mod test {
                 .await?;
             let _: () = jvm
                 .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event,))
-                .await?;
-            assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 0);
-            let _: bool = jvm
-                .invoke_virtual(&event_queue, "net/wie/EventQueue", "dispatchCallbacks", "()Z", ())
                 .await?;
             assert_eq!(jvm.get_field::<i32>(&state_listener, "count", "I").await?, 2);
             assert_eq!(jvm.get_field::<i32>(&command_listener, "count", "I").await?, 1);

--- a/wie-midp/src/classes/javax/microedition/lcdui/item.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/item.rs
@@ -9,6 +9,7 @@ use wie_backend::text_layout::{minimum_width, preferred_width, wrap};
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::lcdui::{Command, Displayable, Font, Graphics, ItemCommandListener};
+use crate::classes::net::wie::{CommandEvent, EventQueue};
 
 const LABEL_COLOR: i32 = 0x52606d;
 const BUTTON_BACKGROUND: i32 = 0xe7edf2;
@@ -887,14 +888,19 @@ impl Item {
             .get_field(&this, "itemCommandListener", "Ljavax/microedition/lcdui/ItemCommandListener;")
             .await?;
         if !listener.is_null() {
-            let _: () = jvm
-                .invoke_virtual(
-                    &listener,
-                    "javax/microedition/lcdui/ItemCommandListener",
-                    "commandAction",
-                    "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
-                    (command, this),
+            let event: ClassInstanceRef<CommandEvent> = jvm
+                .new_class(
+                    "net/wie/CommandEvent",
+                    "(Ljavax/microedition/lcdui/ItemCommandListener;Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
+                    (listener, command, this),
                 )
+                .await?
+                .into();
+            let queue: ClassInstanceRef<EventQueue> = jvm
+                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                .await?;
+            let _: () = jvm
+                .invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (event,))
                 .await?;
         }
 

--- a/wie-midp/src/classes/net/wie.rs
+++ b/wie-midp/src/classes/net/wie.rs
@@ -1,4 +1,5 @@
 mod choice_element;
+mod command_event;
 mod event_queue;
 mod item_state_event;
 mod launcher;
@@ -7,6 +8,7 @@ mod wie_error;
 
 pub use self::{
     choice_element::ChoiceElement,
+    command_event::CommandEvent,
     event_queue::{EventQueue, KeyboardEventType, MIDPKeyCode},
     item_state_event::ItemStateEvent,
     launcher::Launcher,

--- a/wie-midp/src/classes/net/wie/command_event.rs
+++ b/wie-midp/src/classes/net/wie/command_event.rs
@@ -1,0 +1,113 @@
+use alloc::vec;
+
+use jvm::{ClassInstanceRef, Jvm, Result as JvmResult};
+use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
+use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
+
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+
+use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Displayable, Item, ItemCommandListener};
+
+// class net.wie.CommandEvent
+pub struct CommandEvent;
+
+impl CommandEvent {
+    pub fn as_proto() -> WieJavaClassProto {
+        WieJavaClassProto {
+            name: "net/wie/CommandEvent",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec!["java/lang/Runnable"],
+            methods: vec![
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljavax/microedition/lcdui/CommandListener;Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                    Self::init,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new(
+                    "<init>",
+                    "(Ljavax/microedition/lcdui/ItemCommandListener;Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
+                    Self::init_item,
+                    MethodAccessFlags::PUBLIC,
+                ),
+                JavaMethodProto::new("run", "()V", Self::run, MethodAccessFlags::PUBLIC),
+            ],
+            fields: vec![
+                JavaFieldProto::new("command", "Ljavax/microedition/lcdui/Command;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("listener", "Ljavax/microedition/lcdui/CommandListener;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("displayable", "Ljavax/microedition/lcdui/Displayable;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new(
+                    "itemListener",
+                    "Ljavax/microedition/lcdui/ItemCommandListener;",
+                    FieldAccessFlags::PRIVATE,
+                ),
+                JavaFieldProto::new("item", "Ljavax/microedition/lcdui/Item;", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        }
+    }
+
+    async fn init(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        listener: ClassInstanceRef<CommandListener>,
+        command: ClassInstanceRef<Command>,
+        displayable: ClassInstanceRef<Displayable>,
+    ) -> JvmResult<()> {
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "command", "Ljavax/microedition/lcdui/Command;", command).await?;
+        jvm.put_field(&mut this, "listener", "Ljavax/microedition/lcdui/CommandListener;", listener)
+            .await?;
+        jvm.put_field(&mut this, "displayable", "Ljavax/microedition/lcdui/Displayable;", displayable)
+            .await
+    }
+
+    async fn init_item(
+        jvm: &Jvm,
+        _context: &mut WieJvmContext,
+        mut this: ClassInstanceRef<Self>,
+        listener: ClassInstanceRef<ItemCommandListener>,
+        command: ClassInstanceRef<Command>,
+        item: ClassInstanceRef<Item>,
+    ) -> JvmResult<()> {
+        let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
+        jvm.put_field(&mut this, "command", "Ljavax/microedition/lcdui/Command;", command).await?;
+        jvm.put_field(&mut this, "itemListener", "Ljavax/microedition/lcdui/ItemCommandListener;", listener)
+            .await?;
+        jvm.put_field(&mut this, "item", "Ljavax/microedition/lcdui/Item;", item).await
+    }
+
+    async fn run(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
+        let command: ClassInstanceRef<Command> = jvm.get_field(&this, "command", "Ljavax/microedition/lcdui/Command;").await?;
+        let item: ClassInstanceRef<Item> = jvm.get_field(&this, "item", "Ljavax/microedition/lcdui/Item;").await?;
+        let result: JvmResult<()> = if item.is_null() {
+            let listener: ClassInstanceRef<CommandListener> = jvm.get_field(&this, "listener", "Ljavax/microedition/lcdui/CommandListener;").await?;
+            let displayable: ClassInstanceRef<Displayable> = jvm.get_field(&this, "displayable", "Ljavax/microedition/lcdui/Displayable;").await?;
+            jvm.invoke_virtual(
+                &listener,
+                "javax/microedition/lcdui/CommandListener",
+                "commandAction",
+                "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Displayable;)V",
+                (command, displayable),
+            )
+            .await
+        } else {
+            let listener: ClassInstanceRef<ItemCommandListener> = jvm
+                .get_field(&this, "itemListener", "Ljavax/microedition/lcdui/ItemCommandListener;")
+                .await?;
+            jvm.invoke_virtual(
+                &listener,
+                "javax/microedition/lcdui/ItemCommandListener",
+                "commandAction",
+                "(Ljavax/microedition/lcdui/Command;Ljavax/microedition/lcdui/Item;)V",
+                (command, item),
+            )
+            .await
+        };
+        if let Err(error) = result {
+            Display::handle_exception(jvm, error).await?;
+        }
+        Ok(())
+    }
+}

--- a/wie-midp/src/classes/net/wie/command_event.rs
+++ b/wie-midp/src/classes/net/wie/command_event.rs
@@ -6,7 +6,7 @@ use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 
 use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
-use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Display, Displayable, Item, ItemCommandListener};
+use crate::classes::javax::microedition::lcdui::{Command, CommandListener, Displayable, Item, ItemCommandListener};
 
 // class net.wie.CommandEvent
 pub struct CommandEvent;
@@ -81,7 +81,7 @@ impl CommandEvent {
     async fn run(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let command: ClassInstanceRef<Command> = jvm.get_field(&this, "command", "Ljavax/microedition/lcdui/Command;").await?;
         let item: ClassInstanceRef<Item> = jvm.get_field(&this, "item", "Ljavax/microedition/lcdui/Item;").await?;
-        let result: JvmResult<()> = if item.is_null() {
+        if item.is_null() {
             let listener: ClassInstanceRef<CommandListener> = jvm.get_field(&this, "listener", "Ljavax/microedition/lcdui/CommandListener;").await?;
             let displayable: ClassInstanceRef<Displayable> = jvm.get_field(&this, "displayable", "Ljavax/microedition/lcdui/Displayable;").await?;
             jvm.invoke_virtual(
@@ -104,10 +104,6 @@ impl CommandEvent {
                 (command, item),
             )
             .await
-        };
-        if let Err(error) = result {
-            Display::handle_exception(jvm, error).await?;
         }
-        Ok(())
     }
 }

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -387,14 +387,7 @@ impl EventQueue {
             let callback: ClassInstanceRef<Runnable> = jvm
                 .invoke_virtual(&events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
                 .await?;
-            let _: () = jvm
-                .invoke_static(
-                    "javax/microedition/lcdui/Display",
-                    "handleCallbackEvent",
-                    "(Ljava/lang/Runnable;)V",
-                    (callback,),
-                )
-                .await?;
+            let _: () = jvm.invoke_virtual(&callback, "java/lang/Runnable", "run", "()V", ()).await?;
             YieldFuture::new().await;
         }
         Ok(())

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -6,8 +6,8 @@ use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
 use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::Runnable;
 
-use wie_backend::{Event, KeyCode};
-use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+use wie_backend::{Event, KeyCode, YieldFuture};
+use wie_jvm_support::{JvmSupport, WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::midlet::MIDlet;
 
@@ -160,6 +160,7 @@ impl EventQueue {
                 JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("postCallback", "(Ljava/lang/Runnable;)V", Self::post_callback, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new(
                     "getEventQueue",
                     "()Lnet/wie/EventQueue;",
@@ -170,6 +171,7 @@ impl EventQueue {
             fields: vec![
                 JavaFieldProto::new("eventQueue", "Lnet/wie/EventQueue;", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
                 JavaFieldProto::new("callSeriallyEvents", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("callbackEvents", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
@@ -180,9 +182,10 @@ impl EventQueue {
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
-        let call_serially_events = jvm.new_class("java/util/Vector", "()V", ()).await?;
-        jvm.put_field(&mut this, "callSeriallyEvents", "Ljava/util/Vector;", call_serially_events)
-            .await?;
+        for field in ["callSeriallyEvents", "callbackEvents"] {
+            let events = jvm.new_class("java/util/Vector", "()V", ()).await?;
+            jvm.put_field(&mut this, field, "Ljava/util/Vector;", events).await?;
+        }
 
         Ok(())
     }
@@ -198,24 +201,12 @@ impl EventQueue {
 
         let mut pending_timer_events = Vec::new();
         loop {
-            let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-            let callback_count: i32 = jvm.invoke_virtual(&call_serially_events, "java/util/Vector", "size", "()I", ()).await?;
-            if callback_count > 0 {
-                let midlet: ClassInstanceRef<MIDlet> = jvm
-                    .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
-                    .await?;
-                if !midlet.is_null() {
-                    let display = MIDlet::display(jvm, &midlet).await?;
-                    // A frontend Redraw may not have reached the backend queue yet.
-                    let _: () = jvm
-                        .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
-                        .await?;
-                }
-            }
-            // Callbacks queued during delivery wait until the next event-loop iteration.
+            // Item changes must be reported before the next input can dispatch a command.
+            let callbacks = jvm.get_field(&this, "callbackEvents", "Ljava/util/Vector;").await?;
+            let callback_count: i32 = jvm.invoke_virtual(&callbacks, "java/util/Vector", "size", "()I", ()).await?;
             for _ in 0..callback_count {
                 let event: ClassInstanceRef<Runnable> = jvm
-                    .invoke_virtual(&call_serially_events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
+                    .invoke_virtual(&callbacks, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
                     .await?;
                 let _: () = jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await?;
             }
@@ -371,23 +362,60 @@ impl EventQueue {
         Ok(event_queue)
     }
 
-    async fn call_serially(
+    async fn call_serially(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, event: ClassInstanceRef<Runnable>) -> JvmResult<()> {
+        tracing::debug!("net.wie.EventQueue::callSerially({this:?}, {event:?})");
+
+        let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
+        let _: () = jvm
+            .invoke_virtual(
+                &call_serially_events,
+                "java/util/Vector",
+                "addElement",
+                "(Ljava/lang/Object;)V",
+                [event.into()],
+            )
+            .await?;
+
+        // Keep Runnable roots in the guest queue; schedule their delivery with backend input.
+        let due = context.system().platform().now();
+        let jvm = jvm.clone();
+        context.system().event_queue().push(Event::timer(due, move || async move {
+            let result: JvmResult<()> = async {
+                let events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
+                let event: ClassInstanceRef<Runnable> = jvm
+                    .invoke_virtual(&events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
+                    .await?;
+                let midlet: ClassInstanceRef<MIDlet> = jvm
+                    .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                    .await?;
+                if !midlet.is_null() {
+                    let display = MIDlet::display(&jvm, &midlet).await?;
+                    // A frontend Redraw may not have reached the backend queue yet.
+                    let _: () = jvm
+                        .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
+                        .await?;
+                }
+                jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await
+            }
+            .await;
+            if let Err(error) = result {
+                return Err(JvmSupport::to_wie_err(&jvm, error).await);
+            }
+            YieldFuture::new().await;
+            Ok(())
+        }));
+        Ok(())
+    }
+
+    async fn post_callback(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         event: ClassInstanceRef<Runnable>,
     ) -> JvmResult<()> {
-        tracing::debug!("net.wie.EventQueue::callSerially({this:?}, {event:?})");
-
-        let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-        jvm.invoke_virtual(
-            &call_serially_events,
-            "java/util/Vector",
-            "addElement",
-            "(Ljava/lang/Object;)V",
-            [event.into()],
-        )
-        .await
+        let callbacks = jvm.get_field(&this, "callbackEvents", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&callbacks, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (event,))
+            .await
     }
 }
 
@@ -432,7 +460,6 @@ mod test {
 
         async fn run(jvm: &Jvm, _context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
             let count: i32 = jvm.get_field(&this, "count", "I").await?;
-            assert_eq!(count, 0, "requeued callback ran before the pending backend event");
             let display: ClassInstanceRef<Display> = jvm.get_field(&this, "currentDisplay", "Ljavax/microedition/lcdui/Display;").await?;
             let mut graphics: ClassInstanceRef<Graphics> = jvm
                 .invoke_virtual(
@@ -460,7 +487,7 @@ mod test {
     }
 
     #[test]
-    fn pending_canvas_paints_before_recurring_callback_and_backend_input() -> Result<()> {
+    fn recurring_callback_paints_first_and_waits_for_queued_input() -> Result<()> {
         let callback_proto = WieJavaClassProto {
             name: "net/wie/RecurringCallback",
             parent_class: Some("javax/microedition/lcdui/Canvas"),
@@ -524,12 +551,25 @@ mod test {
                     .await?;
                 // The frontend has not delivered its Redraw yet.
                 system.event_queue().push(Event::Keydown(KeyCode::NUM1));
+                system.event_queue().push(Event::Keyup(KeyCode::NUM1));
                 let event: ClassInstanceRef<Array<i32>> = jvm.instantiate_array("I", 4).await?.into();
                 let _: () = jvm
                     .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
                     .await?;
                 assert_eq!(jvm.load_array::<i32>(&event, 0, 1).await?, [EventQueueEvent::KeyEvent as i32]);
                 assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 1);
+                let _: () = jvm
+                    .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                    .await?;
+                assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [EventQueueEvent::KeyEvent as i32, 2, 49, 0]);
+                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 1);
+
+                system.event_queue().push(Event::Keydown(KeyCode::NUM2));
+                let _: () = jvm
+                    .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                    .await?;
+                assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [EventQueueEvent::KeyEvent as i32, 1, 50, 0]);
+                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 2);
                 Ok(())
             },
         )

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -7,7 +7,7 @@ use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 use rustjava_runtime::classes::java::lang::Runnable;
 
 use wie_backend::{Event, KeyCode, YieldFuture};
-use wie_jvm_support::{JvmSupport, WieJavaClassProto, WieJvmContext};
+use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
 
 use crate::classes::javax::microedition::midlet::MIDlet;
 
@@ -160,7 +160,7 @@ impl EventQueue {
                 JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, MethodAccessFlags::PUBLIC),
-                JavaMethodProto::new("postCallback", "(Ljava/lang/Runnable;)V", Self::post_callback, MethodAccessFlags::PUBLIC),
+                JavaMethodProto::new("dispatchCallbacks", "()Z", Self::dispatch_callbacks, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "getEventQueue",
                     "()Lnet/wie/EventQueue;",
@@ -171,7 +171,7 @@ impl EventQueue {
             fields: vec![
                 JavaFieldProto::new("eventQueue", "Lnet/wie/EventQueue;", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
                 JavaFieldProto::new("callSeriallyEvents", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
-                JavaFieldProto::new("callbackEvents", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("inputEventsRemaining", "J", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
@@ -182,10 +182,9 @@ impl EventQueue {
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
-        for field in ["callSeriallyEvents", "callbackEvents"] {
-            let events = jvm.new_class("java/util/Vector", "()V", ()).await?;
-            jvm.put_field(&mut this, field, "Ljava/util/Vector;", events).await?;
-        }
+        let call_serially_events = jvm.new_class("java/util/Vector", "()V", ()).await?;
+        jvm.put_field(&mut this, "callSeriallyEvents", "Ljava/util/Vector;", call_serially_events)
+            .await?;
 
         Ok(())
     }
@@ -194,27 +193,23 @@ impl EventQueue {
     async fn get_next_event(
         jvm: &Jvm,
         context: &mut WieJvmContext,
-        this: ClassInstanceRef<Self>,
+        mut this: ClassInstanceRef<Self>,
         mut event: ClassInstanceRef<Array<i32>>,
     ) -> JvmResult<()> {
         tracing::debug!("net.wie.EventQueue::getNextEvent({this:?}, {event:?})");
 
         let mut pending_timer_events = Vec::new();
         loop {
-            // Item changes must be reported before the next input can dispatch a command.
-            let callbacks = jvm.get_field(&this, "callbackEvents", "Ljava/util/Vector;").await?;
-            let callback_count: i32 = jvm.invoke_virtual(&callbacks, "java/util/Vector", "size", "()I", ()).await?;
-            for _ in 0..callback_count {
-                let event: ClassInstanceRef<Runnable> = jvm
-                    .invoke_virtual(&callbacks, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
-                    .await?;
-                let _: () = jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await?;
-            }
+            let remaining: i64 = jvm.get_field(&this, "inputEventsRemaining", "J").await?;
+            let ran_callback = remaining == 0 && Self::dispatch_callbacks(jvm, context, this.clone()).await?;
 
             let now = context.system().platform().now();
             let maybe_event = context.system().event_queue().pop();
 
-            if let Some(x) = maybe_event {
+            if let Some((x, queued)) = maybe_event {
+                // Drain this input batch before another callback; new arrivals wait for the next batch.
+                let remaining = if remaining == 0 { queued as i64 } else { remaining - 1 };
+                jvm.put_field(&mut this, "inputEventsRemaining", "J", remaining).await?;
                 let event_data = match x {
                     Event::Redraw => vec![EventQueueEvent::RepaintEvent as _, 0, 0, 0],
                     Event::Keydown(x) => vec![
@@ -256,7 +251,9 @@ impl EventQueue {
 
                 break;
             } else {
-                context.system().sleep(16).await; // TODO we need to wait for events
+                if !ran_callback {
+                    context.system().sleep(16).await; // TODO we need to wait for events
+                }
 
                 for event in pending_timer_events.drain(..) {
                     context.system().event_queue().push(event);
@@ -362,60 +359,41 @@ impl EventQueue {
         Ok(event_queue)
     }
 
-    async fn call_serially(jvm: &Jvm, context: &mut WieJvmContext, this: ClassInstanceRef<Self>, event: ClassInstanceRef<Runnable>) -> JvmResult<()> {
-        tracing::debug!("net.wie.EventQueue::callSerially({this:?}, {event:?})");
-
-        let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-        let _: () = jvm
-            .invoke_virtual(
-                &call_serially_events,
-                "java/util/Vector",
-                "addElement",
-                "(Ljava/lang/Object;)V",
-                [event.into()],
-            )
-            .await?;
-
-        // Keep Runnable roots in the guest queue; schedule their delivery with backend input.
-        let due = context.system().platform().now();
-        let jvm = jvm.clone();
-        context.system().event_queue().push(Event::timer(due, move || async move {
-            let result: JvmResult<()> = async {
-                let events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
-                let event: ClassInstanceRef<Runnable> = jvm
-                    .invoke_virtual(&events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
-                    .await?;
-                let midlet: ClassInstanceRef<MIDlet> = jvm
-                    .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
-                    .await?;
-                if !midlet.is_null() {
-                    let display = MIDlet::display(&jvm, &midlet).await?;
-                    // A frontend Redraw may not have reached the backend queue yet.
-                    let _: () = jvm
-                        .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
-                        .await?;
-                }
-                jvm.invoke_virtual(&event, "java/lang/Runnable", "run", "()V", ()).await
-            }
-            .await;
-            if let Err(error) = result {
-                return Err(JvmSupport::to_wie_err(&jvm, error).await);
-            }
-            YieldFuture::new().await;
-            Ok(())
-        }));
-        Ok(())
-    }
-
-    async fn post_callback(
+    async fn call_serially(
         jvm: &Jvm,
         _context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         event: ClassInstanceRef<Runnable>,
     ) -> JvmResult<()> {
-        let callbacks = jvm.get_field(&this, "callbackEvents", "Ljava/util/Vector;").await?;
-        jvm.invoke_virtual(&callbacks, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (event,))
+        tracing::debug!("net.wie.EventQueue::callSerially({this:?}, {event:?})");
+
+        let call_serially_events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
+        jvm.invoke_virtual(&call_serially_events, "java/util/Vector", "addElement", "(Ljava/lang/Object;)V", (event,))
             .await
+    }
+
+    async fn dispatch_callbacks(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+        let events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
+        let count: i32 = jvm.invoke_virtual(&events, "java/util/Vector", "size", "()I", ()).await?;
+        // Callbacks registered during this batch belong to the next event-loop turn.
+        for _ in 0..count {
+            let callback: ClassInstanceRef<Runnable> = jvm
+                .invoke_virtual(&events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
+                .await?;
+            let midlet: ClassInstanceRef<MIDlet> = jvm
+                .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                .await?;
+            if !midlet.is_null() {
+                let display = MIDlet::display(jvm, &midlet).await?;
+                // A frontend Redraw may not have reached the backend queue yet.
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
+                    .await?;
+            }
+            let _: () = jvm.invoke_virtual(&callback, "java/lang/Runnable", "run", "()V", ()).await?;
+            YieldFuture::new().await;
+        }
+        Ok(count > 0)
     }
 }
 
@@ -549,6 +527,7 @@ mod test {
                         (callback.clone(),),
                     )
                     .await?;
+                assert!(system.event_queue().pop().is_none(), "callSerially must not schedule host events");
                 // The frontend has not delivered its Redraw yet.
                 system.event_queue().push(Event::Keydown(KeyCode::NUM1));
                 system.event_queue().push(Event::Keyup(KeyCode::NUM1));
@@ -570,6 +549,26 @@ mod test {
                     .await?;
                 assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [EventQueueEvent::KeyEvent as i32, 1, 50, 0]);
                 assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 2);
+
+                system.event_queue().push(Event::Keydown(KeyCode::NUM3));
+                system.event_queue().push(Event::Keyup(KeyCode::NUM3));
+                for index in 0..10 {
+                    // Keep the input queue nonempty without extending the batch already in progress.
+                    system.event_queue().push(Event::Keyrepeat(KeyCode::NUM3));
+                    let _: () = jvm
+                        .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                        .await?;
+                    let event_type = match index {
+                        0 => 1,
+                        1 => 2,
+                        _ => 3,
+                    };
+                    assert_eq!(
+                        jvm.load_array::<i32>(&event, 0, 4).await?,
+                        [EventQueueEvent::KeyEvent as i32, event_type, 51, 0]
+                    );
+                    assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 3 + index / 3);
+                }
                 Ok(())
             },
         )

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -160,7 +160,7 @@ impl EventQueue {
                 JavaMethodProto::new("getNextEvent", "([I)V", Self::get_next_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("dispatchEvent", "([I)V", Self::dispatch_event, MethodAccessFlags::PUBLIC),
                 JavaMethodProto::new("callSerially", "(Ljava/lang/Runnable;)V", Self::call_serially, MethodAccessFlags::PUBLIC),
-                JavaMethodProto::new("dispatchCallbacks", "()Z", Self::dispatch_callbacks, MethodAccessFlags::empty()),
+                JavaMethodProto::new("dispatchCallbacks", "()V", Self::dispatch_callbacks, MethodAccessFlags::empty()),
                 JavaMethodProto::new(
                     "getEventQueue",
                     "()Lnet/wie/EventQueue;",
@@ -171,7 +171,6 @@ impl EventQueue {
             fields: vec![
                 JavaFieldProto::new("eventQueue", "Lnet/wie/EventQueue;", FieldAccessFlags::PRIVATE | FieldAccessFlags::STATIC),
                 JavaFieldProto::new("callSeriallyEvents", "Ljava/util/Vector;", FieldAccessFlags::PRIVATE),
-                JavaFieldProto::new("inputEventsRemaining", "J", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC,
         }
@@ -193,25 +192,22 @@ impl EventQueue {
     async fn get_next_event(
         jvm: &Jvm,
         context: &mut WieJvmContext,
-        mut this: ClassInstanceRef<Self>,
+        this: ClassInstanceRef<Self>,
         mut event: ClassInstanceRef<Array<i32>>,
     ) -> JvmResult<()> {
         tracing::debug!("net.wie.EventQueue::getNextEvent({this:?}, {event:?})");
 
         let mut pending_timer_events = Vec::new();
         loop {
-            let remaining: i64 = jvm.get_field(&this, "inputEventsRemaining", "J").await?;
-            let ran_callback = remaining == 0 && Self::dispatch_callbacks(jvm, context, this.clone()).await?;
-
             let now = context.system().platform().now();
             let maybe_event = context.system().event_queue().pop();
 
-            if let Some((x, queued)) = maybe_event {
-                // Drain this input batch before another callback; new arrivals wait for the next batch.
-                let remaining = if remaining == 0 { queued as i64 } else { remaining - 1 };
-                jvm.put_field(&mut this, "inputEventsRemaining", "J", remaining).await?;
+            if let Some(x) = maybe_event {
                 let event_data = match x {
-                    Event::Redraw => vec![EventQueueEvent::RepaintEvent as _, 0, 0, 0],
+                    Event::Redraw => {
+                        Self::dispatch_callbacks(jvm, context, this.clone()).await?;
+                        vec![EventQueueEvent::RepaintEvent as _, 0, 0, 0]
+                    }
                     Event::Keydown(x) => vec![
                         EventQueueEvent::KeyEvent as _,
                         KeyboardEventType::KeyPressed as _,
@@ -251,9 +247,8 @@ impl EventQueue {
 
                 break;
             } else {
-                if !ran_callback {
-                    context.system().sleep(16).await; // TODO we need to wait for events
-                }
+                Self::dispatch_callbacks(jvm, context, this.clone()).await?;
+                context.system().sleep(16).await; // TODO we need to wait for events
 
                 for event in pending_timer_events.drain(..) {
                     context.system().event_queue().push(event);
@@ -372,9 +367,21 @@ impl EventQueue {
             .await
     }
 
-    async fn dispatch_callbacks(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<bool> {
+    async fn dispatch_callbacks(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
         let count: i32 = jvm.invoke_virtual(&events, "java/util/Vector", "size", "()I", ()).await?;
+        if count > 0 {
+            let midlet: ClassInstanceRef<MIDlet> = jvm
+                .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                .await?;
+            if !midlet.is_null() {
+                let display = MIDlet::display(jvm, &midlet).await?;
+                // A frontend Redraw may not have reached the backend queue yet.
+                let _: () = jvm
+                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
+                    .await?;
+            }
+        }
         // Callbacks registered during this batch belong to the next event-loop turn.
         for _ in 0..count {
             let callback: ClassInstanceRef<Runnable> = jvm
@@ -390,21 +397,22 @@ impl EventQueue {
                 .await?;
             YieldFuture::new().await;
         }
-        Ok(count > 0)
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use alloc::{boxed::Box, vec};
+    use alloc::{boxed::Box, sync::Arc, vec};
+    use core::sync::atomic::{AtomicBool, Ordering};
 
     use jvm::{Array, ClassInstanceRef, Jvm, Result as JvmResult};
     use jvm_class_proto::{JavaFieldProto, JavaMethodProto};
     use jvm_types::{ClassAccessFlags, FieldAccessFlags, MethodAccessFlags};
 
-    use test_utils::{TestPlatform, run_jvm_test_with_system};
-    use wie_backend::{Event, KeyCode};
-    use wie_jvm_support::{WieJavaClassProto, WieJvmContext};
+    use test_utils::{TestClock, TestPlatform, run_jvm_test_with_system};
+    use wie_backend::{DefaultTaskRunner, Event, KeyCode, System};
+    use wie_jvm_support::{JvmSupport, RustJavaJvmImplementation, WieJavaClassProto, WieJvmContext};
     use wie_util::Result;
 
     use crate::{
@@ -417,15 +425,101 @@ mod test {
 
     use super::{EventQueue, EventQueueEvent};
 
+    struct IdleCallback;
+
+    impl IdleCallback {
+        async fn run(jvm: &Jvm, context: &mut WieJvmContext, mut this: ClassInstanceRef<Self>) -> JvmResult<()> {
+            let count: i32 = jvm.get_field(&this, "count", "I").await?;
+            let now = context.system().platform().now().raw() as i64;
+            if count > 0 {
+                let last_run: i64 = jvm.get_field(&this, "lastRun", "J").await?;
+                assert!(now - last_run >= 16, "idle callbacks must retain the timed wait");
+                context.system().event_queue().push(Event::Keydown(KeyCode::NUM1));
+            } else {
+                let queue = jvm
+                    .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (this.clone(),))
+                    .await?;
+            }
+            jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            jvm.put_field(&mut this, "lastRun", "J", now).await
+        }
+    }
+
+    #[test]
+    fn recurring_callback_waits_while_the_backend_queue_is_empty() -> Result<()> {
+        let callback_proto = WieJavaClassProto {
+            name: "net/wie/IdleCallback",
+            parent_class: Some("java/lang/Object"),
+            interfaces: vec!["java/lang/Runnable"],
+            methods: vec![JavaMethodProto::new("run", "()V", IdleCallback::run, MethodAccessFlags::PUBLIC)],
+            fields: vec![
+                JavaFieldProto::new("count", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("lastRun", "J", FieldAccessFlags::PRIVATE),
+            ],
+            access_flags: ClassAccessFlags::PUBLIC,
+        };
+        let clock = TestClock::new();
+        let mut system = System::new(Box::new(TestPlatform::with_clock(clock.clone())), "", "", DefaultTaskRunner);
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_task = completed.clone();
+        let system_task = system.clone();
+        let clock_task = clock.clone();
+        system.spawn(async move || {
+            let jvm = JvmSupport::new_jvm(
+                &system_task,
+                None,
+                Box::new([get_protos().into(), Box::new([callback_proto])]),
+                &[],
+                RustJavaJvmImplementation,
+            )
+            .await?;
+            let queue = jvm
+                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                .await
+                .unwrap();
+            let callback = jvm.instantiate_class("net/wie/IdleCallback").await.unwrap();
+            let _: () = jvm
+                .invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (callback,))
+                .await
+                .unwrap();
+            let event = jvm.instantiate_array("I", 4).await.unwrap();
+            let _: () = jvm
+                .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event,))
+                .await
+                .unwrap();
+            completed_task.store(true, Ordering::SeqCst);
+            // Let the enclosing tick finish after this task completes.
+            clock_task.advance(100);
+            Ok(())
+        });
+
+        system.tick()?;
+        assert!(!completed.load(Ordering::SeqCst));
+        clock.set(15);
+        system.tick()?;
+        assert!(!completed.load(Ordering::SeqCst));
+        clock.set(16);
+        system.tick()?;
+        clock.set(32);
+        system.tick()?;
+        assert!(completed.load(Ordering::SeqCst));
+        Ok(())
+    }
+
     struct RecurringCallback;
 
     impl RecurringCallback {
         async fn paint(
             jvm: &Jvm,
             _context: &mut WieJvmContext,
-            _this: ClassInstanceRef<Self>,
+            mut this: ClassInstanceRef<Self>,
             graphics: ClassInstanceRef<Graphics>,
         ) -> JvmResult<()> {
+            let paint_count: i32 = jvm.get_field(&this, "paintCount", "I").await?;
+            jvm.put_field(&mut this, "paintCount", "I", paint_count + 1).await?;
             let _: () = jvm
                 .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x22aa44,))
                 .await?;
@@ -453,6 +547,7 @@ mod test {
                 "pending Canvas paint must finish before run"
             );
             jvm.put_field(&mut this, "count", "I", count + 1).await?;
+            let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
             let queue: ClassInstanceRef<EventQueue> = jvm
                 .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
                 .await?;
@@ -462,7 +557,7 @@ mod test {
     }
 
     #[test]
-    fn recurring_callback_paints_first_and_waits_for_queued_input() -> Result<()> {
+    fn input_precedes_recurring_callbacks_and_pending_paint() -> Result<()> {
         let callback_proto = WieJavaClassProto {
             name: "net/wie/RecurringCallback",
             parent_class: Some("javax/microedition/lcdui/Canvas"),
@@ -476,7 +571,10 @@ mod test {
                     MethodAccessFlags::PROTECTED,
                 ),
             ],
-            fields: vec![JavaFieldProto::new("count", "I", FieldAccessFlags::PRIVATE)],
+            fields: vec![
+                JavaFieldProto::new("count", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("paintCount", "I", FieldAccessFlags::PRIVATE),
+            ],
             access_flags: ClassAccessFlags::PUBLIC,
         };
         let midlet_proto = WieJavaClassProto {
@@ -525,7 +623,16 @@ mod test {
                     )
                     .await?;
                 assert!(system.event_queue().pop().is_none(), "callSerially must not schedule host events");
-                // The frontend has not delivered its Redraw yet.
+                let _: () = jvm
+                    .invoke_virtual(
+                        &display,
+                        "javax/microedition/lcdui/Display",
+                        "callSerially",
+                        "(Ljava/lang/Runnable;)V",
+                        (callback.clone(),),
+                    )
+                    .await?;
+                system.event_queue().push(Event::Redraw);
                 system.event_queue().push(Event::Keydown(KeyCode::NUM1));
                 system.event_queue().push(Event::Keyup(KeyCode::NUM1));
                 let event: ClassInstanceRef<Array<i32>> = jvm.instantiate_array("I", 4).await?.into();
@@ -533,24 +640,24 @@ mod test {
                     .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
                     .await?;
                 assert_eq!(jvm.load_array::<i32>(&event, 0, 1).await?, [EventQueueEvent::KeyEvent as i32]);
-                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 1);
+                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 0);
                 let _: () = jvm
                     .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
                     .await?;
                 assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [EventQueueEvent::KeyEvent as i32, 2, 49, 0]);
-                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 1);
+                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 0);
 
                 system.event_queue().push(Event::Keydown(KeyCode::NUM2));
                 let _: () = jvm
                     .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
                     .await?;
                 assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [EventQueueEvent::KeyEvent as i32, 1, 50, 0]);
-                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 2);
+                assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 0);
 
                 system.event_queue().push(Event::Keydown(KeyCode::NUM3));
                 system.event_queue().push(Event::Keyup(KeyCode::NUM3));
                 for index in 0..10 {
-                    // Keep the input queue nonempty without extending the batch already in progress.
+                    // New input retains priority over pending redraw and callback work.
                     system.event_queue().push(Event::Keyrepeat(KeyCode::NUM3));
                     let _: () = jvm
                         .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
@@ -564,7 +671,23 @@ mod test {
                         jvm.load_array::<i32>(&event, 0, 4).await?,
                         [EventQueueEvent::KeyEvent as i32, event_type, 51, 0]
                     );
-                    assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 3 + index / 3);
+                    assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 0);
+                }
+                for _ in 0..2 {
+                    let _: () = jvm
+                        .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                        .await?;
+                    assert_eq!(jvm.load_array::<i32>(&event, 0, 4).await?, [EventQueueEvent::KeyEvent as i32, 3, 51, 0]);
+                    assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 0);
+                }
+                for count in 1..=2 {
+                    system.event_queue().push(Event::Redraw);
+                    let _: () = jvm
+                        .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                        .await?;
+                    assert_eq!(jvm.load_array::<i32>(&event, 0, 1).await?, [EventQueueEvent::RepaintEvent as i32]);
+                    assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, count * 2);
+                    assert_eq!(jvm.get_field::<i32>(&callback, "paintCount", "I").await?, count);
                 }
                 Ok(())
             },

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -380,17 +380,14 @@ impl EventQueue {
             let callback: ClassInstanceRef<Runnable> = jvm
                 .invoke_virtual(&events, "java/util/Vector", "remove", "(I)Ljava/lang/Object;", (0,))
                 .await?;
-            let midlet: ClassInstanceRef<MIDlet> = jvm
-                .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+            let _: () = jvm
+                .invoke_static(
+                    "javax/microedition/lcdui/Display",
+                    "handleCallbackEvent",
+                    "(Ljava/lang/Runnable;)V",
+                    (callback,),
+                )
                 .await?;
-            if !midlet.is_null() {
-                let display = MIDlet::display(jvm, &midlet).await?;
-                // A frontend Redraw may not have reached the backend queue yet.
-                let _: () = jvm
-                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
-                    .await?;
-            }
-            let _: () = jvm.invoke_virtual(&callback, "java/lang/Runnable", "run", "()V", ()).await?;
             YieldFuture::new().await;
         }
         Ok(count > 0)

--- a/wie-midp/src/classes/net/wie/event_queue.rs
+++ b/wie-midp/src/classes/net/wie/event_queue.rs
@@ -204,10 +204,7 @@ impl EventQueue {
 
             if let Some(x) = maybe_event {
                 let event_data = match x {
-                    Event::Redraw => {
-                        Self::dispatch_callbacks(jvm, context, this.clone()).await?;
-                        vec![EventQueueEvent::RepaintEvent as _, 0, 0, 0]
-                    }
+                    Event::Redraw => vec![EventQueueEvent::RepaintEvent as _, 0, 0, 0],
                     Event::Keydown(x) => vec![
                         EventQueueEvent::KeyEvent as _,
                         KeyboardEventType::KeyPressed as _,
@@ -247,6 +244,20 @@ impl EventQueue {
 
                 break;
             } else {
+                let events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
+                let count: i32 = jvm.invoke_virtual(&events, "java/util/Vector", "size", "()I", ()).await?;
+                if count > 0 {
+                    let midlet: ClassInstanceRef<MIDlet> = jvm
+                        .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
+                        .await?;
+                    if !midlet.is_null() {
+                        let display = MIDlet::display(jvm, &midlet).await?;
+                        // A frontend Redraw may not have reached the backend queue yet.
+                        let _: () = jvm
+                            .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
+                            .await?;
+                    }
+                }
                 Self::dispatch_callbacks(jvm, context, this.clone()).await?;
                 context.system().sleep(16).await; // TODO we need to wait for events
 
@@ -265,7 +276,7 @@ impl EventQueue {
 
     async fn dispatch_event(
         jvm: &Jvm,
-        _context: &mut WieJvmContext,
+        context: &mut WieJvmContext,
         this: ClassInstanceRef<Self>,
         event: ClassInstanceRef<Array<i32>>,
     ) -> JvmResult<()> {
@@ -298,6 +309,7 @@ impl EventQueue {
                 let _: () = jvm
                     .invoke_virtual(&display, "javax/microedition/lcdui/Display", "handlePaintEvent", "()V", ())
                     .await?;
+                Self::dispatch_callbacks(jvm, context, this).await?;
             }
             EventQueueEvent::KeyEvent => {
                 let event_type = if let Some(event_type) = KeyboardEventType::from_raw(event[1]) {
@@ -370,18 +382,6 @@ impl EventQueue {
     async fn dispatch_callbacks(jvm: &Jvm, _context: &mut WieJvmContext, this: ClassInstanceRef<Self>) -> JvmResult<()> {
         let events = jvm.get_field(&this, "callSeriallyEvents", "Ljava/util/Vector;").await?;
         let count: i32 = jvm.invoke_virtual(&events, "java/util/Vector", "size", "()I", ()).await?;
-        if count > 0 {
-            let midlet: ClassInstanceRef<MIDlet> = jvm
-                .get_static_field("javax/microedition/midlet/MIDlet", "currentMIDlet", "Ljavax/microedition/midlet/MIDlet;")
-                .await?;
-            if !midlet.is_null() {
-                let display = MIDlet::display(jvm, &midlet).await?;
-                // A frontend Redraw may not have reached the backend queue yet.
-                let _: () = jvm
-                    .invoke_virtual(&display, "javax/microedition/lcdui/Display", "serviceRepaints", "()V", ())
-                    .await?;
-            }
-        }
         // Callbacks registered during this batch belong to the next event-loop turn.
         for _ in 0..count {
             let callback: ClassInstanceRef<Runnable> = jvm
@@ -516,6 +516,9 @@ mod test {
             let _: () = jvm
                 .invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "setColor", "(I)V", (0x22aa44,))
                 .await?;
+            if jvm.get_field::<bool>(&this, "repaintOnPaint", "Z").await? {
+                let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
+            }
             jvm.invoke_virtual(&graphics, "javax/microedition/lcdui/Graphics", "fillRect", "(IIII)V", (0, 0, 1, 1))
                 .await
         }
@@ -540,12 +543,16 @@ mod test {
                 "pending Canvas paint must finish before run"
             );
             jvm.put_field(&mut this, "count", "I", count + 1).await?;
-            let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
-            let queue: ClassInstanceRef<EventQueue> = jvm
-                .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
-                .await?;
-            jvm.invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (this,))
-                .await
+            if jvm.get_field::<bool>(&this, "repeat", "Z").await? {
+                let _: () = jvm.invoke_virtual(&this, "javax/microedition/lcdui/Canvas", "repaint", "()V", ()).await?;
+                let queue: ClassInstanceRef<EventQueue> = jvm
+                    .invoke_static("net/wie/EventQueue", "getEventQueue", "()Lnet/wie/EventQueue;", ())
+                    .await?;
+                let _: () = jvm
+                    .invoke_virtual(&queue, "net/wie/EventQueue", "callSerially", "(Ljava/lang/Runnable;)V", (this,))
+                    .await?;
+            }
+            Ok(())
         }
     }
 
@@ -567,6 +574,8 @@ mod test {
             fields: vec![
                 JavaFieldProto::new("count", "I", FieldAccessFlags::PRIVATE),
                 JavaFieldProto::new("paintCount", "I", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("repeat", "Z", FieldAccessFlags::PRIVATE),
+                JavaFieldProto::new("repaintOnPaint", "Z", FieldAccessFlags::PRIVATE),
             ],
             access_flags: ClassAccessFlags::PUBLIC,
         };
@@ -590,7 +599,8 @@ mod test {
                     .invoke_special(&midlet, "javax/microedition/midlet/MIDlet", "<init>", "()V", ())
                     .await?;
                 let display = MIDlet::display(&jvm, &midlet).await?;
-                let callback: ClassInstanceRef<RecurringCallback> = jvm.instantiate_class("net/wie/RecurringCallback").await?.into();
+                let mut callback: ClassInstanceRef<RecurringCallback> = jvm.instantiate_class("net/wie/RecurringCallback").await?.into();
+                jvm.put_field(&mut callback, "repeat", "Z", true).await?;
                 let _: () = jvm
                     .invoke_special(&callback, "javax/microedition/lcdui/Canvas", "<init>", "()V", ())
                     .await?;
@@ -674,13 +684,33 @@ mod test {
                     assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 0);
                 }
                 for count in 1..=2 {
+                    jvm.put_field(&mut callback, "repaintOnPaint", "Z", count == 2).await?;
                     system.event_queue().push(Event::Redraw);
                     let _: () = jvm
                         .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
                         .await?;
                     assert_eq!(jvm.load_array::<i32>(&event, 0, 1).await?, [EventQueueEvent::RepaintEvent as i32]);
+                    let _: () = jvm
+                        .invoke_virtual(&queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event.clone(),))
+                        .await?;
                     assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, count * 2);
                     assert_eq!(jvm.get_field::<i32>(&callback, "paintCount", "I").await?, count);
+                    assert!(jvm.get_field::<bool>(&display, "repaintPending", "Z").await?);
+                }
+                jvm.put_field(&mut callback, "repaintOnPaint", "Z", false).await?;
+                jvm.put_field(&mut callback, "repeat", "Z", false).await?;
+                for paint_count in 3..=4 {
+                    // First finish the callbacks, then repaint with no pending request or callback.
+                    system.event_queue().push(Event::Redraw);
+                    let _: () = jvm
+                        .invoke_virtual(&queue, "net/wie/EventQueue", "getNextEvent", "([I)V", (event.clone(),))
+                        .await?;
+                    let _: () = jvm
+                        .invoke_virtual(&queue, "net/wie/EventQueue", "dispatchEvent", "([I)V", (event.clone(),))
+                        .await?;
+                    assert_eq!(jvm.get_field::<i32>(&callback, "count", "I").await?, 6);
+                    assert_eq!(jvm.get_field::<i32>(&callback, "paintCount", "I").await?, paint_count);
+                    assert!(!jvm.get_field::<bool>(&display, "repaintPending", "Z").await?);
                 }
                 Ok(())
             },

--- a/wie-midp/src/lib.rs
+++ b/wie-midp/src/lib.rs
@@ -5,7 +5,7 @@ pub mod classes;
 
 use wie_jvm_support::WieJavaClassProto;
 
-pub fn get_protos() -> [WieJavaClassProto; 39] {
+pub fn get_protos() -> [WieJavaClassProto; 40] {
     [
         classes::javax::microedition::lcdui::Alert::as_proto(),
         classes::javax::microedition::lcdui::AlertType::as_proto(),
@@ -41,6 +41,7 @@ pub fn get_protos() -> [WieJavaClassProto; 39] {
         classes::javax::microedition::rms::RecordStore::as_proto(),
         classes::javax::microedition::rms::RecordStoreException::as_proto(),
         classes::net::wie::ChoiceElement::as_proto(),
+        classes::net::wie::CommandEvent::as_proto(),
         classes::net::wie::EventQueue::as_proto(),
         classes::net::wie::ItemStateEvent::as_proto(),
         classes::net::wie::Launcher::as_proto(),


### PR DESCRIPTION
## Summary

- Prioritize key press/release/repeat events over timers, notifications, and redraws while preserving FIFO order within each priority level. Coalesce pending redraws.
- Move serial callback execution from before every backend event dequeue to redraw and idle turns, and yield between callbacks so queued input is not delayed by recurring callback work.
- Paint each redraw before its callback batch, keeping repaint requests made during painting or callbacks pending for the next turn. Idle turns service pending paint before callbacks and retain the existing 16 ms wait.
- Queue Displayable and Item command listeners as guest-backed `CommandEvent` runnables in the existing `callSerially` FIFO. Form item-state notifications therefore precede subsequent commands.

## Behavior

Input priority is strict: sustained input that saturates the consumer can postpone lower-priority work.

Queued command listeners use the existing Runnable exception-propagation behavior. Unlike synchronous command delivery through Display's key handler, an uncaught queued listener exception can terminate the event loop.

## Validation

- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test --workspace`: 321 passed
- Regression coverage includes input priority and FIFO order, redraw coalescing, idle pacing, paint/callback ordering, repaint requests during paint, host redraw without a pending repaint, listener exception propagation, and Form notification-before-command ordering.
- A 75-second native Heroes Lore 1 run delivered all 22 press/release transitions with no runtime errors. Direction-key delivery delay was 404 ms maximum and 192 ms median, measured from host injection to `Display.handleKeyEvent`. Gameplay screenshots confirmed movement. These are single-run debug measurements, not release-performance guarantees.
- `npm run build:prod`: passed with the existing asset-size warning.
- Firefox 155.0: Heroes Lore 1 entered gameplay and completed eight one-second direction-key holds with no runtime errors. Each input interval produced changing canvas pixels, and before/after screenshots confirmed movement.
