### PR TITLE
KTF에서 호스트 Java 메서드를 네이티브 방식으로 호출할 때 발생하는 오류 수정

### DIFF
--- a/wie-ktf/src/runtime/java/jvm_support.rs
+++ b/wie-ktf/src/runtime/java/jvm_support.rs
@@ -324,8 +324,8 @@ mod test {
     use crate::runtime::java::{JavaSvcFunctions, handle_java_svc};
 
     use super::{
-        ClassLoaderContext, JavaArrayClassInstance, JavaClassDefinition, JavaMethod, KtfClassLoader, KtfJvmSupport, KtfJvmThreadContext,
-        value::JavaValueCodec,
+        ClassLoaderContext, JavaArrayClassInstance, JavaClassDefinition, JavaClassInstance, JavaMethod, KtfClassLoader, KtfJvmSupport,
+        KtfJvmThreadContext, value::JavaValueCodec,
     };
 
     use test_utils::{TestClock, TestPlatform};
@@ -612,6 +612,55 @@ mod test {
             }
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_non_native_method_through_native_entry() -> Result<()> {
+        let mut system = System::new(Box::new(TestPlatform::new()), "", "", DefaultTaskRunner);
+        let done = Arc::new(AtomicBool::new(false));
+        let done_clone = done.clone();
+        let mut system_clone = system.clone();
+        system.spawn(async move || {
+            let (jvm, mut core) = init_jvm(&mut system_clone).await?;
+            let mut chars = jvm.instantiate_array("C", 4).await.unwrap();
+            jvm.store_array(&mut chars, 0, vec![0x41u16, 0xd654, 0xc7a5, 0x42]).await.unwrap();
+            let class = jvm.resolve_class("java/lang/String").await.unwrap();
+            let class = class.definition.as_any().downcast_ref::<JavaClassDefinition>().unwrap();
+            let method = class.method("valueOf", "([CII)Ljava/lang/String;", true)?.unwrap();
+            let raw: RawJavaMethod = read_generic(&core, method.ptr_raw)?;
+            assert!(!MethodAccessFlags::from_bits_truncate(raw.access_flags).contains(MethodAccessFlags::NATIVE));
+            assert_eq!(raw.exception_table_count, 0);
+            assert_ne!(raw.fn_body_native_or_exception_table, 0);
+
+            let args = vec![chars.clone().into(), 1.into(), 2.into()];
+            let java_result = method.run(args.clone().into_boxed_slice()).await?;
+            let java_result = Box::<dyn jvm::ClassInstance>::from(java_result);
+            assert_eq!(JavaLangString::to_rust_string(&jvm, &java_result).await.unwrap(), "화장");
+
+            let codec = JavaValueCodec::new(&core);
+            let words = encode_method_arguments(&codec, &args);
+            let ptr_args = Allocator::alloc(&mut core, words.len() as u32 * 4)?;
+            for (index, word) in words.iter().enumerate() {
+                write_generic(&mut core, ptr_args + index as u32 * 4, *word)?;
+            }
+            // KTF AOT callers can use the native argument-buffer ABI even when
+            // the host implementation's Java prototype is not marked native.
+            let result: u32 = core.run_function(raw.fn_body_native_or_exception_table, &[0, ptr_args]).await?;
+            let result: Box<dyn jvm::ClassInstance> = Box::new(JavaClassInstance::from_raw(result, &core));
+            assert_eq!(JavaLangString::to_rust_string(&jvm, &result).await.unwrap(), "화장");
+
+            write_generic(&mut core, ptr_args + 4, (-1i32) as u32)?;
+            let result = core.run_function::<u32>(raw.fn_body_native_or_exception_table, &[0, ptr_args]).await;
+            assert!(matches!(result, Err(WieError::JavaException(_))));
+            Allocator::free(&mut core, ptr_args, words.len() as u32 * 4)?;
+
+            done_clone.store(true, Ordering::Relaxed);
+            Ok(())
+        });
+        while !done.load(Ordering::Relaxed) {
+            system.tick()?;
+        }
         Ok(())
     }
 

--- a/wie-ktf/src/runtime/java/jvm_support/method.rs
+++ b/wie-ktf/src/runtime/java/jvm_support/method.rs
@@ -304,7 +304,6 @@ impl JavaMethod {
             parameter_types.insert(0, JavaType::Class("".into())); // TODO name
         }
 
-        let is_native = proto.access_flags.contains(MethodAccessFlags::NATIVE);
         let proxy = JavaMethodProxy {
             ptr_method,
             jvm: jvm.clone(),
@@ -319,13 +318,12 @@ impl JavaMethod {
 
         // Entry-field addresses identify the ABI while sharing the method implementation.
         let fn_body = core.make_svc_stub(SVC_CATEGORY_JAVA, ptr_method)?;
-        let fn_native = if is_native {
-            let ptr_native_entry = ptr_method + offset_of!(RawJavaMethod, fn_body_native_or_exception_table) as u32;
-            java_functions.lock().insert(ptr_native_entry, proxy);
-            core.make_svc_stub(SVC_CATEGORY_JAVA, ptr_native_entry)?
-        } else {
-            0
-        };
+        // AOT code selects the ABI using the original handset implementation,
+        // which need not have the same native flag as our host prototype.
+        // Host methods have no guest exception table, so both entries can coexist.
+        let ptr_native_entry = ptr_method + offset_of!(RawJavaMethod, fn_body_native_or_exception_table) as u32;
+        java_functions.lock().insert(ptr_native_entry, proxy);
+        let fn_native = core.make_svc_stub(SVC_CATEGORY_JAVA, ptr_native_entry)?;
 
         Ok((fn_body, fn_native))
     }


### PR DESCRIPTION
KTF 게임 **화장빨인생(버전 01.00.06)을 바탕으로 디버그했습니다.** 타이틀 화면에서 확인 키를 누르면 `String.valueOf(char[], int, int)`를 호출하는 과정에서 `jump native address is null` 오류로 종료되는 문제를 수정합니다.

KTF의 AOT 코드는 실제 단말에서 사용하던 호출 방식에 따라 네이티브 인자 버퍼 진입점을 선택할 수 있습니다. 하지만 WIE에서는 호스트 Java 메서드에 `NATIVE` 플래그가 없으면 이 진입점을 0으로 두고 있어 실행이 중단됐습니다.

호스트에서 구현한 Java 메서드에 두 호출 방식의 진입점을 모두 제공하도록 변경했습니다. 기존 인자 해석 코드를 공유하며 Java 접근 플래그는 유지합니다. 게임 바이너리의 AOT 메서드와 예외 테이블은 변경하지 않습니다.

수정 후 로컬 실행에서 오프닝 스토리, 메인 메뉴, 새 게임 대사, 튜토리얼, 화장 플레이 화면과 도구 선택까지 진행되는 것을 확인했습니다. 게임 바이너리나 리소스는 이 PR에 포함하지 않았습니다. 이번 PR은 재현한 실행 중단 문제를 해결하는 수정이며, 게임 전체의 완벽한 호환성을 보장하는 것은 아닙니다.

검증 내용:
- 수정 전 실패하고 수정 후 통과하는 회귀 테스트를 추가했습니다. `NATIVE` 플래그가 없는 `String.valueOf`를 네이티브 인자 버퍼 방식으로 호출하여 한글 문자 범위 변환, 기존 Java 방식 호출, 잘못된 범위에 대한 Java 예외 전달을 확인합니다.
- `cargo test -p wie-ktf`: 20개 테스트 통과
- `cargo test --workspace`: 통과
- `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`: Windows에서 통과