### PR TITLE
Allow platforms to supply an emulated WIPI phone identity

### DIFF
--- a/test-utils/src/platform.rs
+++ b/test-utils/src/platform.rs
@@ -40,6 +40,7 @@ pub enum TestPlatformEvent {
 }
 
 pub struct TestPlatform {
+    phone_number: Option<String>,
     screen: TestScreen,
     event_handler: Option<Box<dyn Fn(TestPlatformEvent) + Sync + Send>>,
     fs: Arc<MemoryFilesystem>,
@@ -55,8 +56,14 @@ impl Default for TestPlatform {
 }
 
 impl TestPlatform {
+    pub fn with_phone_number(mut self, number: &str) -> Self {
+        self.phone_number = Some(String::from(number));
+        self
+    }
+
     pub fn new() -> Self {
         Self {
+            phone_number: None,
             screen: TestScreen::default(),
             event_handler: None,
             fs: Arc::new(MemoryFilesystem::default()),
@@ -71,6 +78,7 @@ impl TestPlatform {
         T: Fn(TestPlatformEvent) + Sync + Send + 'static,
     {
         Self {
+            phone_number: None,
             screen: TestScreen::default(),
             event_handler: Some(Box::new(event_handler)),
             fs: Arc::new(MemoryFilesystem::default()),
@@ -82,6 +90,7 @@ impl TestPlatform {
 
     pub fn with_clock(clock: TestClock) -> Self {
         Self {
+            phone_number: None,
             screen: TestScreen::default(),
             event_handler: None,
             fs: Arc::new(MemoryFilesystem::default()),
@@ -93,6 +102,9 @@ impl TestPlatform {
 }
 
 impl Platform for TestPlatform {
+    fn phone_number(&self) -> Option<&str> {
+        self.phone_number.as_deref()
+    }
     fn font(&self) -> &Font {
         &self.font
     }

--- a/wie-backend/src/platform.rs
+++ b/wie-backend/src/platform.rs
@@ -3,6 +3,11 @@ use alloc::boxed::Box;
 use crate::{audio_sink::AudioSink, canvas::Font, database::DatabaseRepository, screen::Screen, time::Instant};
 
 pub trait Platform: Send + Sync {
+    /// Optional provisioned identity for this emulator instance.
+    fn phone_number(&self) -> Option<&str> {
+        None
+    }
+
     fn font(&self) -> &Font;
     fn screen(&self) -> &dyn Screen;
     fn now(&self) -> Instant;

--- a/wie-wipi-c/src/api/kernel.rs
+++ b/wie-wipi-c/src/api/kernel.rs
@@ -35,12 +35,17 @@ pub async fn get_system_property(context: &mut dyn WIPICContext, ptr_id: WIPICWo
     let id_bytes = read_null_terminated_string_bytes(context, ptr_id)?;
     let id = encoding_rs::EUC_KR.decode(&id_bytes).0;
 
+    let phone_number = if matches!(id.as_ref(), "PHONENUMBER" | "MIN") {
+        context.system().platform().phone_number().map(String::from)
+    } else {
+        None
+    };
     let value = match id.as_ref() {
         "RSSILEVEL" => "30",
         "BATTERYLEVEL" => "100",
         "PHONEMODEL" => "Emulator",
-        "PHONENUMBER" => "", // putting this cause some game to fail authentication
-        "MIN" => "01000000000",
+        "PHONENUMBER" => phone_number.as_deref().unwrap_or(""),
+        "MIN" => phone_number.as_deref().unwrap_or("01000000000"),
         "ANNUN_CALL" => "0",
         "ANNUN_SMS" => "0",
         "ANNUN_SILENT" => "0",
@@ -334,7 +339,12 @@ mod test {
 
     #[futures_test::test]
     async fn test_get_system_property_min() -> Result<()> {
-        let mut context = TestContext::new();
+        let mut context = TestContext::with_system(wie_backend::System::new(
+            Box::new(test_utils::TestPlatform::new()),
+            "test",
+            "test",
+            wie_backend::DefaultTaskRunner,
+        ));
         let id = context.alloc_raw(16).unwrap();
         let out = context.alloc_raw(16).unwrap();
 
@@ -344,6 +354,30 @@ mod test {
         let result = read_null_terminated_string_bytes(&context, out).unwrap();
         assert_eq!(String::from_utf8(result).unwrap(), "01000000000");
 
+        Ok(())
+    }
+
+    #[futures_test::test]
+    async fn test_provisioned_phone_identity_and_short_buffer() -> Result<()> {
+        let platform = test_utils::TestPlatform::new().with_phone_number("01012345678");
+        let mut context = TestContext::with_system(wie_backend::System::new(
+            Box::new(platform),
+            "test",
+            "test",
+            wie_backend::DefaultTaskRunner,
+        ));
+        let id = context.alloc_raw(32)?;
+        let out = context.alloc_raw(16)?;
+        for name in [b"PHONENUMBER".as_slice(), b"MIN".as_slice()] {
+            write_null_terminated_string_bytes(&mut context, id, name)?;
+            context.write_bytes(out, &[0xa5; 16])?;
+            assert_eq!(get_system_property(&mut context, id, out, 11).await?, -18);
+            let mut unchanged = [0; 16];
+            context.read_bytes(out, &mut unchanged)?;
+            assert_eq!(unchanged, [0xa5; 16]);
+            assert_eq!(get_system_property(&mut context, id, out, 12).await?, 0);
+            assert_eq!(read_null_terminated_string_bytes(&context, out)?, b"01012345678");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
WIPI applications that require a provisioned device identity currently receive an empty PHONENUMBER and a fixed MIN, with no way for the embedding platform to supply its identity. Add an optional Platform::phone_number() hook and use it for those two properties. Platforms that do not opt in keep the existing values.

The change is generic: no application names, phone numbers, data bundles, launcher code, or authentication bypass are embedded. Frontends can provide the emulated identity appropriate to their instance. Regression tests cover the override for both property names, null termination and short-buffer behavior, and the existing default MIN.

Validation on current upstream main: cargo fmt --all, cargo clippy --workspace, and cargo test -p wie-wipi-c --lib (33 passed).
