### PR TITLE
Optimize ARM memory access, guest strings, KTF metadata, and rendering

### DIFF
--- a/wie-backend/src/canvas.rs
+++ b/wie-backend/src/canvas.rs
@@ -366,7 +366,7 @@ where
             return;
         }
 
-        if !blend {
+        if !blend || color.a == 255 {
             self.image_buffer.put_pixel(x, y, color);
             return;
         }
@@ -949,6 +949,7 @@ pub fn string_width(font: &Font, string: &str, pt_size: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use alloc::{borrow::Cow, sync::Arc, vec, vec::Vec};
+    use core::sync::atomic::{AtomicUsize, Ordering};
     use spin::Mutex;
 
     use wie_util::Result;
@@ -1029,6 +1030,7 @@ mod tests {
         width: u32,
         height: u32,
         pixels: Arc<Mutex<Vec<Color>>>,
+        reads: Arc<AtomicUsize>,
     }
 
     impl SharedImageBuffer {
@@ -1037,6 +1039,7 @@ mod tests {
                 width,
                 height: pixels.len() as u32 / width,
                 pixels: Arc::new(Mutex::new(pixels)),
+                reads: Arc::new(AtomicUsize::new(0)),
             }
         }
     }
@@ -1055,6 +1058,7 @@ mod tests {
         }
 
         fn get_pixel(&self, x: i32, y: i32) -> Color {
+            self.reads.fetch_add(1, Ordering::Relaxed);
             self.pixels.lock()[(y as u32 * self.width + x as u32) as usize]
         }
 
@@ -1085,6 +1089,31 @@ mod tests {
             pixel.g ^= color.g;
             pixel.b ^= color.b;
             pixel.a = 255;
+        }
+    }
+
+    #[test]
+    fn opaque_composition_skips_background_reads() {
+        let background = Color { a: 64, ..BACKGROUND };
+        for alpha in [0, 1, 127, 254, 255] {
+            let image = SharedImageBuffer::new(1, vec![background]);
+            let reads = image.reads.clone();
+            let mut canvas = ImageBufferCanvas::new(image);
+            let source = Color { a: alpha, ..XOR_COLOR };
+            canvas.blend_pixel(0, 0, source);
+            assert_eq!(reads.load(Ordering::Relaxed), usize::from(alpha != 255));
+            let factor = f32::from(alpha) / 255.0;
+            assert_color(
+                canvas.image(),
+                0,
+                0,
+                Color {
+                    a: 255,
+                    r: (f32::from(source.r) * factor + f32::from(background.r) * (1.0 - factor)) as u8,
+                    g: (f32::from(source.g) * factor + f32::from(background.g) * (1.0 - factor)) as u8,
+                    b: (f32::from(source.b) * factor + f32::from(background.b) * (1.0 - factor)) as u8,
+                },
+            );
         }
     }
 

--- a/wie-backend/src/canvas.rs
+++ b/wie-backend/src/canvas.rs
@@ -949,7 +949,6 @@ pub fn string_width(font: &Font, string: &str, pt_size: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use alloc::{borrow::Cow, sync::Arc, vec, vec::Vec};
-    use core::sync::atomic::{AtomicUsize, Ordering};
     use spin::Mutex;
 
     use wie_util::Result;
@@ -1030,7 +1029,6 @@ mod tests {
         width: u32,
         height: u32,
         pixels: Arc<Mutex<Vec<Color>>>,
-        reads: Arc<AtomicUsize>,
     }
 
     impl SharedImageBuffer {
@@ -1039,7 +1037,6 @@ mod tests {
                 width,
                 height: pixels.len() as u32 / width,
                 pixels: Arc::new(Mutex::new(pixels)),
-                reads: Arc::new(AtomicUsize::new(0)),
             }
         }
     }
@@ -1058,7 +1055,6 @@ mod tests {
         }
 
         fn get_pixel(&self, x: i32, y: i32) -> Color {
-            self.reads.fetch_add(1, Ordering::Relaxed);
             self.pixels.lock()[(y as u32 * self.width + x as u32) as usize]
         }
 
@@ -1089,31 +1085,6 @@ mod tests {
             pixel.g ^= color.g;
             pixel.b ^= color.b;
             pixel.a = 255;
-        }
-    }
-
-    #[test]
-    fn opaque_composition_skips_background_reads() {
-        let background = Color { a: 64, ..BACKGROUND };
-        for alpha in [0, 1, 127, 254, 255] {
-            let image = SharedImageBuffer::new(1, vec![background]);
-            let reads = image.reads.clone();
-            let mut canvas = ImageBufferCanvas::new(image);
-            let source = Color { a: alpha, ..XOR_COLOR };
-            canvas.blend_pixel(0, 0, source);
-            assert_eq!(reads.load(Ordering::Relaxed), usize::from(alpha != 255));
-            let factor = f32::from(alpha) / 255.0;
-            assert_color(
-                canvas.image(),
-                0,
-                0,
-                Color {
-                    a: 255,
-                    r: (f32::from(source.r) * factor + f32::from(background.r) * (1.0 - factor)) as u8,
-                    g: (f32::from(source.g) * factor + f32::from(background.g) * (1.0 - factor)) as u8,
-                    b: (f32::from(source.b) * factor + f32::from(background.b) * (1.0 - factor)) as u8,
-                },
-            );
         }
     }
 

--- a/wie-core-arm/src/engine/arm32_cpu.rs
+++ b/wie-core-arm/src/engine/arm32_cpu.rs
@@ -1,5 +1,4 @@
 use alloc::{boxed::Box, format, vec};
-use core::cell::RefCell;
 
 use arm32_cpu::{Cpu, Memory, Mode, reg};
 
@@ -73,7 +72,7 @@ impl ArmEngine for Arm32CpuEngine {
             }
             instructions_executed += 1;
 
-            if let Some(x) = arm32cpu_memory.memory_error() {
+            if let Some(x) = arm32cpu_memory.memory_error {
                 return Err(WieError::InvalidMemoryAccess(x));
             }
         };
