### PR TITLE
Fix LGT Java exceptions across Rust call boundaries

### DIFF
--- a/wie-core-arm/src/core.rs
+++ b/wie-core-arm/src/core.rs
@@ -219,6 +219,15 @@ impl ArmCore {
     {
         // we don't need to save r0-r3, but to make it simple, we save all registers
         let previous_context = self.save_context();
+        let result = self.run_function_inner(address, params).await;
+        self.restore_context(&previous_context);
+        result
+    }
+
+    async fn run_function_inner<R>(&mut self, address: u32, params: &[u32]) -> Result<R>
+    where
+        R: RunFunctionResult<R>,
+    {
         {
             let mut inner = self.inner.lock();
 
@@ -308,10 +317,7 @@ impl ArmCore {
             }
         }
 
-        let result = R::get(self);
-        self.restore_context(&previous_context);
-
-        Ok(result)
+        Ok(R::get(self))
     }
 
     pub fn register_svc_handler<F, C, R, P>(&mut self, category: u32, handler: F, context: &C) -> Result<()>
@@ -923,6 +929,36 @@ mod tests {
         assert_eq!(result.load(Ordering::Relaxed), 0);
         assert!(matches!(run.as_mut().poll(&mut cx), Poll::Ready(Ok(17))));
         assert_eq!(result.load(Ordering::Relaxed), 5_000);
+    }
+
+    #[test]
+    fn failed_arm_calls_restore_caller_registers_and_stack() {
+        async fn throwing_handler(core: &mut ArmCore, _: &mut ()) -> Result<()> {
+            core.write_return_value(&[99, 98])?;
+            Err(WieError::JavaException(0x1234))
+        }
+
+        let mut core = ArmCore::new(false, None).unwrap();
+        core.map(0x2000, 0x1000).unwrap();
+        core.register_svc_handler(1, throwing_handler, &()).unwrap();
+        let target = core.make_svc_stub(1, 0u32).unwrap();
+        let mut context = core.save_context();
+        context.r0 = 42;
+        context.r1 = 43;
+        context.sp = 0x3000;
+        context.lr = 0x4001;
+        core.restore_context(&context);
+        let registers = core.dump_regs();
+
+        for address in [target, 0x1001] {
+            let result = futures::executor::block_on(core.run_function::<()>(address, &[1, 2, 3, 4, 5]));
+            if address == target {
+                assert!(matches!(result, Err(WieError::JavaException(0x1234))));
+            } else {
+                assert!(matches!(result, Err(WieError::InvalidMemoryAccess(_))));
+            }
+            assert_eq!(core.dump_regs(), registers);
+        }
     }
 
     #[test]

--- a/wie-lgt/src/runtime/java/exception.rs
+++ b/wie-lgt/src/runtime/java/exception.rs
@@ -2,7 +2,7 @@ use core::mem::size_of;
 
 use bytemuck::{Pod, Zeroable};
 
-use wie_core_arm::{Allocator, ArmCore, ArmCoreContext};
+use wie_core_arm::{Allocator, ArmCore, ArmCoreContext, RUN_FUNCTION_LR};
 use wie_util::{Result, read_generic, write_generic};
 
 const SUPPORT_CONTEXT_BASE: u32 = 0x7fff0000;
@@ -66,6 +66,11 @@ pub fn pending(core: &ArmCore) -> Result<u32> {
 }
 
 pub fn unwind(core: &mut ArmCore, ptr_exception: u32) -> Result<Option<u32>> {
+    // Rust callers must handle the exception before an enclosing guest catch can run.
+    if core.read_pc_lr()?.1 == RUN_FUNCTION_LR {
+        return Ok(None);
+    }
+
     let mut support_context: JavaSupportContext = read_generic(core, SUPPORT_CONTEXT_BASE)?;
     if support_context.ptr_current_exception_frame == 0 {
         return Ok(None);

--- a/wie-lgt/src/runtime/java/jvm_support/method.rs
+++ b/wie-lgt/src/runtime/java/jvm_support/method.rs
@@ -268,7 +268,10 @@ mod tests {
     use wie_util::{Result, write_generic, write_null_terminated_string_bytes};
 
     use super::{JavaMethod, JavaMethodRunResult, RawJavaMethod};
-    use crate::runtime::java::jvm_support::{JavaClassInstance, LgtJvmImplementation};
+    use crate::runtime::java::{
+        exception,
+        jvm_support::{JavaClassInstance, LgtJvmImplementation, LgtJvmSupport},
+    };
 
     async fn rust_wide_bridge(_jvm: &Jvm, observed: &mut Arc<Mutex<Option<(i64, u64)>>>, integer: i64, floating: f64) -> JvmResult<i64> {
         *observed.lock() = Some((integer, floating.to_bits()));
@@ -390,6 +393,84 @@ mod tests {
             system.tick()?;
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn missing_database_record_is_translated_before_guest_unwind() -> Result<()> {
+        let mut system = System::new(Box::new(TestPlatform::new()), "", "", DefaultTaskRunner);
+        let done = Arc::new(AtomicBool::new(false));
+        let done_clone = done.clone();
+        let system_clone = system.clone();
+
+        system.spawn(async move || {
+            let mut core = ArmCore::new(false, None)?;
+            Allocator::init(&mut core)?;
+            let stack = Allocator::alloc(&mut core, 0x1000)?;
+            let mut context = core.save_context();
+            context.sp = stack + 0x1000;
+            core.restore_context(&context);
+
+            let implementation = LgtJvmImplementation::new(&mut core)?;
+            let protos = [wie_midp::get_protos().into(), wie_wipi_java::get_protos().into()];
+            let jvm = JvmSupport::new_jvm(&system_clone, None, Box::new(protos), &[], implementation).await?;
+            let name = JavaLangString::from_rust_string(&jvm, "empty-records").await.unwrap();
+            let database: Box<dyn jvm::ClassInstance> = jvm
+                .invoke_static(
+                    "org/kwis/msp/db/DataBase",
+                    "openDataBase",
+                    "(Ljava/lang/String;IZ)Lorg/kwis/msp/db/DataBase;",
+                    (name, 4, true),
+                )
+                .await
+                .unwrap();
+            let class = jvm.get_class("org/kwis/msp/db/DataBase").unwrap();
+            let method = class.definition.method("selectRecord", "(I)[B", false).unwrap();
+            let target = method.as_any().downcast_ref::<JavaMethod>().unwrap().target()?;
+
+            let wrapper = Allocator::alloc(&mut core, 20)?;
+            write_generic(
+                &mut core,
+                wrapper,
+                [
+                    0xb500u16, // push {lr}
+                    0x4c03,    // ldr r4, [pc, #12]
+                    0x47a0,    // blx r4
+                    0x2001,    // movs r0, #1 (normal return)
+                    0xbd00,    // pop {pc}
+                    0x2002,    // movs r0, #2 (catch)
+                    0xbd00,    // pop {pc}
+                    0x46c0,    // nop
+                ],
+            )?;
+            write_generic(&mut core, wrapper + 16, target)?;
+
+            // The guest catch resumes with the wrapper's saved LR still on the stack.
+            let mut catch_context = core.save_context();
+            catch_context.sp -= 4;
+            catch_context.lr = wrapper + 11;
+            catch_context.cpsr = 0x3f;
+            core.restore_context(&catch_context);
+            exception::push(&mut core)?;
+            core.restore_context(&context);
+
+            let result: u32 = core
+                .run_function(wrapper + 1, &[LgtJvmSupport::class_instance_raw(&*database), 0])
+                .await?;
+            assert_eq!(result, 2);
+            let pending = LgtJvmSupport::class_instance_from_raw(&core, exception::pending(&core)?);
+            assert!(jvm.is_instance(&*pending, "org/kwis/msp/db/DataBaseRecordException"));
+            assert_eq!(core.save_context().sp, context.sp);
+            exception::pop(&mut core)?;
+            assert_eq!(exception::pending(&core)?, 0);
+
+            done_clone.store(true, Ordering::Relaxed);
+            Ok(())
+        });
+
+        while !done.load(Ordering::Relaxed) {
+            system.tick()?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
An LGT game reading an absent database record could enter its ARM catch handler before the nested Rust `getRecord` caller received the exception. The catch result was then decoded as an object reference, causing an invalid-memory panic during first startup.

Propagate Java exceptions back to Rust when the return address identifies a Rust caller, and restore the ARM caller's registers on failed calls. Add regressions for register restoration and conversion of `InvalidRecordIDException` into `DataBaseRecordException` before the guest catch runs.

Validation:

- `cargo fmt` and `cargo clippy --workspace --offline -- -D warnings` passed.
- `cargo test -p wie-core-arm -p wie-lgt -p wie-ktf --offline`: 126 tests passed.
- `cargo build --offline` passed. The actual CLI ran 현영맞고2006 with an isolated empty data directory and created all three initial save records; a separate native run completed 3,000 ticks.
- The database regression reproduces the invalid-memory panic when the exception boundary fix is removed. WASM/browser execution was not rerun, as requested.
