### PR TITLE
웹 에뮬레이터의 OK 동작에 Enter 키 추가

### DIFF
--- a/wie-web/src/html/index.html
+++ b/wie-web/src/html/index.html
@@ -242,7 +242,7 @@
             <tr><td><kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd></td><td>숫자 7, 8, 9</td></tr>
             <tr><td><kbd>Z</kbd> <kbd>X</kbd> <kbd>C</kbd></td><td>*, 0, #</td></tr>
             <tr><td>방향키</td><td>이동</td></tr>
-            <tr><td><kbd>Space</kbd></td><td>OK</td></tr>
+            <tr><td><kbd>Enter</kbd> / <kbd>Space</kbd></td><td>OK</td></tr>
             <tr><td><kbd>Backspace</kbd></td><td>CLR</td></tr>
           </tbody>
         </table>

--- a/wie-web/src/ts/app.ts
+++ b/wie-web/src/ts/app.ts
@@ -22,6 +22,8 @@ const KEY_MAP: Record<string, string> = {
   ArrowLeft: "LEFT",
   ArrowRight: "RIGHT",
   ArrowDown: "DOWN",
+  Enter: "OK",
+  NumpadEnter: "OK",
   Space: "OK",
 };
 const icons = {


### PR DESCRIPTION
웹 에뮬레이터에서 Enter와 숫자 키패드 Enter를 OK로 사용할 수 있도록 추가하고, 조작 도움말에 Enter를 표시했습니다. 기존 Space 확인 키, Backspace(CLR), 방향키와 화면 키패드는 그대로 사용할 수 있습니다.

KTF 화장빨인생과 피자타이쿤2를 바탕으로 Chrome에서 키보드 조작을 확인했습니다.

검증:
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`
- `tsc --project wie-web/tsconfig.json --noEmit --skipLibCheck`
- Chrome에서 Enter·숫자 키패드 Enter 입력 처리 및 기존 화면 키패드 확인