@@ -232,19 +231,15 @@ impl EmulatedMemory {
 
 struct Arm32CpuMemory<'a> {
     emulated_memory: &'a mut EmulatedMemory,
-    memory_error: RefCell<Option<u32>>,
+    memory_error: Option<u32>,
 }
 
 impl<'a> Arm32CpuMemory<'a> {
     fn new(emulated_memory: &'a mut EmulatedMemory) -> Self {
         Self {
             emulated_memory,
-            memory_error: RefCell::new(None),
+            memory_error: None,
         }
-    }
-
-    fn memory_error(&self) -> Option<u32> {
-        *self.memory_error.borrow()
     }
 
     fn get_page(&mut self, addr: u32) -> Option<&mut [u8; PAGE_SIZE]> {
@@ -254,7 +249,7 @@ impl<'a> Arm32CpuMemory<'a> {
         if let Some(x) = page_data {
             Some(x)
         } else {
-            *self.memory_error.borrow_mut() = Some(addr);
+            self.memory_error = Some(addr);
             None
         }
     }
@@ -284,7 +279,7 @@ impl Memory for Arm32CpuMemory<'_> {
 
         let data = page.unwrap();
 
-        (data[offset as usize] as u16) | ((data[offset as usize + 1] as u16) << 8)
+        u16::from_le_bytes(data[offset as usize..offset as usize + 2].try_into().unwrap())
     }
 
     fn r32(&mut self, addr: u32) -> u32 {
@@ -296,10 +291,7 @@ impl Memory for Arm32CpuMemory<'_> {
         }
 
         let data = page.unwrap();
-        (data[offset as usize] as u32)
-            | ((data[offset as usize + 1] as u32) << 8)
-            | ((data[offset as usize + 2] as u32) << 16)
-            | ((data[offset as usize + 3] as u32) << 24)
+        u32::from_le_bytes(data[offset as usize..offset as usize + 4].try_into().unwrap())
     }
 
     fn w8(&mut self, addr: u32, val: u8) {
@@ -325,8 +317,7 @@ impl Memory for Arm32CpuMemory<'_> {
 
         let data = page.unwrap();
 
-        data[offset as usize] = val as u8;
-        data[offset as usize + 1] = (val >> 8) as u8;
+        data[offset as usize..offset as usize + 2].copy_from_slice(&val.to_le_bytes());
     }
 
     fn w32(&mut self, addr: u32, val: u32) {
@@ -339,10 +330,7 @@ impl Memory for Arm32CpuMemory<'_> {
 
         let data = page.unwrap();
 
-        data[offset as usize] = val as u8;
-        data[offset as usize + 1] = (val >> 8) as u8;
-        data[offset as usize + 2] = (val >> 16) as u8;
-        data[offset as usize + 3] = (val >> 24) as u8;
+        data[offset as usize..offset as usize + 4].copy_from_slice(&val.to_le_bytes());
     }
 }
 
@@ -432,6 +420,10 @@ mod tests {
 
         let mut buf = [0; 0x1000];
         assert!(memory.read_range(0x1f500, 0x1000, &mut buf).is_err());
+
+        let mut access = memory.as_arm32cpu_memory();
+        assert_eq!(access.r32(0x20000), 0);
+        assert_eq!(access.memory_error, Some(0x20000));
     }
 
     #[test]
@@ -441,5 +433,9 @@ mod tests {
         memory.map(0x10000, 0x10000);
 
         assert!(memory.write_range(0x1f500, &[12; 0x1000]).is_err());
+
+        let mut access = memory.as_arm32cpu_memory();
+        access.w32(0x20000, 12);
+        assert_eq!(access.memory_error, Some(0x20000));
     }
 }

--- a/wie-ktf/src/runtime/java/interface.rs
+++ b/wie-ktf/src/runtime/java/interface.rs
@@ -138,7 +138,7 @@ async fn get_java_method(core: &mut ArmCore, _: &mut (), ptr_class: u32, ptr_ful
     let method = if first_item != ptr_class + 4 {
         let ptr_vtable: u32 = read_generic(core, ptr_class + offset_of!(InitParam2, ptr_java_vtables) as u32)?;
         let vtable = JavaVtable::from_raw(core, ptr_vtable);
-        let method = vtable.find_method(&fullname.name, &fullname.descriptor)?;
+        let method = vtable.find_method(fullname.name(), fullname.descriptor())?;
 
         if method.is_none() {
             return Err(WieError::FatalError(format!("Method {fullname} not found from {ptr_class:#x}")));
@@ -146,7 +146,7 @@ async fn get_java_method(core: &mut ArmCore, _: &mut (), ptr_class: u32, ptr_ful
         method
     } else {
         let class = KtfJvmSupport::class_from_raw(core, ptr_class);
-        let method = find_java_method(&class, &fullname.name, &fullname.descriptor).await?;
+        let method = find_java_method(&class, fullname.name(), fullname.descriptor()).await?;
 
         if method.is_none() {
             return Err(WieError::FatalError(format!("Method {fullname} not found from {}", class.name()?)));
@@ -256,9 +256,9 @@ async fn get_field(core: &mut ArmCore, _: &mut (), ptr_class: u32, field_name: u
     let field_name = KtfJvmSupport::read_name(core, field_name)?;
 
     let class = KtfJvmSupport::class_from_raw(core, ptr_class);
-    let field = class.field(&field_name.name, &field_name.descriptor, true)?;
+    let field = class.field(field_name.name(), field_name.descriptor(), true)?;
     let field = if field.is_none() {
-        class.field(&field_name.name, &field_name.descriptor, false)?
+        class.field(field_name.name(), field_name.descriptor(), false)?
     } else {
         field
     };

--- a/wie-ktf/src/runtime/java/jvm_support.rs
+++ b/wie-ktf/src/runtime/java/jvm_support.rs
@@ -569,6 +569,7 @@ mod test {
 
             let string1 = JavaLangString::from_rust_string(&jvm, "test1").await.unwrap();
             let string2 = JavaLangString::from_rust_string(&jvm, "test2").await.unwrap();
+            assert!(!string1.class_definition().fields().is_empty());
 
             let string3 = jvm
                 .invoke_virtual(
@@ -588,6 +589,9 @@ mod test {
             let temp: Vec<i16> = jvm.load_array(&array, 5, 4).await.unwrap();
 
             assert_eq!(temp, vec![5, 6, 7, 8]);
+
+            let reference_array = jvm.instantiate_array("Ljava/lang/String;", 1).await.unwrap();
+            assert!(reference_array.class_definition().fields().is_empty());
 
             // test 64bit parameter passing
             let date = jvm.new_class("java/util/Date", "(J)V", (0x12345678_abcdef01i64,)).await.unwrap();

--- a/wie-ktf/src/runtime/java/jvm_support.rs
+++ b/wie-ktf/src/runtime/java/jvm_support.rs
@@ -195,12 +195,7 @@ impl KtfJvmSupport {
         while core.run_function::<u32>(predicate, &[ptr_class]).await? != 0 {
             let class = JavaClassDefinition::from_raw(ptr_class, core);
             let name = class.name()?;
-            if !jvm.has_class(&name)
-                && class
-                    .fields()?
-                    .iter()
-                    .any(|field| field.access_flags().contains(FieldAccessFlags::STATIC))
-            {
+            if !jvm.has_class(&name) && class.fields()?.any(|field| field.access_flags().contains(FieldAccessFlags::STATIC)) {
                 jvm.register_class(Box::new(class), Some(class_loader.clone()))
                     .or_else(async |error| Err(JvmSupport::to_wie_err(jvm, error).await))
                     .await?;

--- a/wie-ktf/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/class_definition.rs
@@ -246,7 +246,9 @@ impl JavaClassDefinition {
 
         for method in methods {
             let full_name = method.name()?;
-            if full_name.name == name && full_name.descriptor == descriptor && method.access_flags().contains(MethodAccessFlags::STATIC) == is_static
+            if full_name.name() == name
+                && full_name.descriptor() == descriptor
+                && method.access_flags().contains(MethodAccessFlags::STATIC) == is_static
             {
                 return Ok(Some(method));
             }
@@ -260,7 +262,10 @@ impl JavaClassDefinition {
 
         for field in fields {
             let full_name = field.name()?;
-            if full_name.name == name && full_name.descriptor == descriptor && field.access_flags().contains(FieldAccessFlags::STATIC) == is_static {
+            if full_name.name() == name
+                && full_name.descriptor() == descriptor
+                && field.access_flags().contains(FieldAccessFlags::STATIC) == is_static
+            {
                 return Ok(Some(field));
             }
         }

--- a/wie-ktf/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/class_definition.rs
@@ -182,43 +182,33 @@ impl JavaClassDefinition {
         Ok(descriptor.fields_size as _)
     }
 
-    pub fn methods(&self) -> Result<Vec<JavaMethod>> {
+    pub fn methods(&self) -> Result<impl Iterator<Item = JavaMethod> + '_> {
         let raw: RawJavaClass = read_generic(&self.core, self.ptr_raw)?;
         let descriptor: RawJavaClassDescriptor = read_generic(&self.core, raw.ptr_descriptor)?;
 
-        if descriptor.ptr_methods == 0 {
-            return Ok(Vec::new());
-        }
+        let ptr_methods = if descriptor.ptr_methods == 0 {
+            Vec::new()
+        } else {
+            read_null_terminated_table(&self.core, descriptor.ptr_methods)?
+        };
 
-        let ptr_methods = read_null_terminated_table(&self.core, descriptor.ptr_methods)?;
-
-        let mut result = Vec::with_capacity(ptr_methods.len());
-        for method in ptr_methods {
-            let method = JavaMethod::from_raw(method, &self.core);
-
-            if method.ptr_class() == self.ptr_raw {
-                result.push(method)
-            }
-        }
-
-        Ok(result)
+        Ok(ptr_methods
+            .into_iter()
+            .map(|ptr| JavaMethod::from_raw(ptr, &self.core))
+            .filter(|method| method.ptr_class() == self.ptr_raw))
     }
 
-    pub fn fields(&self) -> Result<Vec<JavaField>> {
+    pub fn fields(&self) -> Result<impl Iterator<Item = JavaField> + '_> {
         let raw: RawJavaClass = read_generic(&self.core, self.ptr_raw)?;
         let descriptor: RawJavaClassDescriptor = read_generic(&self.core, raw.ptr_descriptor)?;
 
-        if descriptor.ptr_fields_or_element_type == 0 {
-            return Ok(Vec::new());
-        }
+        let ptr_fields = if descriptor.ptr_fields_or_element_type == 0 || read_generic::<u8, _>(&self.core, descriptor.ptr_name)? == b'[' {
+            Vec::new()
+        } else {
+            read_null_terminated_table(&self.core, descriptor.ptr_fields_or_element_type)?
+        };
 
-        if read_generic::<u8, _>(&self.core, descriptor.ptr_name)? == b'[' {
-            return Ok(Vec::new());
-        }
-
-        let ptr_fields = read_null_terminated_table(&self.core, descriptor.ptr_fields_or_element_type)?;
-
-        Ok(ptr_fields.into_iter().map(|x| JavaField::from_raw(x, &self.core)).collect())
+        Ok(ptr_fields.into_iter().map(|ptr| JavaField::from_raw(ptr, &self.core)))
     }
 
     pub fn name(&self) -> Result<String> {
@@ -341,7 +331,7 @@ impl ClassDefinition for JavaClassDefinition {
     }
 
     fn fields(&self) -> Vec<Box<dyn Field>> {
-        self.fields().unwrap().into_iter().map(|x| Box::new(x) as _).collect()
+        self.fields().unwrap().map(|x| Box::new(x) as _).collect()
     }
 
     fn get_static_field(&self, field: &dyn Field) -> JvmResult<JavaValue> {

--- a/wie-ktf/src/runtime/java/jvm_support/class_definition.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/class_definition.rs
@@ -212,7 +212,7 @@ impl JavaClassDefinition {
             return Ok(Vec::new());
         }
 
-        if self.name()?.starts_with("[") {
+        if read_generic::<u8, _>(&self.core, descriptor.ptr_name)? == b'[' {
             return Ok(Vec::new());
         }
 
@@ -228,6 +228,13 @@ impl JavaClassDefinition {
         let bytes = read_null_terminated_string_bytes(&self.core, descriptor.ptr_name)?;
 
         Ok(String::from_utf8(bytes).unwrap())
+    }
+
+    pub fn is_array(&self) -> Result<bool> {
+        let raw: RawJavaClass = read_generic(&self.core, self.ptr_raw)?;
+        let descriptor: RawJavaClassDescriptor = read_generic(&self.core, raw.ptr_descriptor)?;
+
+        Ok(read_generic::<u8, _>(&self.core, descriptor.ptr_name)? == b'[')
     }
 
     pub fn parent_class(&self) -> Result<Option<JavaClassDefinition>> {
@@ -341,7 +348,7 @@ impl ClassDefinition for JavaClassDefinition {
         let field = field.as_any().downcast_ref::<JavaField>().unwrap();
         let value = self.read_static_field(field).unwrap();
 
-        let r#type = JavaType::parse(&field.descriptor());
+        let r#type = JavaType::parse(field.name().unwrap().descriptor());
         Ok(JavaValueCodec::new(&self.core).decode_word(value, &r#type))
     }
 

--- a/wie-ktf/src/runtime/java/jvm_support/class_instance.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/class_instance.rs
@@ -156,7 +156,6 @@ impl ClassInstance for JavaClassInstance {
 
     fn put_field(&mut self, field: &dyn Field, value: JavaValue) -> JvmResult<()> {
         let field = field.as_any().downcast_ref::<JavaField>().unwrap();
-        let field_type = JavaType::parse(field.name().unwrap().descriptor());
 
         assert!(!field.access_flags().contains(FieldAccessFlags::STATIC));
 
@@ -164,7 +163,7 @@ impl ClassInstance for JavaClassInstance {
         let address = self.field_address(offset).unwrap();
         let codec = JavaValueCodec::new(&self.core);
 
-        if matches!(field_type, JavaType::Long | JavaType::Double) {
+        if matches!(value, JavaValue::Long(_) | JavaValue::Double(_)) {
             let (value, value_high) = codec.encode_wide(&value);
 
             write_generic(&mut self.core, address, value).unwrap();

--- a/wie-ktf/src/runtime/java/jvm_support/class_instance.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/class_instance.rs
@@ -134,7 +134,7 @@ impl ClassInstance for JavaClassInstance {
 
     fn get_field(&self, field: &dyn Field) -> JvmResult<JavaValue> {
         let field = field.as_any().downcast_ref::<JavaField>().unwrap();
-        let field_type = JavaType::parse(&field.descriptor());
+        let field_type = JavaType::parse(field.name().unwrap().descriptor());
 
         assert!(!field.access_flags().contains(FieldAccessFlags::STATIC));
 
@@ -146,19 +146,17 @@ impl ClassInstance for JavaClassInstance {
             let value: KtfJvmWord = read_generic(&self.core, address).unwrap();
             let value_high: KtfJvmWord = read_generic(&self.core, address + 4).unwrap();
 
-            let r#type = JavaType::parse(&field.descriptor());
-            Ok(codec.decode_wide(value, value_high, &r#type))
+            Ok(codec.decode_wide(value, value_high, &field_type))
         } else {
             let value: KtfJvmWord = read_generic(&self.core, address).unwrap();
 
-            let r#type = JavaType::parse(&field.descriptor());
-            Ok(codec.decode_word(value, &r#type))
+            Ok(codec.decode_word(value, &field_type))
         }
     }
 
     fn put_field(&mut self, field: &dyn Field, value: JavaValue) -> JvmResult<()> {
         let field = field.as_any().downcast_ref::<JavaField>().unwrap();
-        let field_type = JavaType::parse(&field.descriptor());
+        let field_type = JavaType::parse(field.name().unwrap().descriptor());
 
         assert!(!field.access_flags().contains(FieldAccessFlags::STATIC));
 

--- a/wie-ktf/src/runtime/java/jvm_support/field.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/field.rs
@@ -25,11 +25,7 @@ impl JavaField {
     }
 
     pub fn new(core: &mut ArmCore, ptr_class: u32, proto: JavaFieldProto, offset_or_value: u32) -> Result<Self> {
-        let full_name = JavaFullName {
-            tag: 0,
-            name: proto.name,
-            descriptor: proto.descriptor,
-        };
+        let full_name = JavaFullName::new(0, &proto.name, &proto.descriptor);
         let full_name_bytes = full_name.as_bytes();
         let ptr_name = Allocator::alloc(core, full_name_bytes.len() as u32)?;
         core.write_bytes(ptr_name, &full_name_bytes)?;
@@ -47,7 +43,7 @@ impl JavaField {
             },
         )?;
 
-        tracing::trace!("Wrote field {} at {ptr_raw:#x}", full_name.name);
+        tracing::trace!("Wrote field {} at {ptr_raw:#x}", full_name.name());
 
         Ok(Self::from_raw(ptr_raw, core))
     }
@@ -75,13 +71,13 @@ impl Field for JavaField {
     fn name(&self) -> String {
         let name = self.name().unwrap();
 
-        name.name.clone()
+        name.name().into()
     }
 
     fn descriptor(&self) -> String {
         let name = self.name().unwrap();
 
-        name.descriptor.clone()
+        name.descriptor().into()
     }
 
     fn access_flags(&self) -> FieldAccessFlags {

--- a/wie-ktf/src/runtime/java/jvm_support/method.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/method.rs
@@ -55,11 +55,7 @@ impl JavaMethod {
         C: ?Sized + 'static + Send,
         Context: Deref<Target = C> + DerefMut + Clone + 'static + Sync + Send,
     {
-        let full_name = JavaFullName {
-            tag: 0,
-            name: proto.name.clone(),
-            descriptor: proto.descriptor.clone(),
-        };
+        let full_name = JavaFullName::new(0, &proto.name, &proto.descriptor);
         let full_name_bytes = full_name.as_bytes();
 
         let ptr_name = Allocator::alloc(core, full_name_bytes.len() as u32)?;
@@ -86,7 +82,7 @@ impl JavaMethod {
             },
         )?;
 
-        tracing::trace!("Wrote method {} at {ptr_raw:#x}", full_name.name);
+        tracing::trace!("Wrote method {} at {ptr_raw:#x}", full_name.name());
 
         Ok(Self::from_raw(ptr_raw, core))
     }
@@ -336,13 +332,13 @@ impl Method for JavaMethod {
     fn name(&self) -> String {
         let name = self.name().unwrap();
 
-        name.name
+        name.name().into()
     }
 
     fn descriptor(&self) -> String {
         let name = self.name().unwrap();
 
-        name.descriptor
+        name.descriptor().into()
     }
 
     async fn run(&self, jvm: &Jvm, args: Box<[JavaValue]>) -> JvmResult<JavaValue> {

--- a/wie-ktf/src/runtime/java/jvm_support/name.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/name.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 use core::fmt::Display;
 
 use wie_core_arm::ArmCore;
@@ -9,31 +9,42 @@ use super::Result;
 #[derive(Clone)]
 pub struct JavaFullName {
     pub tag: u8,
-    pub name: String,
-    pub descriptor: String,
+    value: String,
+    name_offset: usize,
 }
 
 impl JavaFullName {
+    pub fn new(tag: u8, name: &str, descriptor: &str) -> Self {
+        Self {
+            tag,
+            value: format!("{descriptor}+{name}"),
+            name_offset: descriptor.len() + 1,
+        }
+    }
+
     pub fn from_ptr(core: &ArmCore, ptr: u32) -> Result<Self> {
         let tag = read_generic(core, ptr)?;
 
         let value = read_null_terminated_string_bytes(core, ptr + 1)?;
         let value = String::from_utf8(value).unwrap();
-        let mut values = value.split('+');
+        let name_offset = value.find('+').unwrap() + 1;
 
-        let descriptor = values.next().unwrap().into();
-        let name = values.next().unwrap().into();
+        Ok(Self { tag, value, name_offset })
+    }
 
-        Ok(JavaFullName { tag, name, descriptor })
+    pub fn name(&self) -> &str {
+        &self.value[self.name_offset..]
+    }
+
+    pub fn descriptor(&self) -> &str {
+        &self.value[..self.name_offset - 1]
     }
 
     pub fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(self.value.len() + 2);
 
         bytes.push(self.tag);
-        bytes.extend_from_slice(self.descriptor.as_bytes());
-        bytes.push(b'+');
-        bytes.extend_from_slice(self.name.as_bytes());
+        bytes.extend_from_slice(self.value.as_bytes());
         bytes.push(0);
 
         bytes
@@ -42,8 +53,8 @@ impl JavaFullName {
 
 impl Display for JavaFullName {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.name.fmt(f)?;
-        self.descriptor.fmt(f)?;
+        self.name().fmt(f)?;
+        self.descriptor().fmt(f)?;
         write!(f, "@{}", self.tag)?;
 
         Ok(())
@@ -52,6 +63,36 @@ impl Display for JavaFullName {
 
 impl PartialEq for JavaFullName {
     fn eq(&self, other: &Self) -> bool {
-        self.descriptor == other.descriptor && self.name == other.name
+        self.descriptor() == other.descriptor() && self.name() == other.name()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wie_util::ByteWrite;
+
+    #[test]
+    fn full_names_borrow_parts_and_reread_guest_changes() -> Result<()> {
+        let mut core = ArmCore::new(false, None)?;
+        core.map(0x1000, 0x1000)?;
+
+        for (name, descriptor) in [("count", "I"), ("\u{ac00}", "(Ljava/lang/String;)V")] {
+            let original = JavaFullName::new(0x80, name, descriptor);
+            core.write_bytes(0x1000, &original.as_bytes())?;
+            let parsed = JavaFullName::from_ptr(&core, 0x1000)?;
+            assert_eq!((parsed.tag, parsed.name(), parsed.descriptor()), (0x80, name, descriptor));
+            assert_eq!(parsed.as_bytes(), original.as_bytes());
+            assert_eq!(parsed.descriptor().as_ptr(), parsed.value.as_ptr());
+            assert_eq!(parsed.name().as_ptr(), parsed.value[parsed.name_offset..].as_ptr());
+            assert_eq!(format!("{parsed}"), format!("{name}{descriptor}@128"));
+            assert!(parsed == JavaFullName::new(0, name, descriptor));
+
+            core.write_bytes(0x1000, &JavaFullName::new(1, "updated", "J").as_bytes())?;
+            let updated = JavaFullName::from_ptr(&core, 0x1000)?;
+            assert_eq!((updated.tag, updated.name(), updated.descriptor()), (1, "updated", "J"));
+            assert_eq!((parsed.name(), parsed.descriptor()), (name, descriptor));
+        }
+        Ok(())
     }
 }

--- a/wie-ktf/src/runtime/java/jvm_support/value.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/value.rs
@@ -21,7 +21,7 @@ impl JavaValueCodec {
 impl NativeJavaValueCodec for JavaValueCodec {
     fn object_from_raw(&self, raw: u32) -> Box<dyn ClassInstance> {
         let instance = JavaClassInstance::from_raw(raw, &self.core);
-        if instance.class().unwrap().name().unwrap().starts_with('[') {
+        if instance.class().unwrap().is_array().unwrap() {
             Box::new(JavaArrayClassInstance::from_raw(raw, &self.core))
         } else {
             Box::new(instance)

--- a/wie-ktf/src/runtime/java/jvm_support/vtable.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/vtable.rs
@@ -60,7 +60,6 @@ impl JavaVtable {
             let methods = class.methods()?;
 
             let items = methods
-                .into_iter()
                 .map(|x| {
                     let name = x.name()?;
 

--- a/wie-ktf/src/runtime/java/jvm_support/vtable.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/vtable.rs
@@ -1,14 +1,13 @@
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use wie_core_arm::{Allocator, ArmCore};
 use wie_util::{read_null_terminated_table, write_null_terminated_table};
 
-use super::{JavaMethod, Result, class_definition::JavaClassDefinition};
+use super::{JavaMethod, Result, class_definition::JavaClassDefinition, name::JavaFullName};
 
 struct JavaVtableMethod {
     method: JavaMethod,
-    name: String,
-    descriptor: String,
+    name: JavaFullName,
 }
 
 pub struct JavaVtable {
@@ -38,7 +37,7 @@ impl JavaVtable {
             let method = JavaMethod::from_raw(ptr_method, &self.core);
             let method_name = method.name()?;
 
-            if method_name.name == name && method_name.descriptor == descriptor {
+            if method_name.name() == name && method_name.descriptor() == descriptor {
                 return Ok(Some(method));
             }
         }
@@ -65,16 +64,12 @@ impl JavaVtable {
                 .map(|x| {
                     let name = x.name()?;
 
-                    Ok(JavaVtableMethod {
-                        method: x,
-                        name: name.name,
-                        descriptor: name.descriptor,
-                    })
+                    Ok(JavaVtableMethod { method: x, name })
                 })
                 .collect::<Result<Vec<_>>>()?;
 
             for item in items {
-                let index = if let Some(index) = vtable.iter().position(|x| x.name == item.name && x.descriptor == item.descriptor) {
+                let index = if let Some(index) = vtable.iter().position(|x| x.name == item.name) {
                     vtable[index] = item;
 
                     index

--- a/wie-midp/src/classes/javax/microedition/lcdui/image.rs
+++ b/wie-midp/src/classes/javax/microedition/lcdui/image.rs
@@ -1,7 +1,7 @@
 use alloc::{borrow::Cow, boxed::Box, format, vec, vec::Vec};
 use core::marker::PhantomData;
 
-use bytemuck::cast_vec;
+use bytemuck::{Zeroable, cast_vec};
 
 use jvm::{
     Array, ArrayRawBufferMut, ClassInstanceRef, Jvm, Result as JvmResult,
@@ -290,10 +290,10 @@ where
     fn get_pixel(&self, x: i32, y: i32) -> Color {
         let offset = (((y as u32) * self.width() + (x as u32)) * self.bytes_per_pixel()) as usize;
 
-        let mut buffer = vec![0; self.bytes_per_pixel() as usize];
-        self.raw_buffer.read(offset as _, &mut buffer).unwrap();
+        let mut raw = T::DataType::zeroed();
+        self.raw_buffer.read(offset, bytemuck::bytes_of_mut(&mut raw)).unwrap();
 
-        T::to_color(*bytemuck::from_bytes(&buffer[..size_of::<T::DataType>()]))
+        T::to_color(raw)
     }
 
     fn raw(&self) -> Cow<'_, [u8]> {
@@ -352,10 +352,45 @@ where
 
         let offset = (((y as u32) * self.width() + (x as u32)) * self.bytes_per_pixel()) as usize;
 
-        let mut buffer = vec![0; self.bytes_per_pixel() as usize];
-        self.raw_buffer.read(offset as _, &mut buffer).unwrap();
+        let mut raw = T::DataType::zeroed();
+        self.raw_buffer.read(offset, bytemuck::bytes_of_mut(&mut raw)).unwrap();
 
-        let raw = T::xor_color(*bytemuck::from_bytes(&buffer[..size_of::<T::DataType>()]), color);
+        let raw = T::xor_color(raw, color);
         self.raw_buffer.write(offset as _, bytemuck::bytes_of(&raw)).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn check_pixel_buffer<T: PixelType>(jvm: &Jvm, pixels: [T::DataType; 2]) -> JvmResult<()> {
+        let size = size_of::<T::DataType>();
+        let image = Image::create_image_instance(jvm, 2, 1, bytemuck::cast_slice(&pixels), size as u32).await?;
+        let mut buffer = JavaImageBuffer::<T>::new(jvm, &image).await?;
+        let actual = buffer.get_pixel(1, 0);
+        let expected = T::to_color(pixels[1]);
+        assert_eq!((actual.a, actual.r, actual.g, actual.b), (expected.a, expected.r, expected.g, expected.b));
+
+        let color = Color {
+            a: 255,
+            r: 127,
+            g: 63,
+            b: 31,
+        };
+        buffer.xor_pixel(1, 0, color);
+        let expected = [pixels[0], T::xor_color(pixels[1], color)];
+        assert_eq!(&*buffer.raw(), bytemuck::cast_slice(&expected));
+        Ok(())
+    }
+
+    #[test]
+    fn java_pixel_buffers_preserve_native_formats() -> wie_util::Result<()> {
+        test_utils::run_jvm_test(Box::new([crate::get_protos().into()]), |jvm| async move {
+            check_pixel_buffer::<Rgb332Pixel>(&jvm, [0x13, 0xe7]).await?;
+            check_pixel_buffer::<Rgb565Pixel>(&jvm, [0x1234, 0xabcd]).await?;
+            check_pixel_buffer::<ArgbPixel>(&jvm, [0x10203040, 0x80abcdef]).await?;
+            Ok(())
+        })
     }
 }

--- a/wie-util/src/lib.rs
+++ b/wie-util/src/lib.rs
@@ -85,21 +85,27 @@ where
         return Err(WieError::InvalidMemoryAccess(address));
     }
 
-    let mut result = Vec::with_capacity(20);
+    let mut result = Vec::new();
     let mut cursor = address;
-    let mut byte = [0; 1];
+    let mut buffer = [0; 32];
     loop {
-        let read = reader.read_bytes(cursor, &mut byte)?;
-        if read != 1 {
-            return Err(WieError::FatalError(format!("Short read at {cursor:#x}: expected 1, got {read}")));
+        let (size, read) = match reader.read_bytes(cursor, &mut buffer) {
+            // The terminator may precede an unmapped byte in this chunk.
+            Err(WieError::InvalidMemoryAccess(_)) => (1, reader.read_bytes(cursor, &mut buffer[..1])?),
+            result => (buffer.len(), result?),
+        };
+        if read != size {
+            return Err(WieError::FatalError(format!("Short read at {cursor:#x}: expected {size}, got {read}")));
         }
 
-        if byte[0] == 0 {
+        let bytes = &buffer[..size];
+        if let Some(end) = bytes.iter().position(|&byte| byte == 0) {
+            result.extend_from_slice(&bytes[..end]);
             break;
         }
 
-        result.push(byte[0]);
-        cursor += 1;
+        result.extend_from_slice(bytes);
+        cursor = cursor.wrapping_add(size as u32);
     }
 
     Ok(result)
@@ -228,13 +234,45 @@ mod tests {
     }
 
     #[test]
-    fn read_null_terminated_string_handles_four_byte_boundaries() {
-        let memory = StrictMemory {
-            memory: vec![0, b't', b'e', b's', b't', 0],
-        };
+    fn terminated_string_reads_stop_at_the_reader_boundary() {
+        for bytes in [b"".as_slice(), b"test", &[0xff, 0x80], &[b'x'; 31], &[b'x'; 32], &[b'x'; 33]] {
+            let mut memory = StrictMemory { memory: vec![0] };
+            memory.memory.extend_from_slice(bytes);
+            memory.memory.push(0);
+            assert_eq!(read_null_terminated_string_bytes(&memory, 1).unwrap(), bytes);
+            memory.memory.pop();
+            assert!(matches!(
+                read_null_terminated_string_bytes(&memory, 1),
+                Err(WieError::InvalidMemoryAccess(address)) if address == bytes.len() as u32 + 1
+            ));
+        }
+    }
 
-        let value = read_null_terminated_string_bytes(&memory, 1).unwrap();
+    #[test]
+    fn terminated_string_reads_preserve_short_reads_and_errors() {
+        struct FailingReader(bool);
 
-        assert_eq!(value, b"test");
+        impl ByteRead for FailingReader {
+            fn read_bytes(&self, address: u32, result: &mut [u8]) -> Result<usize> {
+                assert_eq!(result.len(), 32);
+                if address == 1 {
+                    result.fill(b'x');
+                    Ok(result.len())
+                } else if self.0 {
+                    Ok(0)
+                } else {
+                    Err(WieError::AllocationFailure)
+                }
+            }
+        }
+
+        assert!(matches!(
+            read_null_terminated_string_bytes(&FailingReader(true), 1),
+            Err(WieError::FatalError(message)) if message == "Short read at 0x21: expected 32, got 0"
+        ));
+        assert!(matches!(
+            read_null_terminated_string_bytes(&FailingReader(false), 1),
+            Err(WieError::AllocationFailure)
+        ));
     }
 }

--- a/wie-wipi-c/src/api/graphics/framebuffer.rs
+++ b/wie-wipi-c/src/api/graphics/framebuffer.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::ops::{Deref, DerefMut};
 
-use bytemuck::pod_collect_to_vec;
+use bytemuck::{Pod, cast_slice_mut};
 
 use wipi_types::wipic::{WIPICFramebuffer, WIPICIndirectPtr, WIPICWord};
 
@@ -66,45 +66,41 @@ impl FrameBuffer {
         }))
     }
 
-    pub fn data(&self, context: &dyn WIPICContext) -> Result<Vec<u8>> {
+    fn data<T: Pod>(&self, context: &dyn WIPICContext) -> Result<Vec<T>> {
         let (size, _) = buffer_size(self.0.width, self.0.height, self.0.bpp / 8)?;
-        let mut buf = vec![0; size as _];
-        context.read_bytes(context.data_ptr(self.0.buf)?, &mut buf)?;
+        let mut buf = vec![T::zeroed(); size as usize / size_of::<T>()];
+        context.read_bytes(context.data_ptr(self.0.buf)?, cast_slice_mut(&mut buf))?;
 
         Ok(buf)
     }
 
     pub fn image(&self, context: &mut dyn WIPICContext) -> Result<Box<dyn Image>> {
-        let data = self.data(context)?;
-
         Ok(match self.0.bpp {
             16 => Box::new(VecImageBuffer::<Rgb565Pixel>::from_raw(
                 self.0.width as _,
                 self.0.height as _,
-                pod_collect_to_vec(&data),
+                self.data(context)?,
             )),
             32 => Box::new(VecImageBuffer::<ArgbPixel>::from_raw(
                 self.0.width as _,
                 self.0.height as _,
-                pod_collect_to_vec(&data),
+                self.data(context)?,
             )),
             _ => unimplemented!("Unsupported pixel format: {}", self.0.bpp),
         })
     }
 
     pub fn canvas<'a>(&'a self, context: &'a mut dyn WIPICContext) -> Result<FramebufferCanvas<'a>> {
-        let data = self.data(context)?;
-
         let canvas: Box<dyn Canvas> = match self.0.bpp {
             16 => Box::new(ImageBufferCanvas::new(VecImageBuffer::<Rgb565Pixel>::from_raw(
                 self.0.width as _,
                 self.0.height as _,
-                pod_collect_to_vec(&data),
+                self.data(context)?,
             ))),
             32 => Box::new(ImageBufferCanvas::new(VecImageBuffer::<ArgbPixel>::from_raw(
                 self.0.width as _,
                 self.0.height as _,
-                pod_collect_to_vec(&data),
+                self.data(context)?,
             ))),
             _ => unimplemented!("Unsupported pixel format: {}", self.0.bpp),
         };
@@ -215,11 +211,19 @@ mod test {
     fn test_new_normal_size_ok() {
         let mut context = TestContext::new();
 
-        let framebuffer = FrameBuffer::new(&mut context, 100, 100, 16).unwrap();
-        assert_eq!(framebuffer.0.width, 100);
-        assert_eq!(framebuffer.0.height, 100);
-        assert_eq!(framebuffer.0.bpl, 200);
-        assert_eq!(framebuffer.0.bpp, 16);
-        assert_eq!(framebuffer.data(&context).unwrap().len(), 20000);
+        for bpp in [16, 32] {
+            let framebuffer = FrameBuffer::new(&mut context, 100, 100, bpp).unwrap();
+            assert_eq!(framebuffer.0.width, 100);
+            assert_eq!(framebuffer.0.height, 100);
+            assert_eq!(framebuffer.0.bpl, 100 * bpp / 8);
+            assert_eq!(framebuffer.0.bpp, bpp);
+            let pixels = (0..100 * 100 * bpp / 8).map(|i| i as u8).collect::<alloc::vec::Vec<_>>();
+            framebuffer.write(&mut context, &pixels).unwrap();
+            assert_eq!(&*framebuffer.image(&mut context).unwrap().raw(), pixels.as_slice());
+            let canvas = framebuffer.canvas(&mut context).unwrap();
+            assert_eq!(&*canvas.image().raw(), pixels.as_slice());
+            canvas.flush().unwrap();
+            assert_eq!(&*framebuffer.image(&mut context).unwrap().raw(), pixels.as_slice());
+        }
     }
 }


### PR DESCRIPTION
## Changes

### Guest strings and KTF metadata
- Read NUL-terminated guest strings in 32-byte chunks, retrying one byte when a chunk crosses an unmapped boundary. Preserve exact-read errors and boundary-terminated strings.
- Store `JavaFullName` as one encoded string with borrowed name/descriptor slices, and use those accessors throughout KTF lookups and bridge calls.
- Classify arrays from the first class-name byte, reuse parsed field types on reads, and select field-write width directly from `JavaValue`.
- Enumerate method and field adapters lazily over guest pointer tables, preserving method ownership and static/instance filtering. Guest memory remains authoritative.

### Rendering
- Read MIDP pixels and XOR operands into typed stack values, removing per-pixel temporary allocations.
- Write fully opaque normal pixels without reading the background, preserving XOR and partial/zero-alpha behavior.
- Read WIPI C framebuffers directly into typed pixel vectors, removing the intermediate byte-vector allocation and conversion copy.

### ARM memory access
- Use standard little-endian slice conversions for 16/32-bit reads and writes.
- Store instruction-local memory faults in a plain `Option`, removing unnecessary `RefCell` access while preserving fault propagation.

## Verification

- `cargo test --workspace --locked --offline --quiet`: 338 tests passed.
- `cargo fmt`, `cargo clippy --workspace --locked --offline`, and `git diff --check` passed.
- Tests cover guest-string boundaries and read errors, borrowed names and rereading guest changes, array/object fields, native pixel formats and XOR bytes, 16/32-bit framebuffer round trips, and unmapped ARM accesses. Existing canvas tests cover opaque drawing and XOR composition.
- Production WebAssembly builds passed with the existing three webpack asset/performance warnings. Comparison builds add only `-g` to the existing release `wasm-opt` arguments to retain function names.
- Generated WebAssembly inspection confirmed that ARM `r32` uses one unaligned 32-bit load and one page-offset bound check, replacing split loads and repeated offset checks.
- Completed 16 unprofiled comparison runs across four games, plus four separate 1 ms CPU profiles comparing both versions in Minigame Heaven 1 and Action Puzzle Family. All 20 runs recorded no page errors.
- Hero 1 continue, save-selection, and field hashes matched across all four timing runs. Minigame end screens and both new games' start/end screens were visually checked for the selected waiting scenes; animated pixels vary.

## Measured Performance

Reference: `c849e8dd`. Updated: `52a4d280`. The reference already contains the guest-string, lazy KTF metadata, borrowed-name, and per-pixel changes. **This comparison measures the field-write, framebuffer, and ARM memory changes, not the total PR speedup relative to main.**

Chrome `153.0.8010.36`, fresh browser profiles, identical archives and input sequences per game, and ten seconds without input in each selected scene. Benchmark processes were pinned to CPUs 6-8, with no concurrent builds or tests. Each game used reference/updated/updated/reference order. Values are means of two unprofiled runs per version; parenthesized values are the observed run ranges.

### Main-thread task time per canvas update: lower is better

| Game and scene | Reference, ms/update (range) | Updated, ms/update (range) |
| --- | ---: | ---: |
| Hero 1, indoor field | 52.14 (51.75-52.54) | 50.75 (49.77-51.74) |
| Minigame Heaven 1, first-game waiting board | 8.96 (8.49-9.43) | 9.16 (9.10-9.23) |
| Super Action Hero, training confirmation | 1.51 (1.48-1.54) | 1.51 (1.47-1.54) |
| Action Puzzle Family, first-puzzle confirmation | 2.91 (2.82-2.99) | 2.93 (2.84-3.01) |

Hero's mean was 2.7% lower, but the nearest observations differ by only 0.01 ms. Two runs per version do not establish a reliable improvement. The other three games' ranges overlap. This comparison establishes neither a clear additional game-level speedup nor a clear regression.

### Canvas update rate: higher is better

| Game | Reference, updates/second | Updated, updates/second |
| --- | ---: | ---: |
| Hero 1 | 12.83 | 13.13 |
| Minigame Heaven 1 | 9.85 | 9.95 |
| Super Action Hero | 59.42 | 59.41 |
| Action Puzzle Family | 84.18 | 84.15 |

These are short, selected scenes, not active-playthrough benchmarks. New-game confirmation prompts remain open; Action Puzzle Family's built-in startup calibration remains enabled. Fixed navigation waits are not entry-latency measurements. Canvas updates are not monitor presentation frames, and main-thread task duration is not total browser CPU usage.

The CPU profiles still identify ARM execution as the main non-idle hotspot. The removed framebuffer conversion no longer appears in the updated profiles, consistent with the code change. Sampled idle/active proportions varied considerably, so per-function sample totals are used diagnostically, not as speedup estimates. No further small optimization with a demonstrated game-level benefit was identified in these scenes.
